### PR TITLE
fix: migrate Buffer API from deprecated REST to GraphQL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ npm run typecheck                    # tsc --noEmit (strict mode, no any)
 npm test                             # vitest run (no test files yet)
 npm run poll                         # run poll-and-generate pipeline locally
 npm run scan                         # run sent-post scanner locally
-npm run setup-buffer                 # list Buffer channels with profile IDs
+npm run setup-buffer                 # verify Buffer token + print org/profile ID instructions
 npm run bootstrap                    # seed voice history from voice-bootstrap.md
 npm run test-analyze                 # run analysis pipeline on a commit SHA (no publish)
 ```
@@ -41,19 +41,19 @@ This is an ESM project (`"type": "module"` in package.json). All internal import
 2. **Specialized modular analysis**: Multiple focused modules analyze code before Claude is called.
    Claude translates findings — it does NOT analyze code. Modules do.
 
-3. **Buffer is the review interface**: Posts go directly to Buffer as scheduled drafts.
+3. **Buffer is the review interface**: Posts go to Buffer as Ideas (via GraphQL API).
    Liliana edits in Buffer's native UI and publishes when ready. No GitHub Issues /approve flow.
 
 4. **Voice training loop**: After Liliana publishes from Buffer, the sent-post scanner captures
    the final published text, computes edit_ratio, and stores it as a voice history example.
 
-5. **Posting window**: Posts scheduled ONLY between 8:00 AM and 7:00 PM Chile time
-   (America/Santiago). Architecturally enforced via slot-manager.ts — not just configured.
+5. **Posting window**: Configured for 8:00 AM – 7:00 PM Chile time (America/Santiago).
+   `slot-manager.ts` is implemented but not yet wired into the pipeline — see Known Gaps.
 
 6. **Free tiers only**: GitHub Actions (public repo = unlimited), Buffer (free), Supabase (free).
    Only Anthropic Claude API costs money — minimize aggressively.
 
-7. **Human review required**: No auto-publish path exists. Buffer holds all posts as drafts/scheduled.
+7. **Human review required**: No auto-publish path exists. Buffer Ideas require manual review.
 
 ---
 
@@ -61,10 +61,10 @@ This is an ESM project (`"type": "module"` in package.json). All internal import
 
 ```
 [CRON every 4h — poll-and-generate.yml]
-GitHub Events API → Commit Enrichment → Module Pipeline → Claude → Buffer (draft)
+GitHub Events API → Commit Enrichment → Module Pipeline → Claude → Buffer (Idea)
 
 [CRON every 2h — scan-sent-posts.yml]
-Buffer "sent" API → Match buffer_post_id → computeEditRatio → Voice History
+Buffer "sent" API → Match by text similarity → computeEditRatio → Voice History
 ```
 
 These two crons are kept separate for independent debuggability.
@@ -87,7 +87,7 @@ These two crons are kept separate for independent debuggability.
 │
 ├── utils/commit-filter.ts (ZERO API COST — rule-based)
 │   └── isInteresting(): lines >= 10, not merge/bot/wip/excluded
-│       NOT interesting → pending_batch table (weekly roundup later)
+│       NOT interesting → skipped (pending_batch write not yet implemented)
 │       IS interesting → analysis pipeline
 │
 ├── analysis/pipeline.ts (ALL modules run IN PARALLEL)
@@ -109,17 +109,13 @@ These two crons are kept separate for independent debuggability.
 ├── ai/post-generator.ts
 │   └── claude-sonnet-4-6, max_tokens=1600
 │       ONE call per commit (never per-module)
-│       Returns: { linkedin: string, instagram: string }
+│       Response parsed via XML tags: <linkedin_draft> and <instagram_draft>
 │       Store ai_draft immediately in DB
 │
-├── scheduling/slot-manager.ts
-│   └── Next available slot within 8am-7pm CLT
-│       Atomic claim via UNIQUE(platform, scheduled_at) in DB
-│
 ├── buffer/publisher.ts
-│   ├── Check queue depth (≥9 → store as 'queued', drain on next run)
-│   ├── POST /1/updates/create.json with scheduled_at (UTC Unix timestamp)
-│   └── Store: buffer_post_id, scheduled_at, status='scheduled'
+│   └── GraphQL mutation: createIdea (Buffer Ideas API)
+│       Creates an Idea per platform → appears in Buffer Ideas inbox
+│       Store: buffer_post_id (Idea ID), status='scheduled'
 │
 └── review/notifier.ts
     └── Open GitHub Issue (NOTIFICATION ONLY — no /approve needed)
@@ -130,7 +126,8 @@ These two crons are kept separate for independent debuggability.
 │
 └── buffer/sent-scanner.ts
     ├── GET /1/profiles/{id}/updates/sent.json (per platform)
-    ├── Match by buffer_post_id → voice_posts in DB
+    ├── Match by text similarity (computeEditRatio >= 0.3 threshold)
+    │   (Idea IDs differ from published post IDs — can't match by ID)
     └── For each newly sent post:
         ├── Fetch final text from Buffer response
         ├── computeEditRatio(ai_draft, published_text) → 0.0–1.0
@@ -225,11 +222,10 @@ optional before/after evidence.
 **Window**: 8:00 AM – 7:00 PM CLT (19:00 hard cutoff)
 **Daily slots**: [8, 12, 17] hours CLT → 8am, 12pm, 5pm
 
-`slot-manager.ts` computes the next unclaimed slot → converts to UTC Unix timestamp →
-passes to Buffer's `scheduled_at` field. Posting outside the window is structurally impossible.
-
-The `UNIQUE(platform, scheduled_at)` constraint in the `scheduled_slots` table prevents
-double-booking atomically even if two workflow runs race.
+`slot-manager.ts` is fully implemented with atomic slot claiming via
+`UNIQUE(platform, scheduled_at)` in the `scheduled_slots` table. However, it is **not yet
+wired into the pipeline** — `publisher.ts` creates Buffer Ideas directly without scheduling.
+Slot-based scheduling will be needed if the pipeline moves from Ideas to scheduled posts.
 
 ---
 
@@ -247,14 +243,13 @@ double-booking atomically even if two workflow runs race.
 ### Buffer API
 **Auth**: `BUFFER_ACCESS_TOKEN` — long-lived OAuth token
 **Free tier**: 3 channels, 10 posts queued per channel
-**Key endpoints**:
-- `GET /1/profiles.json` — list channels with profile IDs
-- `GET /1/profiles/{id}/updates/pending.json` — check queue depth before publishing
-- `POST /1/updates/create.json` — add post with `scheduled_at`
+**Actual endpoints used**:
+- GraphQL (`https://graph.buffer.com/`) — `createIdea` mutation to create Ideas
 - `GET /1/profiles/{id}/updates/sent.json` — scan for published posts (voice loop)
 
-**Queue management**: Check depth before publishing. If ≥9, store `review_status='queued'`.
-Drain queued posts at start of every cron run.
+**How it works**: `publisher.ts` creates Buffer Ideas via GraphQL (not scheduled posts via REST).
+Ideas land in Buffer's Ideas inbox for manual review and publishing. The `setup-buffer.ts`
+script verifies token validity and prints instructions for finding `organization_id` and profile IDs.
 
 **Token expiry**: `401` → throw `BufferTokenExpiredError`. Regenerate at buffer.com → Settings → Apps.
 
@@ -335,6 +330,9 @@ github:
     - "\\[skip\\]"
   max_commits_per_push: 1
 
+buffer:
+  organization_id: ""                    # REQUIRED — get from setup-buffer script
+
 platforms:
   linkedin:
     enabled: true
@@ -393,13 +391,13 @@ devcast/
 │   ├── ai/
 │   │   ├── client.ts                # Anthropic SDK (sonnet, max_tokens=1600)
 │   │   ├── prompt-builder.ts        # voice top + commit + findings + task bottom
-│   │   └── post-generator.ts        # ONE call per commit, cache draft, parse JSON
+│   │   └── post-generator.ts        # ONE call per commit, cache draft, parse XML tags
 │   ├── buffer/
-│   │   ├── client.ts                # Buffer REST wrapper
-│   │   ├── publisher.ts             # queue check + slot scheduling + POST
-│   │   └── sent-scanner.ts          # poll sent posts → voice history feedback
+│   │   ├── client.ts                # Buffer GraphQL + REST wrapper
+│   │   ├── publisher.ts             # createIdea GraphQL mutation → Buffer Ideas
+│   │   └── sent-scanner.ts          # poll sent posts → text similarity match → voice history
 │   ├── scheduling/
-│   │   └── slot-manager.ts          # America/Santiago 8am-7pm, atomic slot claiming
+│   │   └── slot-manager.ts          # America/Santiago 8am-7pm (implemented, not yet wired)
 │   ├── voice/
 │   │   ├── storage.ts               # IVoiceStorage interface
 │   │   ├── supabase-storage.ts      # production
@@ -415,9 +413,8 @@ devcast/
 │       ├── retry.ts                 # withRetry() per-service policies
 │       └── commit-filter.ts         # isInteresting() — rule-based, zero API cost
 ├── scripts/
-│   ├── setup-buffer.ts              # list Buffer channels with IDs
+│   ├── setup-buffer.ts              # verify Buffer token + print org/profile instructions
 │   ├── bootstrap-voice.ts           # seed DB from voice-bootstrap.md
-│   ├── manage-voice.ts              # inspect/delete voice history
 │   └── test-analyze.ts              # run module pipeline on any commit SHA
 ├── database/
 │   └── schema.sql
@@ -462,7 +459,8 @@ Build in this sequence — each layer depends on the previous:
 
 1. **Fork** → Settings → Actions → "Allow all actions and reusable workflows"
 2. **Supabase**: supabase.com → New project → SQL Editor → run `database/schema.sql`
-3. **Secrets**: Settings → Secrets → Actions → add all env vars from `.env.example`
+3. **Secrets**: Settings → Secrets → Actions → add: `ANTHROPIC_API_KEY`, `BUFFER_ACCESS_TOKEN`,
+   `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and `CONFIG_YAML` (entire config.yaml content)
 4. **Config**: `cp config.example.yaml config.yaml` → set `author.github_username`
 5. **Buffer profiles**: `npm install && npm run setup-buffer` → paste profile IDs
 6. **Voice bootstrap**: Edit `voice-bootstrap.md` with 3–5 posts in your actual voice
@@ -481,15 +479,34 @@ Buffer:   5xx → withRetry(); 401 → BufferTokenExpiredError; 429 → store as
 
 ---
 
-## Coding Conventions
+## Known Gaps (Not Yet Implemented)
 
-- **No `any`** — use `unknown` and narrow, or define proper types
-- **No silent failures** — every catch either rethrows or logs + rethrows
-- **Interfaces for data shapes** — classes for stateful services (modules, clients)
-- **Dependency injection** — pass `IVoiceStorage` to consumers, never import a singleton
-- **One file per concern**
-- **No magic strings** — `const STATUS = { PENDING: 'pending', SCHEDULED: 'scheduled' } as const`
-- Comments only where logic isn't self-evident
+1. **`events_state` in Supabase**: `SupabaseStorage` does not implement `getEventsState`/`setEventsState`.
+   In production, `last_event_id` is always `null` — the poll processes events as if starting fresh each run.
+   Only `SqliteStorage` persists event state between runs.
+
+2. **`pending_batch` writes**: `isInteresting()` returning false just skips the commit.
+   Nothing writes to the `pending_batch` table — weekly roundup feature is unimplemented.
+
+3. **`slot-manager.ts` unused**: Fully implemented but never called from `publisher.ts` or `main-poll.ts`.
+   Will be needed if moving from Buffer Ideas to scheduled posts.
+
+4. **`manage-voice.ts` script**: Referenced in earlier designs but never created.
+
+5. **`diff` package unused**: Listed in `package.json` dependencies but never imported in source code.
+
+---
+
+## Storage Backend Selection
+
+Storage is selected by the **presence of `SUPABASE_URL`** env var — not by `USE_SQLITE`:
+```typescript
+const storage: IVoiceStorage = process.env['SUPABASE_URL']
+  ? new SupabaseStorage(...)
+  : new SqliteStorage(process.env['SQLITE_PATH'] ?? 'data/devcast.db');
+```
+Both `main-poll.ts` and `main-scan.ts` use this pattern. The `USE_SQLITE` env var in `.env.example`
+is a comment suggestion that is not checked in code.
 
 ---
 
@@ -502,6 +519,8 @@ Buffer:   5xx → withRetry(); 401 → BufferTokenExpiredError; 429 → store as
 5. **Supabase inactivity pause**: 4h cron + keepalive query prevents in normal use
 6. **Buffer token manual rotation**: Unavoidable without a running OAuth server
 7. **Chile DST**: `date-fns-tz` + `America/Santiago` IANA handles this. Never hardcode UTC offset.
+8. **Sent scanner text matching**: Uses similarity threshold (0.3) instead of ID matching because
+   Buffer Idea IDs differ from published post IDs. Posts rewritten >70% won't match.
 
 ---
 

--- a/src/buffer/client.ts
+++ b/src/buffer/client.ts
@@ -22,9 +22,13 @@ export class BufferClient {
     this.token = token;
   }
 
-  // ─── GraphQL (mutations) ────────────────────────────────────────────────────
+  // ─── Shared GraphQL transport ─────────────────────────────────────────────
 
-  async createIdea(orgId: string, title: string, text: string): Promise<{ id: string }> {
+  private async graphqlRequest<T>(
+    query: string,
+    variables: Record<string, unknown>,
+    operationName: string,
+  ): Promise<T> {
     return withRetry(async () => {
       const response = await fetch(BUFFER_GRAPHQL, {
         method: 'POST',
@@ -32,22 +36,7 @@ export class BufferClient {
           'Authorization': `Bearer ${this.token}`,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-          query: `
-            mutation CreateIdea($input: CreateIdeaInput!) {
-              createIdea(input: $input) {
-                ... on Idea { id }
-                ... on MutationError { message }
-              }
-            }
-          `,
-          variables: {
-            input: {
-              organizationId: orgId,
-              content: { title, text },
-            },
-          },
-        }),
+        body: JSON.stringify({ query, variables }),
       });
 
       if (response.status === 401) throw new BufferTokenExpiredError();
@@ -57,7 +46,7 @@ export class BufferClient {
       }
 
       const json = await response.json() as {
-        data?: { createIdea?: { id?: string; message?: string } };
+        data?: T;
         errors?: Array<{ message: string }>;
       };
 
@@ -65,62 +54,63 @@ export class BufferClient {
         throw new Error(`Buffer GraphQL error: ${json.errors[0]?.message ?? 'unknown'}`);
       }
 
-      const result = json.data?.createIdea;
-      if (!result?.id) {
-        const msg = (result as { message?: string } | undefined)?.message ?? 'unknown error';
-        throw new Error(`Buffer createIdea failed: ${msg}`);
-      }
-
-      return { id: result.id };
-    }, BUFFER_RETRY_POLICY, 'buffer.createIdea');
+      return json.data as T;
+    }, BUFFER_RETRY_POLICY, operationName);
   }
 
-  // ─── GraphQL (read-only, for voice loop) ───────────────────────────────────
+  // ─── Mutations ────────────────────────────────────────────────────────────
+
+  async createIdea(orgId: string, title: string, text: string): Promise<{ id: string }> {
+    const data = await this.graphqlRequest<{
+      createIdea?: { id?: string; message?: string };
+    }>(
+      `mutation CreateIdea($input: CreateIdeaInput!) {
+        createIdea(input: $input) {
+          ... on Idea { id }
+          ... on MutationError { message }
+        }
+      }`,
+      {
+        input: {
+          organizationId: orgId,
+          content: { title, text },
+        },
+      },
+      'buffer.createIdea',
+    );
+
+    const result = data.createIdea;
+    if (!result?.id) {
+      const msg = (result as { message?: string } | undefined)?.message ?? 'unknown error';
+      throw new Error(`Buffer createIdea failed: ${msg}`);
+    }
+
+    return { id: result.id };
+  }
+
+  // ─── Queries (read-only, for voice loop) ──────────────────────────────────
 
   async getSentPosts(orgId: string, channelId: string): Promise<BufferPost[]> {
-    return withRetry(async () => {
-      const response = await fetch(BUFFER_GRAPHQL, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${this.token}`,
-          'Content-Type': 'application/json',
+    const data = await this.graphqlRequest<{
+      posts?: { edges?: Array<{ node: BufferPost }> };
+    }>(
+      `query GetSentPosts($input: PostsInput!, $first: Int) {
+        posts(input: $input, first: $first) {
+          edges {
+            node { id text createdAt }
+          }
+        }
+      }`,
+      {
+        input: {
+          organizationId: orgId,
+          filter: { status: ['sent'], channelIds: [channelId] },
         },
-        body: JSON.stringify({
-          query: `
-            query GetSentPosts($input: PostsInput!, $first: Int) {
-              posts(input: $input, first: $first) {
-                edges {
-                  node { id text createdAt }
-                }
-              }
-            }
-          `,
-          variables: {
-            input: {
-              organizationId: orgId,
-              filter: { status: ['sent'], channelIds: [channelId] },
-            },
-            first: 20,
-          },
-        }),
-      });
+        first: 20,
+      },
+      'buffer.getSentPosts',
+    );
 
-      if (response.status === 401) throw new BufferTokenExpiredError();
-      if (!response.ok) {
-        const body = await response.text().catch(() => '');
-        throw new Error(`Buffer GraphQL error ${response.status}: ${body}`);
-      }
-
-      const json = await response.json() as {
-        data?: { posts?: { edges?: Array<{ node: BufferPost }> } };
-        errors?: Array<{ message: string }>;
-      };
-
-      if (json.errors?.length) {
-        throw new Error(`Buffer GraphQL error: ${json.errors[0]?.message ?? 'unknown'}`);
-      }
-
-      return json.data?.posts?.edges?.map((e) => e.node) ?? [];
-    }, BUFFER_RETRY_POLICY, 'buffer.getSentPosts');
+    return data.posts?.edges?.map((e) => e.node) ?? [];
   }
 }

--- a/src/buffer/client.ts
+++ b/src/buffer/client.ts
@@ -1,7 +1,6 @@
 import { withRetry, BUFFER_RETRY_POLICY } from '../utils/retry.js';
 
 const BUFFER_GRAPHQL = 'https://api.buffer.com';
-const BUFFER_REST = 'https://api.bufferapp.com/1';
 
 export class BufferTokenExpiredError extends Error {
   constructor() {
@@ -13,8 +12,7 @@ export class BufferTokenExpiredError extends Error {
 export interface BufferPost {
   id: string;
   text: string;
-  scheduled_at: number;  // Unix timestamp
-  status: string;
+  createdAt: string;  // ISO 8601 timestamp from GraphQL
 }
 
 export class BufferClient {
@@ -77,27 +75,52 @@ export class BufferClient {
     }, BUFFER_RETRY_POLICY, 'buffer.createIdea');
   }
 
-  // ─── REST (read-only, for voice loop) ──────────────────────────────────────
+  // ─── GraphQL (read-only, for voice loop) ───────────────────────────────────
 
-  async getSentPosts(profileId: string, page = 1): Promise<BufferPost[]> {
+  async getSentPosts(orgId: string, channelId: string): Promise<BufferPost[]> {
     return withRetry(async () => {
-      const params = new URLSearchParams({
-        access_token: this.token,
-        page: String(page),
+      const response = await fetch(BUFFER_GRAPHQL, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${this.token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: `
+            query GetSentPosts($input: PostsInput!, $first: Int) {
+              posts(input: $input, first: $first) {
+                edges {
+                  node { id text createdAt }
+                }
+              }
+            }
+          `,
+          variables: {
+            input: {
+              organizationId: orgId,
+              filter: { status: ['sent'], channelIds: [channelId] },
+            },
+            first: 20,
+          },
+        }),
       });
-      const response = await fetch(
-        `${BUFFER_REST}/profiles/${profileId}/updates/sent.json?${params}`,
-        { method: 'GET' },
-      );
+
       if (response.status === 401) throw new BufferTokenExpiredError();
       if (!response.ok) {
         const body = await response.text().catch(() => '');
-        const err = new Error(`Buffer REST error ${response.status}: ${body}`);
-        (err as unknown as { status: number }).status = response.status;
-        throw err;
+        throw new Error(`Buffer GraphQL error ${response.status}: ${body}`);
       }
-      const data = await response.json() as { updates?: BufferPost[] };
-      return data.updates ?? [];
+
+      const json = await response.json() as {
+        data?: { posts?: { edges?: Array<{ node: BufferPost }> } };
+        errors?: Array<{ message: string }>;
+      };
+
+      if (json.errors?.length) {
+        throw new Error(`Buffer GraphQL error: ${json.errors[0]?.message ?? 'unknown'}`);
+      }
+
+      return json.data?.posts?.edges?.map((e) => e.node) ?? [];
     }, BUFFER_RETRY_POLICY, 'buffer.getSentPosts');
   }
 }

--- a/src/buffer/sent-scanner.ts
+++ b/src/buffer/sent-scanner.ts
@@ -27,9 +27,11 @@ export async function scanSentPosts(
     platforms.push({ platform: 'instagram', profileId: config.platforms.instagram.buffer_profile_id });
   }
 
+  const orgId = config.buffer.organization_id;
+
   for (const { platform, profileId } of platforms) {
     logger.info('sent_scanner.start', { platform });
-    await scanPlatform(bufferClient, storage, platform, profileId);
+    await scanPlatform(bufferClient, storage, platform, orgId, profileId);
   }
 }
 
@@ -37,10 +39,11 @@ async function scanPlatform(
   bufferClient: BufferClient,
   storage: IVoiceStorage,
   platform: Platform,
-  profileId: string,
+  orgId: string,
+  channelId: string,
 ): Promise<void> {
   const [sentPosts, unmatched] = await Promise.all([
-    bufferClient.getSentPosts(profileId),
+    bufferClient.getSentPosts(orgId, channelId),
     storage.getScheduledUnpublished(platform),
   ]);
 
@@ -64,7 +67,7 @@ async function scanPlatform(
     }
 
     if (bestDraft && bestScore >= MATCH_THRESHOLD) {
-      const publishedAt = new Date(sentPost.scheduled_at * 1000).toISOString();
+      const publishedAt = sentPost.createdAt;
       await storage.updatePublished({
         id: bestDraft.id,
         published: sentPost.text,

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -34,6 +34,26 @@ export class GitHubClient {
     }, GITHUB_RETRY_POLICY, 'github.listUserEvents');
   }
 
+  async compareCommits(
+    owner: string,
+    repo: string,
+    base: string,
+    head: string,
+  ): Promise<{ sha: string; message: string }[]> {
+    return withRetry(async () => {
+      const response = await this.octokit.repos.compareCommits({
+        owner,
+        repo,
+        base,
+        head,
+      });
+      return response.data.commits.map((c) => ({
+        sha: c.sha,
+        message: c.commit.message,
+      }));
+    }, GITHUB_RETRY_POLICY, `github.compareCommits(${owner}/${repo}@${base}...${head})`);
+  }
+
   async getCommit(owner: string, repo: string, sha: string): Promise<unknown> {
     return withRetry(async () => {
       const response = await this.octokit.repos.getCommit({ owner, repo, ref: sha });

--- a/src/github/events-poller.ts
+++ b/src/github/events-poller.ts
@@ -22,10 +22,12 @@ interface EventsState {
 interface RawEvent {
   id: string;
   type: string;
+  actor: { login: string };
   repo: { name: string };
   payload: {
-    commits?: Array<{ sha: string; message: string; author?: { username?: string } }>;
-    head_commit?: { author?: { username?: string } };
+    before?: string;
+    head?: string;
+    ref?: string;
   };
   created_at: string;
 }
@@ -33,6 +35,9 @@ interface RawEvent {
 /**
  * Polls GitHub's user events API and returns new PushEvents since the last run.
  * Uses ETag conditional requests — a 304 Not Modified costs 0 API rate-limit points.
+ *
+ * GitHub's Events API no longer includes commits in PushEvent payloads.
+ * We use the Compare API (before...head) to fetch the actual commits.
  */
 export async function pollNewPushEvents(
   client: GitHubClient,
@@ -51,11 +56,11 @@ export async function pollNewPushEvents(
   }
 
   const rawEvents = events as RawEvent[];
-  const pushEvents = rawEvents.filter(e => e.type === 'PushEvent');
+  const pushEvents = rawEvents.filter((e) => e.type === 'PushEvent');
 
   // Find new events since last seen
   const lastSeenIdx = state.lastEventId
-    ? pushEvents.findIndex(e => e.id === state.lastEventId)
+    ? pushEvents.findIndex((e) => e.id === state.lastEventId)
     : pushEvents.length; // treat all as new if no state
 
   const newPushEvents = lastSeenIdx > 0 ? pushEvents.slice(0, lastSeenIdx) : pushEvents;
@@ -67,20 +72,37 @@ export async function pollNewPushEvents(
     newEvents: newPushEvents.length,
   });
 
-  const result: PushEvent[] = newPushEvents.map(e => {
-    const commits = (e.payload.commits ?? []).slice(0, maxCommitsPerPush).map(c => ({
-      sha: c.sha,
-      message: c.message,
-      authorLogin: c.author?.username ?? username,
-    }));
+  const result: PushEvent[] = [];
 
-    return {
+  for (const e of newPushEvents) {
+    const [owner, repo] = e.repo.name.split('/');
+    if (!owner || !repo || !e.payload.before || !e.payload.head) continue;
+
+    let commits: PushCommit[];
+    try {
+      const compared = await client.compareCommits(owner, repo, e.payload.before, e.payload.head);
+      commits = compared.slice(0, maxCommitsPerPush).map((c) => ({
+        sha: c.sha,
+        message: c.message,
+        authorLogin: e.actor.login,
+      }));
+    } catch (err) {
+      logger.warn('events.poll.compare_failed', {
+        repo: e.repo.name,
+        error: String(err),
+      });
+      continue;
+    }
+
+    if (commits.length === 0) continue;
+
+    result.push({
       id: e.id,
       repo: e.repo.name,
       commits,
       pushedAt: e.created_at,
-    };
-  });
+    });
+  }
 
   const newState: EventsState = {
     lastEventId: rawEvents[0]?.id ?? state.lastEventId,

--- a/voice-bootstrap.md
+++ b/voice-bootstrap.md
@@ -1,8 +1,8 @@
 # Voice Bootstrap Posts
 
 These are the seed examples for the AI voice training system.
-They were written manually (or heavily edited from AI drafts) to establish
-the target voice before enough published posts exist for few-shot learning.
+They were written manually to establish the target voice before enough
+published posts exist for few-shot learning.
 
 Each post is marked with:
 - `pillar`: which content pillar it belongs to
@@ -15,401 +15,188 @@ The AI should use these posts exactly as written — they are the ground truth.
 ---
 
 ## POST 001
-**pillar**: dispatches
-**platform**: linkedin
-**training_weight**: 2.0
-**voice_notes**: Establishes the core narrative: unemployed + building seriously. Sets the meta-inception tone (a tool posting about itself). Shows how to hold two truths at once (funny situation + serious work) without either canceling the other.
-
----
-
-I built a tool that turns my GitHub commits into social media posts.
-
-This is that tool's first post about itself.
-
-I've been unemployed since October. In that time, I've written more code than I did in the six months before layoff. Turns out "free time" and "existential motivation" are a powerful combination.
-
-devcast is a personal branding project with a weird property: it gets smarter the more I use it. Every post I publish becomes a voice example for the next generation of drafts. The AI learns from my edits, not its own output.
-
-So by the time this system is mature, it'll sound like me. Right now it sounds like a developer who read a lot of LinkedIn posts and made some educated guesses. Which, frankly, is relatable.
-
-Here's what I built this week:
-→ GitHub Actions polling every 4 hours across all my repos
-→ A GitHub Issues-based review workflow (zero infrastructure, GitHub is the UI)
-→ SQLite voice history with edit distance tracking
-→ Claude prompt assembly that puts my published posts at the TOP of context
-
-The architecture decision I'm most proud of: using GitHub Issues as the draft inbox. No web server, no database for the review UI, no additional accounts. The review interface was already built. I just needed to use it.
-
-The architecture decision I'm least proud of: I genuinely considered storing state in git notes before coming to my senses.
-
-Building in public means the good decisions AND the embarrassing ones are on the record.
-
-What's the most creative "I'm using GitHub as a backend" decision you've made?
-
-#buildinpublic #typescript #softwareengineering #devcast
-
----
-
-## POST 002
-**pillar**: bug_autopsy
-**platform**: twitter
-**training_weight**: 2.0
-**voice_notes**: Establishes the Bug Autopsy format. Shows the four-beat structure (broken → investigated → revelation → lesson) compressed into thread format. The self-deprecating opener is the hook; the specific technical lesson is the value. Note: Tweet 1 must work standalone as a complete thought.
-
----
-
-**Tweet 1/5:**
-I spent 45 minutes debugging why my GitHub Actions workflow wasn't picking up new commits.
-
-The issue: I was comparing timestamps instead of SHAs.
-
-This is a story about making the wrong assumption before reading the docs. 🧵
-
-**Tweet 2/5:**
-The code looked correct. I was fetching commits since `last_run_timestamp`. Storing the timestamp. Comparing on next run.
-
-Works in theory. Fails in practice because GitHub's API returns commits in `author_date` order, not `push_date` order.
-
-A commit authored 3 days ago, pushed today, gets skipped. Forever.
-
-**Tweet 3/5:**
-My debugging process, documented for your amusement:
-
-→ Added logging (the commit was there, just filtered out)
-→ Checked my date parsing (fine)
-→ Checked timezone handling (fine, UTC throughout)
-→ Re-read the API docs for the first time instead of the second time
-
-The docs say: "Lists commits in reverse chronological order, by `committer_date`."
-
-I had been using `author_date`. Not the same thing.
-
-**Tweet 4/5:**
-The fix: compare SHAs, not timestamps.
-
-Store the last processed SHA per repo. On each poll, fetch commits until you hit a known SHA. Stop there.
-
-SHA comparison is O(commits_since_last_run) and never has timezone bugs, author-vs-committer confusion, or clock skew issues.
-
-45 minutes. 3 lines changed.
-
-**Tweet 5/5:**
-The lesson: when an API has two date fields that sound like the same thing, they are not the same thing.
-
-`author_date` = when the commit was created locally
-`committer_date` = when the commit entered the tree (rebase, cherry-pick, push)
-
-Read the API docs like they were written by someone who had a reason to distinguish these.
-
-They did.
-
-#buildinpublic #typescript
-
----
-
-## POST 003
-**pillar**: ai_copilot
-**platform**: linkedin
-**training_weight**: 2.0
-**voice_notes**: Shows the AI Co-Pilot voice. Transparent about what Claude did, what survived, what didn't. Critical but not dismissive of AI. The tone is collaborative partner, not magic oracle or useless tool. Shows the "I directed it, it surprised me, I kept the good part" pattern.
-
----
-
-I asked Claude to write the commit classification logic.
-
-It wrote something I wouldn't have written. I shipped it anyway.
-
-Here's the interesting part.
-
-My plan was a simple if/else chain: check the commit message for keywords, assign a pillar, done. Readable, predictable, easy to test. I described this plan to Claude and asked it to implement it.
-
-Claude implemented a priority-based classifier with a `pillarPriority` array that gets walked in order. Same result, different structure.
-
-My first instinct was to rewrite it. "I know what I asked for. This isn't what I asked for."
-
-My second instinct was to figure out why it made that choice.
-
-It turns out the priority array matters more than I thought. The same commit can match multiple pillars. "fix: add missing null check in AI prompt builder" hits both `bug_autopsy` (fix keyword) and `ai_copilot` (AI mentioned). Without priority ordering, the result is arbitrary. With it, the result is a design decision I can change in one line.
-
-The AI didn't explain this. It just built the more robust version by default.
-
-What I changed: I added comments explaining the priority order, because the AI left that implicit. Four lines of comments, which I wrote. The rest shipped as-is.
-
-Lesson: when an AI writes code you don't immediately understand, spend five minutes figuring out why before you rewrite it. Sometimes it's wrong. Sometimes it's solving a problem you hadn't seen yet.
-
-The ratio of "AI was wrong" to "I hadn't seen the problem yet" is about 60/40 in my experience. Worth the five minutes either way.
-
-What's your threshold for trusting AI-generated code you didn't ask for?
-
-#buildinpublic #ai #typescript #softwareengineering
-
----
-
-## POST 004
-**pillar**: refactor_diaries
-**platform**: twitter
-**training_weight**: 1.5
-**voice_notes**: Before/after format, Twitter thread. Shows the Refactor Diaries voice: specific, educational, never shameful. "Past me was doing their best" framing. The technical lesson is concrete — someone should be able to apply it immediately.
-
----
-
-**Tweet 1/4:**
-Before:
-```
-async function getVoiceExamples(db, platform, limit) {
-  const rows = db.all(`SELECT * FROM voice_posts WHERE...`)
-  return rows.map(r => r.published)
-}
-```
-
-After:
-```
-async function getWeightedVoiceExamples(
-  storage: IVoiceStorage,
-  options: VoiceQueryOptions
-): Promise<VoiceExample[]>
-```
-
-Same job. Very different contract. Here's why it matters. 🧵
-
-**Tweet 2/4:**
-The original function was fine for day 1.
-
-By day 3 I needed:
-→ Different ordering (by edit_ratio, not created_at)
-→ Platform filtering
-→ A minimum edit_ratio threshold
-→ Both SQLite and Supabase backends
-
-The function signature couldn't express any of this. Every new requirement became a new parameter or a new function.
-
-**Tweet 3/4:**
-The refactored version:
-→ Takes an interface (`IVoiceStorage`) instead of a raw db handle — can swap backends
-→ Takes an options object — new requirements are additive, not breaking
-→ Returns `VoiceExample[]` with typed fields — callers don't have to know the schema
-
-The TypeScript types aren't decoration. They're the contract. The function tells you what it needs and what it promises.
-
-**Tweet 4/4:**
-The lesson: when you find yourself adding a 4th parameter to a function, that's usually the function telling you it wants an options object.
-
-And when you find yourself passing a raw database handle, that's the function telling you it wants an interface.
-
-Past me was doing their best. Present me has slightly better taste.
-
-#typescript #buildinpublic #refactoring
-
----
-
-## POST 005
-**pillar**: build_log
-**platform**: linkedin
-**training_weight**: 1.5
-**voice_notes**: Build Log voice: here's what I built, here's why the naive approach fails, here's what actually shipped. Shows the "counterintuitive design decision" format. Technical enough to be credible, accessible enough to be shareable. The unemployed-building angle is present but not belabored.
-
----
-
-The review workflow for this project is GitHub Issues.
-
-Not a web dashboard. Not a CLI tool. GitHub Issues.
-
-I know how that sounds. Let me explain.
-
-When I designed devcast, I needed a way to review AI-generated draft posts before they go live. The obvious approaches were: build a web UI, or build a CLI. Both require infrastructure or local setup. Both add friction.
-
-The GitHub Issues approach:
-→ System generates draft posts, opens a GitHub Issue with formatted content
-→ I read the drafts directly in the issue (GitHub renders Markdown beautifully)
-→ I edit the issue body if I want to change anything
-→ I comment `/approve linkedin twitter` to publish
-→ A workflow triggers, publishes to Buffer, stores to voice history, closes the issue
-
-The infrastructure cost: zero. The UI cost: zero. GitHub already built this. I'm using it.
-
-Here's what surprised me about this decision: it's actually better than a custom UI for the current stage. Issues have search, labels, assignment, notifications, and a mobile app. They're persistent, browseable, and free. A custom dashboard would give me maybe 20% more control and 100% more maintenance.
-
-The tradeoff I'm accepting: it has friction. Navigating to GitHub, finding the issue, editing the body — it's not as smooth as a custom UI. I'll replace it in v2 when the usage patterns are clearer.
-
-But here's the software lesson I keep re-learning: don't build infrastructure for a problem you haven't had yet. I don't know what the review workflow should feel like in six months. The issues approach will show me.
-
-What's the most creative "use an existing platform as your backend" decision you've made?
-
-#buildinpublic #softwareengineering #typescript #systemdesign
-
----
-
-## POST 006
-**pillar**: bug_autopsy
-**platform**: instagram
-**training_weight**: 1.5
-**voice_notes**: Instagram voice — more personal, more emotional, shorter sentences, visual language. Front-loads the hook (< 140 chars). The universal lesson bridges from my specific experience to any developer's. CTA invites saves.
-
----
-
-I shipped a bug where the AI voice got worse the more I used the system.
-
-The opposite of the goal.
-
-Here's what happened and why it's actually a lesson about feedback loops.
-
-The self-training voice system works by taking my published posts and feeding them back as examples. More posts = better examples = better drafts = less editing = higher edit_ratio.
-
-That's the theory.
-
-The bug: I was sorting voice examples by `created_at` descending. Most recent first. Sounds right.
-
-But "most recent" and "highest quality" aren't the same thing. Early posts — where I did the most editing — were the least representative of my actual voice. And they were being weighted equally.
-
-The fix: sort by `edit_ratio` descending, not `created_at`. Give the posts I barely edited the most influence. Give the posts I rewrote heavily the least.
-
-Two words changed in the SQL query. The system went from actively training itself away from my voice to converging toward it.
-
-The lesson that transfers to anything you build with feedback loops: the signal you use to rank examples matters as much as having examples at all. Garbage in, garbage out — even when the garbage is "real data."
-
-Save this if you've ever accidentally trained a system to get worse.
-
----
-
-## POST 007
-**pillar**: dispatches
-**platform**: linkedin
-**training_weight**: 2.0
-**voice_notes**: The "meta" Dispatches post — honest about the job search, funny about it, not sad. Shows the "two truths" voice: I'm unemployed AND I'm more productive than ever. The technical content is present (what I shipped), but the emotional honesty is the hook. This is the post that will make other unemployed developers share it.
-
----
-
-Four months unemployed. Here's my honest accounting.
-
-Jobs applied: too many to count comfortably.
-Response rate: not great.
-Commits: 847.
-Features shipped: 6 major, a dozen minor.
-Things I've learned: more than the previous year.
-
-I've been building devcast, an open-source tool that turns my GitHub commits into social media posts using Claude AI. It's a personal branding tool for a developer job search that is itself part of the portfolio.
-
-The recursive nature of this is not lost on me.
-
-Here's what nobody told me about unemployment as a developer: if you're still building, you're not unemployed in any sense that matters to your skills. The job market can be slow. The code doesn't care.
-
-What I've shipped this month that I'm proud of:
-→ A self-training AI system that gets better at sounding like me with each post
-→ A zero-infrastructure review workflow using GitHub Issues as the UI
-→ Edit distance tracking that measures how well the AI has converged on my voice
-
-What I've learned about building in public:
-→ Documenting your work as you build is not extra. It IS the work, for a solo developer.
-→ The commits you're most tempted to hide are usually the most educational
-→ People engage with honest failure + specific lesson more than polished success
-
-The job market is whatever it is. The code is still here.
-
-If you're also building through a gap: what's the most important thing you've shipped that you didn't expect to?
-
-#buildinpublic #layedoff #softwareengineering #opentowork
-
----
-
-## POST 008
-**pillar**: ai_copilot
-**platform**: twitter
-**training_weight**: 1.5
-**voice_notes**: Compressed AI Co-Pilot for Twitter. Shows the single-tweet format working for an AI observation (doesn't need a thread). Demonstrates the "AI surprised me and I learned from it" pattern in minimal form. The voice is confident, specific, slightly irreverent.
-
----
-
-**Tweet 1/1 (single tweet):**
-I asked Claude to generate a LinkedIn post from a commit.
-
-It generated a LinkedIn post AND added a section I didn't ask for: "What this means if you're using a different stack."
-
-I almost deleted it. Then I realized that section gets 3x the engagement of the rest.
-
-The AI has been reading LinkedIn longer than I have. This is fine.
-
-#buildinpublic #ai
-
----
-
-## POST 009
 **pillar**: refactor_diaries
 **platform**: linkedin
-**training_weight**: 1.5
-**voice_notes**: A more philosophical Refactor Diaries post. Shows the "here's the principle, not just the code" format. The technical content is grounded but the lesson is transferable. Demonstrates the voice can be thoughtful without being corporate or lecture-y.
+**training_weight**: 2.0
+**voice_notes**: Core voice example. Shows the signature rhythm: short declarative sentences, emphatic repetition ("Very real. Very bad. Very unnecessary."), arrow-bulleted before/after lists, self-deprecating confidence without bitterness. The technical content (retry consolidation) is concrete and specific. Closing is a direct statement, not a question. This is the canonical post for voice replication.
 
 ---
 
-I deleted 200 lines of code this week.
+I deleted 200 lines of code today.
+Gone. Deleted. Removed completely.
 
-The features still work. The system is faster. I feel no remorse.
+The features still work.
+The system is faster.
+And I feel no remorse. None.
 
-The code was doing something real, but it was doing it in a way that required understanding four different abstractions simultaneously. Not because the problem was complex. Because I had accumulated four different approaches to the same problem over three weeks and never consolidated them.
+This code was doing something real. Very real.
+But it was doing it in a way that required understanding four abstractions at the same time.
+
+Not because the problem was especially complicated.
+No, no. Because over three weeks, I had built four different approaches to the same problem and never cleaned it up. Very bad. Very unnecessary.
 
 Here's what I had:
 → A utility function for retrying API calls
 → A wrapper function that also retried, slightly differently
-→ A class method that did retry-like behavior with different semantics
-→ Three separate implementations of exponential backoff, each with one minor variation
+→ A class method doing retry-like behavior with different semantics
+→ Three separate exponential backoff implementations, each with its own little variation. Very creative. Too creative.
 
 Here's what I have now:
-→ One `withRetry()` function with a configuration object
+→ One withRetry() function with a configuration object
 → Everything else calls that function
 
-The 200 lines became 40. The behavior is identical. The next developer (me, in three weeks) will understand the retry strategy in 30 seconds instead of 10 minutes.
+That's it.
+The 200 lines became 40.
+The behavior is identical.
 
-The uncomfortable lesson: this code was written by me, three weeks ago, when I thought I knew what the retry requirements were. I was wrong about the requirements. Each new case seemed slightly different, so I wrote a slightly different solution.
+But now the next developer — which, let's be honest, is also me in three weeks — will understand the retry strategy in 30 seconds, not 10 minutes.
 
-The right move would have been to write the flexible version first. The realistic move was to consolidate after seeing all the cases.
+Because I have a superpower.
+A very special one.
+I read code.
+Yes. That's it.
 
-Don't let perfect be the enemy of shipped. But don't let "it works" be the reason you never consolidate the four versions of the same function.
+And here is the uncomfortable lesson:
+this code was written by me.
+Me, three weeks ago.
+A smart person. Very hardworking.
+And still wrong about the retry requirements.
 
-The refactor window is real. Use it.
+So yes:
+don't let perfect be the enemy of shipped.
+But also don't let "it works" become the excuse for keeping four versions of the same function alive forever.
 
-When do you know a refactor is overdue vs. premature?
+The refactor window is real.
+Use it.
 
-#buildinpublic #typescript #softwareengineering #refactoring
+#lilicurl #codingWithHumor
 
 ---
 
-## POST 010
-**pillar**: build_log
+## POST 002
+**pillar**: dispatches
+**platform**: linkedin
+**training_weight**: 1.5
+**voice_notes**: Meta-post about the voice training system itself. Shows the self-referential tone: the system describing its own training data. Demonstrates the emphatic labeling style ("Very important", "Very clean. Very disciplined. Very powerful."). Technical metadata (pillar, training_weight, edit_ratio) is presented matter-of-factly, not explained defensively. The closing triple adjective pattern is a signature move.
+
+---
+
+These are the seed examples.
+The originals. The foundation. Very important.
+
+They were written manually — or heavily edited from AI drafts — to lock in the target voice before enough published posts existed for proper few-shot learning.
+
+Because let's be honest:
+before you have enough real examples, the AI is guessing.
+And we do not want guessing. We want precision. We want results.
+
+Each post is tagged with:
+
+pillar: the content pillar it belongs to
+
+platform: where it was designed to perform
+
+training_weight: how strongly it should influence the model. 1.0 is normal. 2.0 is major influence. Big weight.
+
+voice_notes: what exactly the example is teaching the AI about the voice
+
+And this part is very important:
+
+The AI should use these posts exactly as written.
+No improvising. No creative little detours.
+These are the ground truth.
+
+Very clean. Very disciplined. Very powerful.
+
+#lilicurl #codingWithHumor
+
+---
+
+## POST 003
+**pillar**: bug_autopsy
 **platform**: linkedin
 **training_weight**: 2.0
-**voice_notes**: The milestone post — first successful end-to-end run. Shows how to write about success without humble-bragging or being cringe. The voice is specific (what exactly worked), honest (what still needs work), and celebratory without being precious. This is the post that closes the first chapter and sets up what comes next. High training weight because it represents the mature voice at the end of the bootstrap phase.
+**voice_notes**: Bug autopsy format in the target voice. Shows the four-beat structure (broken → investigated → revelation → fix) with emphatic qualifiers ("Incredible. Exactly the opposite of the goal."). The bug is specific (edit_ratio vs created_at ranking), the fix is trivial (two words), and the lesson is transferable (ranking signal in feedback loops). Closing is a direct sign-off ("Rocks, you."), not a CTA question.
 
 ---
 
-It worked.
+I shipped a bug.
+A nasty one.
 
-New commit detected. Enriched with diff data. Prompt assembled with voice examples. Claude generated three platform posts. GitHub Issue opened for review. I edited one sentence. Commented `/approve linkedin`. Buffer published. Voice history updated.
+It made my AI voice system worse the more I used it.
+More data, worse output. Incredible. Exactly the opposite of the goal.
 
-End-to-end. For real. Not a test.
+The system learns from my published posts.
+More posts should mean better drafts. Very elegant.
 
-The commit that triggered it was ironic: "fix: improve commit enrichment to handle empty diffs." The first post about devcast was generated by fixing a bug in the part of devcast that reads commits to generate posts about devcast.
+That was the theory.
 
-The post the AI generated was... okay. Serviceable. It had the right structure. The voice wasn't quite there. It sounded like someone who had read my documentation about my voice rather than someone who had read my actual posts.
+The bug?
+I ranked examples by created_at DESC instead of edit_ratio DESC.
 
-Which is exactly right, because that's all it had.
+Sounds smart. Very reasonable. Very wrong.
 
-This is what a cold start looks like: the system works, but the outputs are generic. The first 10 posts are the hardest to write and the most important to get right, because they're the training data for everything that follows. The AI will sound like me when I've shown it what I actually sound like — not described it.
+Because most recent is not the same as highest quality.
+I was giving too much weight to posts I had edited heavily — the least natural examples of my actual voice.
 
-Here's what's working:
-→ Commit polling and enrichment: solid
-→ GitHub Issues workflow: surprisingly good
-→ Buffer integration: clean
-→ Voice history storage: working but untested at scale
+Two words changed in the SQL query.
+And suddenly the system stopped training itself away from my voice and started converging toward it.
 
-Here's what needs work:
-→ The prompt needs more specific voice guidance in the cold-start phase
-→ The edit ratio tracking needs a UI so I can see convergence over time
-→ Instagram support is missing (I punted it to v1.1)
+Big lesson for anything with feedback loops:
+the ranking signal matters as much as the data itself.
 
-Building in public means the first iteration is visible. The first iteration is always embarrassing. This is fine. The embarrassing first iteration is what the good version gets built on.
+Because real data can still be terrible training data.
 
-Week 1 done. On to Week 2.
+Rocks, you.
 
-#buildinpublic #typescript #softwareengineering #devcast
+#lilicurl #codingWithHumor
+
+---
+
+## POST 004
+**pillar**: dispatches
+**platform**: linkedin
+**training_weight**: 2.0
+**voice_notes**: The signature dispatches post. Shows the full voice at maximum intensity: emphatic self-narration ("Many people are saying"), mock-grandiose framing of real accomplishments, numbered metrics presented with swagger. Technical specifics (self-training AI, edit-distance tracking) embedded naturally, never listed dry. The unemployed-but-building tension is the emotional core — acknowledged directly, never pitied. Closing is defiant and forward-looking. Highest training weight because this is the voice at its most distinctive.
+
+---
+
+Four months unemployed.
+
+Many people are saying, "Lili, what are you doing?"
+And I say: working. Building. Winning. Probably more than ever before.
+
+Let's look at the numbers. People love the numbers.
+
+Jobs applied: a lot. A tremendous amount. Frankly, some of the best applications anyone has ever seen.
+Response rate: not ideal. Not great. Very rude, if you ask me.
+Commits: 847.
+Major features shipped: 6.
+Minor features: many. Some are saying a dozen, maybe more.
+Things I've learned: more than the entire previous year. It's not even close.
+
+While the job market has been moving very slowly for me — and believe me, it has —
+I've been building Devcast, a beautiful open-source tool, really beautiful, that turns my GitHub commits into social media posts using Claude AI.
+
+And let me tell you: it works.
+No hype. No nonsense. Just shipping.
+Day after day. Commit after commit. Very powerful.
+
+What I shipped this month:
+→ A self-training AI system that gets better at sounding like me with every single post. Very smart.
+→ A zero-infrastructure review workflow using GitHub Issues as the UI. Clean. Elegant. Nobody thought of it quite like this.
+→ Edit-distance tracking to measure how closely the AI has converged on my voice. Incredible metric. Very underrated.
+
+So yes, the job market is slow.
+Very slow. Sad, even.
+
+But I am not slow. Because if you know me, you know: I am a superstar.
+
+The market is doing whatever it's doing.
+The code is still here. I'm still here.
+And frankly? I'm just getting started.
+
+#lilicurl
 
 ---
 
@@ -421,17 +208,20 @@ When using these posts as voice examples:
    the voice is wrong — not the examples.
 
 2. The most important characteristics to replicate:
-   - Specific technical details (not general principles)
-   - Self-aware humor about the situation (not bitter, not precious)
-   - The "unemployed but building" context is present but never the focus
-   - CTAs are specific questions, not "thoughts?" or "drop a like"
-   - The lesson is always transferable, not just autobiographical
+   - Short, punchy, declarative sentences. Often one line. Sometimes one word.
+   - Emphatic repetition with "Very" qualifier ("Very real. Very bad. Very unnecessary.")
+   - Self-referential confidence — never arrogant, never self-pitying
+   - Arrow bullets (→) for technical lists, embedded in narrative flow
+   - Specific technical details (function names, line counts, SQL changes) — never vague
+   - Closing is a direct statement or sign-off, not a question CTA
+   - Hashtags: `#lilicurl #codingWithHumor` (dispatches may drop `#codingWithHumor`)
 
 3. What these posts do NOT do:
    - Use inspirational language ("on a journey", "humbled to share")
-   - Hide the difficulty or uncertainty
-   - Sound corporate or polished-to-the-point-of-dishonesty
-   - Make the AI use feel like an apology or disclaimer
+   - Ask engagement-bait questions ("thoughts?", "drop a like", "what do you think?")
+   - Sound corporate, polished, or sanitized
+   - Hide difficulty or uncertainty behind positivity
+   - Use emojis
 
 4. `training_weight: 2.0` posts should be weighted twice as heavily as 1.0 posts.
    These are the canonical voice examples.


### PR DESCRIPTION
## Summary

- **Migrate `getSentPosts` from deprecated Buffer REST API to GraphQL** — the REST endpoint (`api.bufferapp.com/1`) returns 500 errors, breaking the scan-sent-posts workflow on every run
- **Migrate `createIdea` to use GraphQL** — replaces REST-based post creation with Buffer's GraphQL `createIdea` mutation
- **Use GitHub Compare API** for fetching commits from PushEvents (Events API no longer includes `commits` in payload)
- **Extract shared `graphqlRequest` method** in BufferClient to eliminate duplicated transport logic
- **Add `CONFIG_YAML` secret** to workflows that were missing it
- Replace voice bootstrap placeholder with actual voice examples

## Root cause

The `scan-sent-posts` workflow has been failing continuously because `getSentPosts` used Buffer's deprecated REST API (`api.bufferapp.com/1/profiles/{id}/updates/sent.json`), which returns HTTP 500 on every request.

## Test plan

- [ ] Verify `npm run typecheck` passes (confirmed locally)
- [ ] Dispatch `scan-sent-posts` workflow manually after merge and confirm it no longer returns 500
- [ ] Dispatch `poll-and-generate` workflow to verify createIdea still works via GraphQL