### PR TITLE
fix: use PAT for cross-repo access and increase commits per push

### DIFF
--- a/.github/workflows/poll-and-generate.yml
+++ b/.github/workflows/poll-and-generate.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run poll and generate
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           BUFFER_ACCESS_TOKEN: ${{ secrets.BUFFER_ACCESS_TOKEN }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,7 +8,7 @@ github:
   exclude_patterns:
     - "^(wip|temp|fixup!|squash!)"
     - "\\[skip\\]"
-  max_commits_per_push: 1                    # process at most N commits per push event
+  max_commits_per_push: 4                    # process at most N commits per push event
 
 buffer:
   organization_id: ""                        # from: buffer.com → Settings → Organizations


### PR DESCRIPTION
## Summary

- Use `GH_PAT` secret instead of default `GITHUB_TOKEN` in poll workflow — the auto-provided token only has access to the current repo, preventing detection of commits in other repos (personal and vialabs-net org)
- Increase `max_commits_per_push` default from 1 to 4 — allows processing multiple commits per push event

## Test plan

- [ ] Dispatch poll-and-generate workflow manually after merge
- [ ] Verify logs show events from repos other than social-engagement
- [ ] Verify multiple commits per push are processed (up to 4)