### PR TITLE
feat: add 10 new analysis modules (17 total)

### DIFF
--- a/src/analysis/modules/api-design.ts
+++ b/src/analysis/modules/api-design.ts
@@ -1,0 +1,109 @@
+import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+
+interface ApiPattern {
+  readonly name: string;
+  readonly score: number;
+  readonly technicalDetail: string;
+  readonly explanation: string;
+  detect(addedLines: readonly string[]): boolean;
+}
+
+const BACKEND_FILE_REGEX = /(?:route|controller|handler|middleware|server|api[\\/])/i;
+
+const PAGINATION_KEYWORDS = ['limit', 'offset', 'cursor', 'page', 'per_page', 'pageSize'];
+
+function hasPaginationCoOccurrence(lines: readonly string[]): boolean {
+  const joined = lines.join('\n').toLowerCase();
+  let matches = 0;
+  for (const kw of PAGINATION_KEYWORDS) {
+    if (joined.includes(kw)) matches++;
+    if (matches >= 2) return true;
+  }
+  return false;
+}
+
+const PATTERNS: readonly ApiPattern[] = [
+  {
+    name: 'RESTful route definition',
+    score: 8,
+    technicalDetail: 'RESTful routing — HTTP verbs mapped to resource endpoints following REST conventions.',
+    explanation: 'REST routes use HTTP verbs (GET, POST, PUT, DELETE) to express intent. A well-named route like GET /users/:id is self-documenting — the verb says the action, the path says the resource.',
+    detect: (lines) => lines.some((l) =>
+      /\b(router|app)\.(get|post|put|patch|delete)\s*\(\s*['"`]\//.test(l) ||
+      /\b@(Get|Post|Put|Patch|Delete)\s*\(/.test(l),
+    ),
+  },
+  {
+    name: 'error response contract',
+    score: 8,
+    technicalDetail: 'Standardized error responses — consistent error envelope with status code, error code, and message.',
+    explanation: 'A consistent error format means every client knows exactly what to expect when something fails. Status code for machines, message for humans, error code for programmatic handling.',
+    detect: (lines) => lines.some((l) =>
+      /\.status\(\d{3}\)\s*\.json\(\s*\{/.test(l) ||
+      /\b(reply|response)\.(code|status)\(\d{3}\)/.test(l),
+    ),
+  },
+  {
+    name: 'API versioning',
+    score: 7,
+    technicalDetail: 'API versioning — URL path or header-based version prefix to maintain backwards compatibility.',
+    explanation: 'Versioning lets you evolve the API without breaking existing clients. Old clients keep using /v1, new clients move to /v2. No surprise breaking changes.',
+    detect: (lines) => lines.some((l) =>
+      /['"`]\/(?:api\/)?v\d+/.test(l) ||
+      /api-version|x-api-version/i.test(l),
+    ),
+  },
+  {
+    name: 'rate limiting',
+    score: 7,
+    technicalDetail: 'Rate limiting — restricting request frequency per client to protect against abuse and ensure fair resource usage.',
+    explanation: 'Rate limiting prevents one client from overwhelming the server. Without it, a single script can exhaust your resources and take down the service for everyone.',
+    detect: (lines) => lines.some((l) =>
+      /\b(rateLimit|rateLimiter|throttle)\s*\(/.test(l) ||
+      /\b@Throttle\s*\(/.test(l) ||
+      /express-rate-limit|@nestjs\/throttler|rate-limiter-flexible/.test(l),
+    ),
+  },
+  {
+    name: 'pagination',
+    score: 7,
+    technicalDetail: 'Pagination — returning data in bounded pages instead of unbounded result sets.',
+    explanation: 'Pagination keeps responses fast and predictable. Without it, a table with 100k rows returns everything at once — slow response, high memory, bad UX.',
+    detect: (lines) => hasPaginationCoOccurrence(lines),
+  },
+];
+
+export class ApiDesignModule implements CodeAnalyzer {
+  readonly id = 'api_design';
+  readonly name = 'API Design';
+  readonly category = 'api_design' as const;
+
+  async analyze(ctx: AnalysisContext): Promise<Finding | null> {
+    for (const diff of ctx.diffs) {
+      if (!diff.patch || diff.status === 'removed') continue;
+      if (!BACKEND_FILE_REGEX.test(diff.filename)) continue;
+
+      const addedLines = diff.patch
+        .split('\n')
+        .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+        .map((l) => l.slice(1));
+
+      if (addedLines.length === 0) continue;
+
+      for (const pattern of PATTERNS) {
+        if (pattern.detect(addedLines)) {
+          return {
+            moduleId: this.id,
+            aspect: pattern.name,
+            finding: `${pattern.name} in ${diff.filename}`,
+            technicalDetail: pattern.technicalDetail,
+            plainLanguage: pattern.explanation,
+            interestScore: pattern.score,
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/analysis/modules/api-design.ts
+++ b/src/analysis/modules/api-design.ts
@@ -25,7 +25,7 @@ function hasPaginationCoOccurrence(lines: readonly string[]): boolean {
 const PATTERNS: readonly ApiPattern[] = [
   {
     name: 'RESTful route definition',
-    score: 8,
+    score: 5,
     technicalDetail: 'RESTful routing — HTTP verbs mapped to resource endpoints following REST conventions.',
     explanation: 'REST routes use HTTP verbs (GET, POST, PUT, DELETE) to express intent. A well-named route like GET /users/:id is self-documenting — the verb says the action, the path says the resource.',
     detect: (lines) => lines.some((l) =>

--- a/src/analysis/modules/clean-code.ts
+++ b/src/analysis/modules/clean-code.ts
@@ -10,7 +10,7 @@ export class CleanCodeModule implements CodeAnalyzer {
 
   async analyze(ctx: AnalysisContext): Promise<Finding | null> {
     for (const diff of ctx.diffs) {
-      if (!diff.patch) continue;
+      if (!diff.patch || diff.status === 'removed') continue;
 
       const totalBefore = diff.deletions;
       const totalAfter = diff.additions;

--- a/src/analysis/modules/concurrency.ts
+++ b/src/analysis/modules/concurrency.ts
@@ -1,0 +1,101 @@
+import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+
+interface ConcurrencyPattern {
+  readonly name: string;
+  readonly score: number;
+  readonly technicalDetail: string;
+  readonly explanation: string;
+  detect(addedLines: readonly string[]): boolean;
+}
+
+const PATTERNS: readonly ConcurrencyPattern[] = [
+  {
+    name: 'mutex / lock',
+    score: 9,
+    technicalDetail: 'Mutex — mutual exclusion lock that ensures only one operation accesses a shared resource at a time.',
+    explanation: 'A mutex prevents two operations from modifying the same data simultaneously. Without it, concurrent writes can corrupt state — one update overwrites the other silently.',
+    detect: (lines) => lines.some((l) =>
+      /\bnew\s+Mutex\s*\(/.test(l) ||
+      /\b(acquireLock|releaseLock|lock\.acquire|lock\.release|withLock)\s*\(/.test(l) ||
+      /\bnew\s+Semaphore\s*\(/.test(l),
+    ),
+  },
+  {
+    name: 'atomic operation',
+    score: 8,
+    technicalDetail: 'Atomic operations — indivisible read-modify-write operations that prevent partial updates in concurrent contexts.',
+    explanation: 'Atomic operations guarantee that a read-then-write happens as one indivisible step. Without atomicity, two concurrent increments can both read the same value and one update is lost.',
+    detect: (lines) => lines.some((l) =>
+      /\bAtomics\.(add|sub|load|store|exchange|compareExchange)\s*\(/.test(l) ||
+      /\b(compareAndSwap|compareAndSet)\s*\(/.test(l) ||
+      /\.\$inc\s*\(|\bincrement\s*\(.*atomic/i.test(l),
+    ),
+  },
+  {
+    name: 'worker threads',
+    score: 8,
+    technicalDetail: 'Worker threads — true parallelism by running CPU-intensive tasks in separate threads with message-passing communication.',
+    explanation: 'Worker threads move heavy computation off the main thread. Node.js is single-threaded by default — without workers, a CPU-bound task blocks every other request.',
+    detect: (lines) => lines.some((l) =>
+      /\bnew\s+Worker\s*\(/.test(l) ||
+      /\b(worker_threads|parentPort|workerData|isMainThread)\b/.test(l) ||
+      /\bWorkerPool\s*[.(]/.test(l),
+    ),
+  },
+  {
+    name: 'concurrency control',
+    score: 8,
+    technicalDetail: 'Concurrency limiting — bounding the number of parallel operations to prevent resource exhaustion.',
+    explanation: 'Running 10,000 requests in parallel crashes the process. A concurrency limiter runs them in controlled batches — fast enough to be useful, bounded enough to stay stable.',
+    detect: (lines) => lines.some((l) =>
+      /\b(p-limit|p-queue|p-map|PQueue|pLimit)\b/.test(l) ||
+      /\bPromise\.allSettled\s*\(/.test(l) ||
+      /\bPromise\.all\s*\(\s*\w+\.map\s*\(/.test(l),
+    ),
+  },
+  {
+    name: 'race condition guard',
+    score: 7,
+    technicalDetail: 'Race condition guard — idempotency keys or abort signals that prevent duplicate or stale operations from corrupting state.',
+    explanation: 'An idempotency key ensures the same request processed twice produces the same result. An AbortController cancels stale requests so old responses do not overwrite new ones.',
+    detect: (lines) => lines.some((l) =>
+      /\b(idempotencyKey|idempotency[_-]key|idempotent)\b/i.test(l) ||
+      /\bnew\s+AbortController\s*\(/.test(l) ||
+      /\bsignal\s*:\s*\w+\.signal\b/.test(l),
+    ),
+  },
+];
+
+export class ConcurrencyModule implements CodeAnalyzer {
+  readonly id = 'concurrency';
+  readonly name = 'Concurrency';
+  readonly category = 'concurrency' as const;
+
+  async analyze(ctx: AnalysisContext): Promise<Finding | null> {
+    for (const diff of ctx.diffs) {
+      if (!diff.patch || diff.status === 'removed') continue;
+
+      const addedLines = diff.patch
+        .split('\n')
+        .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+        .map((l) => l.slice(1));
+
+      if (addedLines.length === 0) continue;
+
+      for (const pattern of PATTERNS) {
+        if (pattern.detect(addedLines)) {
+          return {
+            moduleId: this.id,
+            aspect: pattern.name,
+            finding: `${pattern.name} in ${diff.filename}`,
+            technicalDetail: pattern.technicalDetail,
+            plainLanguage: pattern.explanation,
+            interestScore: pattern.score,
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/analysis/modules/dependency-health.ts
+++ b/src/analysis/modules/dependency-health.ts
@@ -1,0 +1,125 @@
+import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+
+const SEMVER_REGEX = /["'][\^~]?(\d+)\.\d+\.\d+["']/;
+
+const SECURITY_DEPS = new Set([
+  'helmet', 'cors', 'bcrypt', 'bcryptjs', 'jsonwebtoken',
+  'passport', 'express-rate-limit', 'csurf', 'hpp',
+  'express-validator', 'zod', 'joi',
+]);
+
+interface DepPattern {
+  readonly name: string;
+  readonly score: number;
+  readonly technicalDetail: string;
+  readonly explanation: string;
+  detect(addedLines: readonly string[], removedLines: readonly string[]): boolean;
+}
+
+const PATTERNS: readonly DepPattern[] = [
+  {
+    name: 'security-sensitive dependency',
+    score: 8,
+    technicalDetail: 'Security dependency — a package dedicated to protecting the application from common attack vectors.',
+    explanation: 'Adding a security package like helmet or bcrypt means someone is actively hardening the app. Each one closes a specific attack surface — CSRF, brute-force, injection.',
+    detect: (added) => added.some((l) => {
+      const match = l.match(/"([^"]+)":\s*"/);
+      return match !== null && SECURITY_DEPS.has(match[1]!);
+    }),
+  },
+  {
+    name: 'major version bump',
+    score: 8,
+    technicalDetail: 'Major version upgrade — a semver major bump that may include breaking changes requiring code migration.',
+    explanation: 'A major version bump means breaking changes. The maintainers changed the API, removed features, or restructured internals. It requires reading the migration guide and testing thoroughly.',
+    detect: (added, removed) => {
+      for (const addedLine of added) {
+        const addedMatch = addedLine.match(/"([^"]+)":\s*"[\^~]?(\d+)\./);
+        if (!addedMatch) continue;
+        const [, depName, addedMajor] = addedMatch;
+        for (const removedLine of removed) {
+          const removedMatch = removedLine.match(new RegExp(`"${depName}":\\s*"[\\^~]?(\\d+)\\.`));
+          if (removedMatch && removedMatch[1] !== addedMajor) return true;
+        }
+      }
+      return false;
+    },
+  },
+  {
+    name: 'new dependency added',
+    score: 7,
+    technicalDetail: 'New dependency — a new package added to the project, expanding the dependency tree and attack surface.',
+    explanation: 'Every new dependency is a bet on someone else\'s code. It solves a problem, but adds maintenance burden, security surface, and bundle size. The best dependency is one you don\'t need.',
+    detect: (added, removed) => {
+      const removedDeps = new Set(
+        removed.map((l) => l.match(/"([^"]+)":\s*"/)?.[1]).filter(Boolean),
+      );
+      return added.some((l) => {
+        const match = l.match(/"([^"]+)":\s*"/);
+        return match !== null && SEMVER_REGEX.test(l) && !removedDeps.has(match[1]!);
+      });
+    },
+  },
+  {
+    name: 'dependency removed',
+    score: 7,
+    technicalDetail: 'Dependency removal — reducing the dependency tree by eliminating an unused or replaced package.',
+    explanation: 'Removing a dependency shrinks the attack surface, reduces install time, and eliminates a maintenance burden. Every removed package is code you no longer need to audit or update.',
+    detect: (added, removed) => {
+      const addedDeps = new Set(
+        added.map((l) => l.match(/"([^"]+)":\s*"/)?.[1]).filter(Boolean),
+      );
+      return removed.some((l) => {
+        const match = l.match(/"([^"]+)":\s*"/);
+        return match !== null && SEMVER_REGEX.test(l) && !addedDeps.has(match[1]!);
+      });
+    },
+  },
+  {
+    name: 'engine constraint',
+    score: 7,
+    technicalDetail: 'Engine constraint — pinning the required Node.js or npm version to prevent runtime incompatibilities.',
+    explanation: 'An engine constraint in package.json prevents "works on my machine" problems. npm install fails immediately if the Node version is wrong — no mysterious runtime errors later.',
+    detect: (added) => added.some((l) =>
+      /["']engines["']|["']node["']\s*:\s*["'][><=^~]?\d+/.test(l),
+    ),
+  },
+];
+
+export class DependencyHealthModule implements CodeAnalyzer {
+  readonly id = 'dependency_health';
+  readonly name = 'Dependency Health';
+  readonly category = 'dependency_health' as const;
+
+  async analyze(ctx: AnalysisContext): Promise<Finding | null> {
+    for (const diff of ctx.diffs) {
+      if (!diff.patch || diff.status === 'removed') continue;
+      if (!diff.filename.endsWith('package.json')) continue;
+
+      const lines = diff.patch.split('\n');
+      const addedLines = lines
+        .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+        .map((l) => l.slice(1));
+      const removedLines = lines
+        .filter((l) => l.startsWith('-') && !l.startsWith('---'))
+        .map((l) => l.slice(1));
+
+      if (addedLines.length === 0 && removedLines.length === 0) continue;
+
+      for (const pattern of PATTERNS) {
+        if (pattern.detect(addedLines, removedLines)) {
+          return {
+            moduleId: this.id,
+            aspect: pattern.name,
+            finding: `${pattern.name} in ${diff.filename}`,
+            technicalDetail: pattern.technicalDetail,
+            plainLanguage: pattern.explanation,
+            interestScore: pattern.score,
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/analysis/modules/dependency-health.ts
+++ b/src/analysis/modules/dependency-health.ts
@@ -49,7 +49,7 @@ const PATTERNS: readonly DepPattern[] = [
   },
   {
     name: 'new dependency added',
-    score: 7,
+    score: 5,
     technicalDetail: 'New dependency — a new package added to the project, expanding the dependency tree and attack surface.',
     explanation: 'Every new dependency is a bet on someone else\'s code. It solves a problem, but adds maintenance burden, security surface, and bundle size. The best dependency is one you don\'t need.',
     detect: (added, removed) => {
@@ -79,7 +79,7 @@ const PATTERNS: readonly DepPattern[] = [
   },
   {
     name: 'engine constraint',
-    score: 7,
+    score: 5,
     technicalDetail: 'Engine constraint — pinning the required Node.js or npm version to prevent runtime incompatibilities.',
     explanation: 'An engine constraint in package.json prevents "works on my machine" problems. npm install fails immediately if the Node version is wrong — no mysterious runtime errors later.',
     detect: (added) => added.some((l) =>

--- a/src/analysis/modules/dependency-health.ts
+++ b/src/analysis/modules/dependency-health.ts
@@ -36,7 +36,9 @@ const PATTERNS: readonly DepPattern[] = [
       for (const addedLine of added) {
         const addedMatch = addedLine.match(/"([^"]+)":\s*"[\^~]?(\d+)\./);
         if (!addedMatch) continue;
-        const [, depName, addedMajor] = addedMatch;
+        const depName = addedMatch[1];
+        const addedMajor = addedMatch[2];
+        if (!depName || !addedMajor) continue;
         for (const removedLine of removed) {
           const removedMatch = removedLine.match(new RegExp(`"${depName}":\\s*"[\\^~]?(\\d+)\\.`));
           if (removedMatch && removedMatch[1] !== addedMajor) return true;

--- a/src/analysis/modules/dx.ts
+++ b/src/analysis/modules/dx.ts
@@ -62,6 +62,17 @@ const PATTERNS: readonly DxPattern[] = [
       /\b(assert|invariant)\s*\(.*,\s*['"`]/.test(l),
     ),
   },
+  {
+    name: 'callback to promise conversion',
+    score: 7,
+    technicalDetail: 'util.promisify — converts Node.js error-first callback APIs into promise-based functions for async/await usage.',
+    explanation: 'Legacy Node.js APIs use error-first callbacks that nest deeply. util.promisify wraps them as promises so you can use async/await — flat, readable, and try/catch-friendly.',
+    detect: (lines) => lines.some((l) =>
+      /\butil\.promisify\s*\(/.test(l) ||
+      /\bpromisify\b.*\brequire\s*\(\s*['"]util['"]/.test(l) ||
+      /\bimport\b.*\bpromisify\b.*\bfrom\s*['"](?:node:)?util['"]/.test(l),
+    ),
+  },
 ];
 
 export class DxModule implements CodeAnalyzer {

--- a/src/analysis/modules/dx.ts
+++ b/src/analysis/modules/dx.ts
@@ -1,0 +1,99 @@
+import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+
+interface DxPattern {
+  readonly name: string;
+  readonly score: number;
+  readonly technicalDetail: string;
+  readonly explanation: string;
+  detect(addedLines: readonly string[], filename: string): boolean;
+}
+
+const CONFIG_FILE_REGEX = /(?:config|settings|options|env)\b/i;
+
+const PATTERNS: readonly DxPattern[] = [
+  {
+    name: 'custom error class',
+    score: 8,
+    technicalDetail: 'Custom error class — domain-specific errors with descriptive names that communicate what went wrong and why.',
+    explanation: 'A generic Error("something failed") tells you nothing. A BufferTokenExpiredError tells you exactly what happened, what service failed, and hints at the fix — without reading the stack trace.',
+    detect: (lines) => lines.some((l) =>
+      /\bclass\s+\w+Error\s+extends\s+(Error|BaseError|CustomError)\b/.test(l),
+    ),
+  },
+  {
+    name: 'config schema validation',
+    score: 8,
+    technicalDetail: 'Config schema validation — validating configuration at startup with a schema to catch misconfiguration before the app starts serving traffic.',
+    explanation: 'Validating config at startup catches typos and missing values immediately. Without it, a misspelled key silently becomes undefined and the app crashes at 3am when that code path runs.',
+    detect: (lines, filename) => {
+      if (!CONFIG_FILE_REGEX.test(filename)) return false;
+      return lines.some((l) =>
+        /\b(z\.object|z\.string|z\.number|Joi\.object|\.safeParse|\.parse)\s*\(/.test(l),
+      );
+    },
+  },
+  {
+    name: 'CLI setup',
+    score: 7,
+    technicalDetail: 'CLI framework — structured command-line interface with help text, options parsing, and usage documentation.',
+    explanation: 'A CLI framework turns a script into a tool. Help text, typed options, and validation mean users discover features through --help instead of reading source code.',
+    detect: (lines) => lines.some((l) =>
+      /\b(program|commander|yargs|meow|cac)\b.*\.(description|option|command|parse)\s*\(/.test(l) ||
+      /\bimport\b.*\b(commander|yargs|meow|cac)\b/.test(l),
+    ),
+  },
+  {
+    name: 'environment validation',
+    score: 7,
+    technicalDetail: 'Environment variable validation — verifying required env vars exist at startup and failing fast with clear messages if they are missing.',
+    explanation: 'Validating env vars at startup catches deployment mistakes immediately. Without it, a missing API key goes unnoticed until the first request fails — hours or days later.',
+    detect: (lines) => lines.some((l) =>
+      /\benvalid\b/.test(l) ||
+      /\bif\s*\(\s*!process\.env\[.*\]\s*\)\s*(throw|process\.exit)/.test(l) ||
+      /\bprocess\.env\b.*\bz\.(string|number|enum)\s*\(/.test(l),
+    ),
+  },
+  {
+    name: 'descriptive assertion',
+    score: 7,
+    technicalDetail: 'Descriptive assertion — runtime invariant checks with human-readable messages that explain what assumption was violated.',
+    explanation: 'An assertion with a message turns a cryptic crash into a diagnosis. "Expected userId to be defined after auth middleware" tells the next developer exactly what broke and where to look.',
+    detect: (lines) => lines.some((l) =>
+      /\b(assert|invariant)\s*\(.*,\s*['"`]/.test(l),
+    ),
+  },
+];
+
+export class DxModule implements CodeAnalyzer {
+  readonly id = 'dx';
+  readonly name = 'Developer Experience';
+  readonly category = 'dx' as const;
+
+  async analyze(ctx: AnalysisContext): Promise<Finding | null> {
+    for (const diff of ctx.diffs) {
+      if (!diff.patch || diff.status === 'removed') continue;
+
+      const addedLines = diff.patch
+        .split('\n')
+        .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+        .map((l) => l.slice(1));
+
+      if (addedLines.length === 0) continue;
+
+      for (const pattern of PATTERNS) {
+        if (pattern.detect(addedLines, diff.filename)) {
+          return {
+            moduleId: this.id,
+            aspect: pattern.name,
+            finding: `${pattern.name} in ${diff.filename}`,
+            technicalDetail: pattern.technicalDetail,
+            plainLanguage: pattern.explanation,
+            interestScore: pattern.score,
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/analysis/modules/error-resilience.ts
+++ b/src/analysis/modules/error-resilience.ts
@@ -1,0 +1,97 @@
+import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+
+interface ResiliencePattern {
+  readonly name: string;
+  readonly score: number;
+  readonly technicalDetail: string;
+  readonly explanation: string;
+  detect(addedLines: readonly string[]): boolean;
+}
+
+const PATTERNS: readonly ResiliencePattern[] = [
+  {
+    name: 'circuit breaker',
+    score: 9,
+    technicalDetail: 'Circuit breaker — stops calling a failing service after repeated failures, allowing it time to recover before retrying.',
+    explanation: 'A circuit breaker prevents cascading failures. After enough errors, it stops making requests and returns a fallback instead of hammering a dying service. Once the service recovers, it gradually resumes.',
+    detect: (lines) => lines.some((l) =>
+      /\b(CircuitBreaker|circuitBreaker|circuit[_-]?breaker)\s*[.(]/.test(l) ||
+      /\b(opossum|cockatiel|mollitia)/.test(l),
+    ),
+  },
+  {
+    name: 'retry with backoff',
+    score: 8,
+    technicalDetail: 'Retry with exponential backoff — automatically retrying failed operations with increasing delay between attempts.',
+    explanation: 'Retrying with backoff gives transient failures time to resolve. Each retry waits longer — 1s, 2s, 4s — so you recover from blips without overwhelming a struggling service.',
+    detect: (lines) => lines.some((l) =>
+      /\b(withRetry|retryWith|retry)\s*\(/.test(l) ||
+      /\b(exponentialBackoff|backoff|retryDelay)\b/.test(l) ||
+      /\bp-retry\b/.test(l),
+    ),
+  },
+  {
+    name: 'graceful degradation',
+    score: 8,
+    technicalDetail: 'Graceful degradation — providing a reduced but functional response when a dependency fails instead of crashing.',
+    explanation: 'When a service goes down, graceful degradation keeps the app running with reduced functionality. Users get a cached result or a default instead of an error page.',
+    detect: (lines) => lines.some((l) =>
+      /\b(fallback|withFallback|onFallback|gracefulShutdown|degradeGracefully|getDefault[A-Z])\s*[.(]/.test(l),
+    ),
+  },
+  {
+    name: 'request timeout',
+    score: 7,
+    technicalDetail: 'Request timeout — bounding how long a network call can take to prevent indefinite blocking.',
+    explanation: 'Without a timeout, a slow service can block your entire application indefinitely. Explicit timeouts ensure you fail fast and free resources instead of waiting forever.',
+    detect: (lines) => lines.some((l) =>
+      /\bAbortSignal\.timeout\s*\(/.test(l) ||
+      /\b(axios|fetch|http|request|got)\b.*\btimeout\s*[:=]/.test(l) ||
+      /\btimeout\s*[:=].*\b(axios|fetch|http|request|got)\b/.test(l),
+    ),
+  },
+  {
+    name: 'health check endpoint',
+    score: 7,
+    technicalDetail: 'Health check — a dedicated endpoint that reports service status for load balancers and orchestrators.',
+    explanation: 'A /health endpoint lets Kubernetes, load balancers, and monitoring tools know if the service is alive. Without it, traffic keeps flowing to a broken instance.',
+    detect: (lines) => lines.some((l) =>
+      /\b(router|app)\.(get|all)\s*\(\s*['"`]\/(health|ready|liveness|readiness)/.test(l) ||
+      /\b@Get\s*\(\s*['"`](health|ready|liveness)/.test(l),
+    ),
+  },
+];
+
+export class ErrorResilienceModule implements CodeAnalyzer {
+  readonly id = 'error_resilience';
+  readonly name = 'Error Resilience';
+  readonly category = 'error_resilience' as const;
+
+  async analyze(ctx: AnalysisContext): Promise<Finding | null> {
+    for (const diff of ctx.diffs) {
+      if (!diff.patch || diff.status === 'removed') continue;
+
+      const addedLines = diff.patch
+        .split('\n')
+        .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+        .map((l) => l.slice(1));
+
+      if (addedLines.length === 0) continue;
+
+      for (const pattern of PATTERNS) {
+        if (pattern.detect(addedLines)) {
+          return {
+            moduleId: this.id,
+            aspect: pattern.name,
+            finding: `${pattern.name} in ${diff.filename}`,
+            technicalDetail: pattern.technicalDetail,
+            plainLanguage: pattern.explanation,
+            interestScore: pattern.score,
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/analysis/modules/error-resilience.ts
+++ b/src/analysis/modules/error-resilience.ts
@@ -60,6 +60,15 @@ const PATTERNS: readonly ResiliencePattern[] = [
       /\b@Get\s*\(\s*['"`](health|ready|liveness)/.test(l),
     ),
   },
+  {
+    name: 'graceful shutdown',
+    score: 8,
+    technicalDetail: 'Graceful shutdown — listening for SIGINT/SIGTERM to close connections and flush buffers before the process exits.',
+    explanation: 'When Kubernetes sends SIGTERM, a graceful shutdown finishes in-flight requests and closes DB connections. Without it, requests get cut mid-response and data can corrupt.',
+    detect: (lines) => lines.some((l) =>
+      /\bprocess\.on\s*\(\s*['"`](SIGINT|SIGTERM)['"`]/.test(l),
+    ),
+  },
 ];
 
 export class ErrorResilienceModule implements CodeAnalyzer {

--- a/src/analysis/modules/evolutionary.ts
+++ b/src/analysis/modules/evolutionary.ts
@@ -47,7 +47,7 @@ function detectFileRename(diffs: readonly FileDiff[]): Finding | null {
     finding: `file renamed: ${renamed.filename}`,
     technicalDetail: 'File rename — improving naming to better reflect the module\'s responsibility and make the codebase more navigable.',
     plainLanguage: 'Renaming a file signals that the team is investing in clarity. Good names reduce the time it takes a new developer to find what they are looking for.',
-    interestScore: 8,
+    interestScore: 5,
   };
 }
 

--- a/src/analysis/modules/evolutionary.ts
+++ b/src/analysis/modules/evolutionary.ts
@@ -1,0 +1,114 @@
+import type { CodeAnalyzer, AnalysisContext, Finding, FileDiff } from '../types.js';
+
+const MIGRATION_REGEX = /(?:migrat|\.sql$)/i;
+const MIN_EXTRACTION_LINES = 30;
+const MIN_LARGE_DELETION = 50;
+
+function getExtension(filename: string): string {
+  const dot = filename.lastIndexOf('.');
+  return dot === -1 ? '' : filename.slice(dot);
+}
+
+function getDirectory(filename: string): string {
+  const slash = filename.lastIndexOf('/');
+  return slash === -1 ? '' : filename.slice(0, slash);
+}
+
+function detectModuleExtraction(diffs: readonly FileDiff[]): Finding | null {
+  const addedFiles = diffs.filter((d) => d.status === 'added' && d.additions >= MIN_EXTRACTION_LINES);
+  const modifiedWithDeletions = diffs.filter((d) => d.status === 'modified' && d.deletions >= MIN_EXTRACTION_LINES);
+
+  for (const added of addedFiles) {
+    for (const modified of modifiedWithDeletions) {
+      const sameDir = getDirectory(added.filename) === getDirectory(modified.filename);
+      const sameExt = getExtension(added.filename) === getExtension(modified.filename);
+      if (sameDir || sameExt) {
+        return {
+          moduleId: 'evolutionary',
+          aspect: 'module extraction',
+          finding: `module extraction: ${modified.filename} -> ${added.filename}`,
+          technicalDetail: 'Module extraction — splitting a large file into smaller, focused modules with single responsibilities.',
+          plainLanguage: 'Extracting code into its own module is a sign of a codebase maturing. A file that does too much gets split into focused pieces — each easier to test, read, and change independently.',
+          interestScore: 9,
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+function detectFileRename(diffs: readonly FileDiff[]): Finding | null {
+  const renamed = diffs.find((d) => d.status === 'renamed');
+  if (!renamed) return null;
+  return {
+    moduleId: 'evolutionary',
+    aspect: 'file rename',
+    finding: `file renamed: ${renamed.filename}`,
+    technicalDetail: 'File rename — improving naming to better reflect the module\'s responsibility and make the codebase more navigable.',
+    plainLanguage: 'Renaming a file signals that the team is investing in clarity. Good names reduce the time it takes a new developer to find what they are looking for.',
+    interestScore: 8,
+  };
+}
+
+function detectMigration(diffs: readonly FileDiff[]): Finding | null {
+  const migration = diffs.find((d) => d.status === 'added' && MIGRATION_REGEX.test(d.filename));
+  if (!migration) return null;
+  return {
+    moduleId: 'evolutionary',
+    aspect: 'migration file',
+    finding: `migration added: ${migration.filename}`,
+    technicalDetail: 'Database migration — a versioned schema change that evolves the database structure alongside application code.',
+    plainLanguage: 'Migrations keep the database in sync with the code. Each migration is a reversible step — if something breaks, you roll back one version, not the entire schema.',
+    interestScore: 8,
+  };
+}
+
+function detectDeprecation(diffs: readonly FileDiff[]): Finding | null {
+  for (const diff of diffs) {
+    if (!diff.patch || diff.status === 'removed') continue;
+    const addedLines = diff.patch
+      .split('\n')
+      .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+      .map((l) => l.slice(1));
+
+    if (addedLines.some((l) => /\b@[Dd]eprecated\b|\/\/\s*DEPRECATED|\/\*\*?\s*@deprecated/.test(l))) {
+      return {
+        moduleId: 'evolutionary',
+        aspect: 'deprecation marker',
+        finding: `deprecation marker in ${diff.filename}`,
+        technicalDetail: 'Deprecation — marking code as obsolete with a clear signal to stop using it before it is removed.',
+        plainLanguage: 'Deprecation warnings give consumers time to migrate. Instead of a breaking removal, you mark it deprecated, document the replacement, and remove it in the next major version.',
+        interestScore: 7,
+      };
+    }
+  }
+  return null;
+}
+
+function detectLargeDeletion(diffs: readonly FileDiff[]): Finding | null {
+  const large = diffs.find((d) => d.status === 'modified' && d.deletions >= MIN_LARGE_DELETION);
+  if (!large) return null;
+  return {
+    moduleId: 'evolutionary',
+    aspect: 'large-scale simplification',
+    finding: `${large.deletions} lines removed from ${large.filename}`,
+    technicalDetail: 'Large-scale deletion — significant code removal indicating simplification, dead code cleanup, or responsibility transfer.',
+    plainLanguage: 'Deleting code is underrated. Every line removed is a line that no longer needs tests, reviews, or maintenance. The best refactor often makes the codebase smaller, not bigger.',
+    interestScore: 7,
+  };
+}
+
+export class EvolutionaryModule implements CodeAnalyzer {
+  readonly id = 'evolutionary';
+  readonly name = 'Evolutionary Design';
+  readonly category = 'evolutionary' as const;
+
+  async analyze(ctx: AnalysisContext): Promise<Finding | null> {
+    return detectModuleExtraction(ctx.diffs)
+      ?? detectFileRename(ctx.diffs)
+      ?? detectMigration(ctx.diffs)
+      ?? detectDeprecation(ctx.diffs)
+      ?? detectLargeDeletion(ctx.diffs);
+  }
+}

--- a/src/analysis/modules/index.ts
+++ b/src/analysis/modules/index.ts
@@ -23,6 +23,7 @@ import { ErrorResilienceModule } from './error-resilience.js';
 import { ObservabilityModule }   from './observability.js';
 import { ConcurrencyModule }    from './concurrency.js';
 import { DxModule }              from './dx.js';
+import { DependencyHealthModule } from './dependency-health.js';
 
 export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new ComplexityModule(),
@@ -39,4 +40,5 @@ export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new ObservabilityModule(),
   new ConcurrencyModule(),
   new DxModule(),
+  new DependencyHealthModule(),
 ];

--- a/src/analysis/modules/index.ts
+++ b/src/analysis/modules/index.ts
@@ -17,6 +17,7 @@ import { IntegrationModule }     from './integration.js';
 import { TestingModule }         from './testing.js';
 import { AiAssistedModule }      from './ai-assisted.js';
 import { PerformanceModule }     from './performance.js';
+import { SecurityModule }        from './security.js';
 
 export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new ComplexityModule(),
@@ -27,4 +28,5 @@ export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new TestingModule(),
   new AiAssistedModule(),
   new PerformanceModule(),
+  new SecurityModule(),
 ];

--- a/src/analysis/modules/index.ts
+++ b/src/analysis/modules/index.ts
@@ -22,6 +22,7 @@ import { ApiDesignModule }       from './api-design.js';
 import { ErrorResilienceModule } from './error-resilience.js';
 import { ObservabilityModule }   from './observability.js';
 import { ConcurrencyModule }    from './concurrency.js';
+import { DxModule }              from './dx.js';
 
 export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new ComplexityModule(),
@@ -37,4 +38,5 @@ export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new ErrorResilienceModule(),
   new ObservabilityModule(),
   new ConcurrencyModule(),
+  new DxModule(),
 ];

--- a/src/analysis/modules/index.ts
+++ b/src/analysis/modules/index.ts
@@ -21,6 +21,7 @@ import { SecurityModule }        from './security.js';
 import { ApiDesignModule }       from './api-design.js';
 import { ErrorResilienceModule } from './error-resilience.js';
 import { ObservabilityModule }   from './observability.js';
+import { ConcurrencyModule }    from './concurrency.js';
 
 export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new ComplexityModule(),
@@ -35,4 +36,5 @@ export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new ApiDesignModule(),
   new ErrorResilienceModule(),
   new ObservabilityModule(),
+  new ConcurrencyModule(),
 ];

--- a/src/analysis/modules/index.ts
+++ b/src/analysis/modules/index.ts
@@ -25,6 +25,7 @@ import { ConcurrencyModule }    from './concurrency.js';
 import { DxModule }              from './dx.js';
 import { DependencyHealthModule } from './dependency-health.js';
 import { EvolutionaryModule }    from './evolutionary.js';
+import { JsAdvancedModule }      from './js-advanced.js';
 
 export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new ComplexityModule(),
@@ -43,4 +44,5 @@ export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new DxModule(),
   new DependencyHealthModule(),
   new EvolutionaryModule(),
+  new JsAdvancedModule(),
 ];

--- a/src/analysis/modules/index.ts
+++ b/src/analysis/modules/index.ts
@@ -19,6 +19,7 @@ import { AiAssistedModule }      from './ai-assisted.js';
 import { PerformanceModule }     from './performance.js';
 import { SecurityModule }        from './security.js';
 import { ApiDesignModule }       from './api-design.js';
+import { ErrorResilienceModule } from './error-resilience.js';
 
 export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new ComplexityModule(),
@@ -31,4 +32,5 @@ export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new PerformanceModule(),
   new SecurityModule(),
   new ApiDesignModule(),
+  new ErrorResilienceModule(),
 ];

--- a/src/analysis/modules/index.ts
+++ b/src/analysis/modules/index.ts
@@ -16,6 +16,7 @@ import { TypeSystemModule }      from './type-system.js';
 import { IntegrationModule }     from './integration.js';
 import { TestingModule }         from './testing.js';
 import { AiAssistedModule }      from './ai-assisted.js';
+import { PerformanceModule }     from './performance.js';
 
 export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new ComplexityModule(),
@@ -25,4 +26,5 @@ export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new IntegrationModule(),
   new TestingModule(),
   new AiAssistedModule(),
+  new PerformanceModule(),
 ];

--- a/src/analysis/modules/index.ts
+++ b/src/analysis/modules/index.ts
@@ -18,6 +18,7 @@ import { TestingModule }         from './testing.js';
 import { AiAssistedModule }      from './ai-assisted.js';
 import { PerformanceModule }     from './performance.js';
 import { SecurityModule }        from './security.js';
+import { ApiDesignModule }       from './api-design.js';
 
 export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new ComplexityModule(),
@@ -29,4 +30,5 @@ export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new AiAssistedModule(),
   new PerformanceModule(),
   new SecurityModule(),
+  new ApiDesignModule(),
 ];

--- a/src/analysis/modules/index.ts
+++ b/src/analysis/modules/index.ts
@@ -20,6 +20,7 @@ import { PerformanceModule }     from './performance.js';
 import { SecurityModule }        from './security.js';
 import { ApiDesignModule }       from './api-design.js';
 import { ErrorResilienceModule } from './error-resilience.js';
+import { ObservabilityModule }   from './observability.js';
 
 export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new ComplexityModule(),
@@ -33,4 +34,5 @@ export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new SecurityModule(),
   new ApiDesignModule(),
   new ErrorResilienceModule(),
+  new ObservabilityModule(),
 ];

--- a/src/analysis/modules/index.ts
+++ b/src/analysis/modules/index.ts
@@ -24,6 +24,7 @@ import { ObservabilityModule }   from './observability.js';
 import { ConcurrencyModule }    from './concurrency.js';
 import { DxModule }              from './dx.js';
 import { DependencyHealthModule } from './dependency-health.js';
+import { EvolutionaryModule }    from './evolutionary.js';
 
 export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new ComplexityModule(),
@@ -41,4 +42,5 @@ export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new ConcurrencyModule(),
   new DxModule(),
   new DependencyHealthModule(),
+  new EvolutionaryModule(),
 ];

--- a/src/analysis/modules/integration.ts
+++ b/src/analysis/modules/integration.ts
@@ -8,6 +8,9 @@ interface ServiceSignature {
   score: number;
 }
 
+// AI integrations are covered by AiAssistedModule — skip here to avoid duplicate findings
+const AI_CATEGORY = 'AI / large language model';
+
 const KNOWN_SERVICES: ServiceSignature[] = [
   {
     name: 'Redis',
@@ -98,6 +101,7 @@ export class IntegrationModule implements CodeAnalyzer {
     const addedText = addedLines.join('\n');
 
     for (const service of KNOWN_SERVICES) {
+      if (service.category === AI_CATEGORY) continue;
       if (service.patterns.some(p => p.test(addedText))) {
         return {
           moduleId: this.id,

--- a/src/analysis/modules/js-advanced.ts
+++ b/src/analysis/modules/js-advanced.ts
@@ -1,0 +1,79 @@
+import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+
+interface JsAdvancedPattern {
+  readonly name: string;
+  readonly score: number;
+  readonly technicalDetail: string;
+  readonly explanation: string;
+  detect(addedLines: readonly string[]): boolean;
+}
+
+const PATTERNS: readonly JsAdvancedPattern[] = [
+  {
+    name: 'Proxy / Reflect metaprogramming',
+    score: 9,
+    technicalDetail: 'Proxy/Reflect — intercepts fundamental object operations (get, set, has, delete) to add custom behavior without modifying the target object.',
+    explanation: 'A Proxy wraps an object and intercepts every operation on it. You can validate property assignments, log access, implement lazy loading, or build reactive systems — all transparently to the caller.',
+    detect: (lines) => lines.some((l) =>
+      /\bnew\s+Proxy\s*\(/.test(l) ||
+      /\bReflect\.(get|set|has|deleteProperty|apply|construct|ownKeys)\s*\(/.test(l),
+    ),
+  },
+  {
+    name: 'WeakRef / FinalizationRegistry',
+    score: 9,
+    technicalDetail: 'WeakRef/FinalizationRegistry — weak references that do not prevent garbage collection, with optional cleanup callbacks when objects are collected.',
+    explanation: 'WeakRef holds a reference to an object without preventing it from being garbage collected. FinalizationRegistry runs cleanup code when the object is collected. Together they solve cache invalidation and resource cleanup without memory leaks.',
+    detect: (lines) => lines.some((l) =>
+      /\bnew\s+WeakRef\s*\(/.test(l) ||
+      /\bnew\s+FinalizationRegistry\s*\(/.test(l),
+    ),
+  },
+  {
+    name: 'iterator / generator protocol',
+    score: 8,
+    technicalDetail: 'Iterator protocol — custom iteration with generators (function*), Symbol.iterator, or async iteration (for await...of) for lazy, on-demand data processing.',
+    explanation: 'Generators produce values one at a time instead of building an entire array upfront. A generator that yields database rows processes millions of records with constant memory — each row is fetched only when requested.',
+    detect: (lines) => lines.some((l) =>
+      /\bfunction\s*\*/.test(l) ||
+      /\basync\s+function\s*\*/.test(l) ||
+      /\bSymbol\.iterator\b/.test(l) ||
+      /\bSymbol\.asyncIterator\b/.test(l) ||
+      /\bfor\s+await\s*\(/.test(l),
+    ),
+  },
+];
+
+export class JsAdvancedModule implements CodeAnalyzer {
+  readonly id = 'js_advanced';
+  readonly name = 'Advanced JavaScript';
+  readonly category = 'js_advanced' as const;
+
+  async analyze(ctx: AnalysisContext): Promise<Finding | null> {
+    for (const diff of ctx.diffs) {
+      if (!diff.patch || diff.status === 'removed') continue;
+
+      const addedLines = diff.patch
+        .split('\n')
+        .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+        .map((l) => l.slice(1));
+
+      if (addedLines.length === 0) continue;
+
+      for (const pattern of PATTERNS) {
+        if (pattern.detect(addedLines)) {
+          return {
+            moduleId: this.id,
+            aspect: pattern.name,
+            finding: `${pattern.name} in ${diff.filename}`,
+            technicalDetail: pattern.technicalDetail,
+            plainLanguage: pattern.explanation,
+            interestScore: pattern.score,
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/analysis/modules/observability.ts
+++ b/src/analysis/modules/observability.ts
@@ -52,7 +52,7 @@ const PATTERNS: readonly ObservabilityPattern[] = [
   },
   {
     name: 'correlation ID',
-    score: 7,
+    score: 5,
     technicalDetail: 'Correlation ID — a unique identifier propagated through all services handling a single request for end-to-end traceability.',
     explanation: 'A correlation ID ties every log, error, and metric to one user request. When something breaks, you search one ID and see everything that happened across all services.',
     detect: (lines) => lines.some((l) =>

--- a/src/analysis/modules/observability.ts
+++ b/src/analysis/modules/observability.ts
@@ -36,7 +36,7 @@ const PATTERNS: readonly ObservabilityPattern[] = [
     detect: (lines) => lines.some((l) =>
       /\bnew\s+(Counter|Histogram|Gauge|Summary)\s*\(/.test(l) ||
       /\b(prometheus|prom-client|statsd|datadog-metrics)\b/.test(l) ||
-      /\.(inc|observe|set|timing)\s*\(/.test(l),
+      /\.(observe|timing)\s*\(/.test(l),
     ),
   },
   {

--- a/src/analysis/modules/observability.ts
+++ b/src/analysis/modules/observability.ts
@@ -1,0 +1,96 @@
+import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+
+interface ObservabilityPattern {
+  readonly name: string;
+  readonly score: number;
+  readonly technicalDetail: string;
+  readonly explanation: string;
+  detect(addedLines: readonly string[]): boolean;
+}
+
+const PATTERNS: readonly ObservabilityPattern[] = [
+  {
+    name: 'distributed tracing',
+    score: 9,
+    technicalDetail: 'Distributed tracing — propagating trace context across service boundaries to follow a request end-to-end.',
+    explanation: 'Distributed tracing connects the dots across microservices. When a request touches 5 services, a trace shows exactly where it spent time and where it broke.',
+    detect: (lines) => lines.some((l) =>
+      /\b(tracer\.startSpan|trace\.getTracer|startActiveSpan|@opentelemetry\/|opentracing)\b/.test(l),
+    ),
+  },
+  {
+    name: 'structured logging',
+    score: 8,
+    technicalDetail: 'Structured logging — emitting log entries as key-value pairs instead of plain text for machine-parseable analysis.',
+    explanation: 'Structured logs are searchable. Instead of grepping through "User 123 logged in", you query {event: "login", userId: 123}. Every log becomes a queryable data point.',
+    detect: (lines) => lines.some((l) =>
+      /\b(pino|winston|bunyan|log4js)\s*[.(]/.test(l) ||
+      /\blogger\.(info|warn|error|debug)\s*\(\s*\{/.test(l),
+    ),
+  },
+  {
+    name: 'metrics instrumentation',
+    score: 8,
+    technicalDetail: 'Metrics — numeric measurements (counters, histograms, gauges) that track system behavior over time.',
+    explanation: 'Metrics tell you what is happening right now. A counter tracks how many requests failed, a histogram shows response time distribution. Without metrics, you are flying blind.',
+    detect: (lines) => lines.some((l) =>
+      /\bnew\s+(Counter|Histogram|Gauge|Summary)\s*\(/.test(l) ||
+      /\b(prometheus|prom-client|statsd|datadog-metrics)\b/.test(l) ||
+      /\.(inc|observe|set|timing)\s*\(/.test(l),
+    ),
+  },
+  {
+    name: 'error tracking',
+    score: 7,
+    technicalDetail: 'Error tracking — capturing exceptions with context and stack traces in a dedicated error monitoring service.',
+    explanation: 'Error tracking services group, deduplicate, and alert on exceptions. Instead of searching logs for stack traces, you see every error ranked by frequency and impact.',
+    detect: (lines) => lines.some((l) =>
+      /\bSentry\.(captureException|captureMessage|init|withScope)\s*\(/.test(l) ||
+      /\b(Bugsnag|bugsnag|@bugsnag\/|rollbar|Rollbar)\b/.test(l) ||
+      /\b@sentry\//.test(l),
+    ),
+  },
+  {
+    name: 'correlation ID',
+    score: 7,
+    technicalDetail: 'Correlation ID — a unique identifier propagated through all services handling a single request for end-to-end traceability.',
+    explanation: 'A correlation ID ties every log, error, and metric to one user request. When something breaks, you search one ID and see everything that happened across all services.',
+    detect: (lines) => lines.some((l) =>
+      /\b(correlationId|correlation[_-]id|requestId|request[_-]id|x-request-id|x-correlation-id)\b/i.test(l),
+    ),
+  },
+];
+
+export class ObservabilityModule implements CodeAnalyzer {
+  readonly id = 'observability';
+  readonly name = 'Observability';
+  readonly category = 'observability' as const;
+
+  async analyze(ctx: AnalysisContext): Promise<Finding | null> {
+    for (const diff of ctx.diffs) {
+      if (!diff.patch || diff.status === 'removed') continue;
+
+      const addedLines = diff.patch
+        .split('\n')
+        .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+        .map((l) => l.slice(1));
+
+      if (addedLines.length === 0) continue;
+
+      for (const pattern of PATTERNS) {
+        if (pattern.detect(addedLines)) {
+          return {
+            moduleId: this.id,
+            aspect: pattern.name,
+            finding: `${pattern.name} in ${diff.filename}`,
+            technicalDetail: pattern.technicalDetail,
+            plainLanguage: pattern.explanation,
+            interestScore: pattern.score,
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/analysis/modules/performance.ts
+++ b/src/analysis/modules/performance.ts
@@ -78,6 +78,28 @@ const PATTERNS: readonly PerformancePattern[] = [
       /\b(React\.lazy\(|lazy\(\(\)\s*=>|import\(\s*['"]|dynamic\(\(\)\s*=>)/.test(l),
     ),
   },
+  {
+    name: 'event loop blocking (sync I/O)',
+    score: 8,
+    technicalDetail: 'Synchronous I/O — fs.readFileSync, execSync, and similar *Sync calls block the event loop, stalling all concurrent requests.',
+    explanation: 'Node.js handles thousands of requests on a single thread. A *Sync call freezes that thread until the disk or child process responds — every other request waits in line.',
+    detect: (lines, filePatch) => {
+      const isCli = /(?:cli|script|bin|seed|migrate|setup)\b/i.test(filePatch);
+      if (isCli) return false;
+      return lines.some((l) =>
+        /\b(readFileSync|writeFileSync|appendFileSync|existsSync|mkdirSync|readdirSync|statSync|execSync|execFileSync|spawnSync)\s*\(/.test(l),
+      );
+    },
+  },
+  {
+    name: 'stream processing',
+    score: 7,
+    technicalDetail: 'Node.js streams — processing data chunk-by-chunk instead of loading the entire payload into memory.',
+    explanation: 'Streams process data as it arrives. Instead of reading a 2GB file into memory, a stream handles it in small chunks — constant memory, no matter the file size.',
+    detect: (lines) => lines.some((l) =>
+      /\b(createReadStream|createWriteStream|pipeline\(|new\s+Transform\(|new\s+Readable\(|new\s+Writable\(|\.pipe\s*\()/.test(l),
+    ),
+  },
 ];
 
 export class PerformanceModule implements CodeAnalyzer {

--- a/src/analysis/modules/performance.ts
+++ b/src/analysis/modules/performance.ts
@@ -1,0 +1,115 @@
+import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+
+interface PerformancePattern {
+  readonly name: string;
+  readonly score: number;
+  readonly technicalDetail: string;
+  readonly explanation: string;
+  detect(addedLines: readonly string[], filePatch: string): boolean;
+}
+
+const LOOP_KEYWORDS = /\b(for|while|forEach|\.map\(|\.flatMap\(|for\s+of|for\s+in)\b/;
+const QUERY_KEYWORDS = /\b(\.query\(|\.execute\(|\.findOne\(|\.findMany\(|\.find\(|\.select\(|\.where\(|await\s+prisma\.|await\s+db\.)\b/;
+
+function hasProximityMatch(
+  lines: readonly string[],
+  patternA: RegExp,
+  patternB: RegExp,
+  maxDistance: number,
+): boolean {
+  for (let i = 0; i < lines.length; i++) {
+    if (patternA.test(lines[i]!)) {
+      const start = Math.max(0, i - maxDistance);
+      const end = Math.min(lines.length, i + maxDistance + 1);
+      for (let j = start; j < end; j++) {
+        if (j !== i && patternB.test(lines[j]!)) return true;
+      }
+    }
+  }
+  return false;
+}
+
+const PATTERNS: readonly PerformancePattern[] = [
+  {
+    name: 'query in loop (potential N+1)',
+    score: 9,
+    technicalDetail: 'N+1 query pattern — database call inside a loop. Each iteration triggers a separate query instead of a single batch fetch.',
+    explanation: 'Each loop iteration fires a separate database query. With 100 items, that is 101 queries instead of 1. Batching or joining removes the bottleneck.',
+    detect: (lines) => hasProximityMatch(lines, LOOP_KEYWORDS, QUERY_KEYWORDS, 10),
+  },
+  {
+    name: 'sequential await in loop',
+    score: 8,
+    technicalDetail: 'Sequential async/await inside a loop — each iteration waits for the previous one to finish instead of running in parallel.',
+    explanation: 'Awaiting inside a loop means each step waits for the previous one. If the operations are independent, running them in parallel with Promise.all cuts total time dramatically.',
+    detect: (lines) => hasProximityMatch(lines, LOOP_KEYWORDS, /\bawait\s+/, 8),
+  },
+  {
+    name: 'database index creation',
+    score: 8,
+    technicalDetail: 'Database index — speeds up queries by avoiding full table scans on filtered or joined columns.',
+    explanation: 'Adding an index turns a slow full-table scan into a fast lookup. One line in a migration can turn a 2-second query into a 2-millisecond one.',
+    detect: (lines) => lines.some((l) => /\b(CREATE\s+INDEX|\.createIndex\(|\.ensureIndex\()/i.test(l)),
+  },
+  {
+    name: 'batch operation',
+    score: 8,
+    technicalDetail: 'Batch processing — groups multiple operations into a single call to reduce round-trips and overhead.',
+    explanation: 'Instead of sending requests one by one, batching groups them into a single call. Fewer round-trips means less latency and lower resource usage.',
+    detect: (lines) => lines.some((l) =>
+      /\b(Promise\.all\(|Promise\.allSettled\(|\$in\b|\.insertMany\(|\.bulkWrite\(|\.createMany\(|\.batchWrite\()/.test(l),
+    ),
+  },
+  {
+    name: 'memoization / caching',
+    score: 7,
+    technicalDetail: 'Memoization or caching layer — stores computed results to avoid redundant work on repeated calls.',
+    explanation: 'Caching saves the result of expensive work so it does not repeat. The first call pays the cost; every subsequent call is near-instant.',
+    detect: (lines) => lines.some((l) =>
+      /\b(useMemo\(|useCallback\(|React\.memo\(|\.memoize\(|cache\.get\(|cache\.set\(|new\s+Map\(\)|\.getOrSet\()/.test(l),
+    ),
+  },
+  {
+    name: 'lazy loading / code splitting',
+    score: 7,
+    technicalDetail: 'Lazy loading — defers loading of code or resources until they are actually needed, reducing initial bundle size.',
+    explanation: 'Loading everything upfront slows the first render. Lazy loading defers heavy modules until the user needs them, cutting initial load time.',
+    detect: (lines) => lines.some((l) =>
+      /\b(React\.lazy\(|lazy\(\(\)\s*=>|import\(\s*['"]|dynamic\(\(\)\s*=>)/.test(l),
+    ),
+  },
+];
+
+export class PerformanceModule implements CodeAnalyzer {
+  readonly id = 'performance';
+  readonly name = 'Performance Patterns';
+  readonly category = 'performance' as const;
+
+  async analyze(ctx: AnalysisContext): Promise<Finding | null> {
+    for (const diff of ctx.diffs) {
+      if (!diff.patch || diff.status === 'removed') continue;
+
+      const addedLines = diff.patch
+        .split('\n')
+        .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+        .map((l) => l.slice(1));
+
+      if (addedLines.length === 0) continue;
+
+      for (const pattern of PATTERNS) {
+        if (pattern.detect(addedLines, diff.patch)) {
+          return {
+            moduleId: this.id,
+            aspect: pattern.name,
+            finding: `Detected ${pattern.name} in ${diff.filename}`,
+            technicalDetail: pattern.technicalDetail,
+            plainLanguage: pattern.explanation,
+            interestScore: pattern.score,
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/analysis/modules/security.ts
+++ b/src/analysis/modules/security.ts
@@ -43,7 +43,7 @@ const PATTERNS: readonly SecurityPattern[] = [
     technicalDetail: 'Input validation — schema-based validation at system boundaries to reject malformed data before it reaches business logic.',
     explanation: 'Validating input at the boundary catches bad data early. A Zod schema or validator middleware rejects invalid requests before they touch the database or trigger unexpected behavior.',
     detect: (lines) => lines.some((l) =>
-      /\b(z\.object\(|z\.string\(|z\.number\(|Joi\.|joi\.|\.validate\(|express-validator|sanitize|\.safeParse\(|\.parse\()/.test(l),
+      /\b(z\.object\(|z\.string\(|z\.number\(|Joi\.|joi\.|\.validate\(|express-validator|sanitize|\.safeParse\(|schema\.parse\()/.test(l),
     ),
   },
   {

--- a/src/analysis/modules/security.ts
+++ b/src/analysis/modules/security.ts
@@ -1,0 +1,104 @@
+import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+
+interface SecurityPattern {
+  readonly name: string;
+  readonly score: number;
+  readonly technicalDetail: string;
+  readonly explanation: string;
+  readonly isConcern: boolean;
+  detect(addedLines: readonly string[], filename: string): boolean;
+}
+
+const SECRET_REGEX = /(?:api[_-]?key|secret|token|password|credentials)\s*[:=]\s*['"][A-Za-z0-9+/=_-]{16,}['"]/i;
+const SQL_CONCAT_REGEX = /(?:`SELECT|`INSERT|`UPDATE|`DELETE|`DROP).*\$\{|['"]SELECT.*['"]\s*\+|['"]INSERT.*['"]\s*\+/i;
+const TEST_FILE_REGEX = /\.(test|spec)\.(ts|tsx|js|jsx)$|__tests__\//;
+
+const PATTERNS: readonly SecurityPattern[] = [
+  {
+    name: 'hardcoded secret',
+    score: 9,
+    isConcern: true,
+    technicalDetail: 'Hardcoded secret — API key, token, or password embedded directly in source code instead of environment variables.',
+    explanation: 'Secrets in source code end up in version control, CI logs, and every developer\'s machine. One leaked commit exposes the key forever. Environment variables keep secrets out of the codebase.',
+    detect: (lines, filename) => {
+      if (TEST_FILE_REGEX.test(filename)) return false;
+      return lines.some((l) => SECRET_REGEX.test(l));
+    },
+  },
+  {
+    name: 'SQL injection surface',
+    score: 9,
+    isConcern: true,
+    technicalDetail: 'SQL injection — user input concatenated into a query string instead of using parameterized queries.',
+    explanation: 'String-concatenated SQL lets an attacker inject arbitrary queries. Parameterized queries separate data from code, making injection impossible regardless of input.',
+    detect: (lines, filename) => {
+      if (TEST_FILE_REGEX.test(filename)) return false;
+      return lines.some((l) => SQL_CONCAT_REGEX.test(l));
+    },
+  },
+  {
+    name: 'input validation',
+    score: 8,
+    isConcern: false,
+    technicalDetail: 'Input validation — schema-based validation at system boundaries to reject malformed data before it reaches business logic.',
+    explanation: 'Validating input at the boundary catches bad data early. A Zod schema or validator middleware rejects invalid requests before they touch the database or trigger unexpected behavior.',
+    detect: (lines) => lines.some((l) =>
+      /\b(z\.object\(|z\.string\(|z\.number\(|Joi\.|joi\.|\.validate\(|express-validator|sanitize|\.safeParse\(|\.parse\()/.test(l),
+    ),
+  },
+  {
+    name: 'authentication / authorization',
+    score: 7,
+    isConcern: false,
+    technicalDetail: 'Auth layer — authentication verifies identity, authorization verifies permissions before granting access to protected resources.',
+    explanation: 'Auth middleware ensures every request proves who it is and what it can do. Without it, any endpoint is public by default — one missing check and sensitive data leaks.',
+    detect: (lines) => lines.some((l) =>
+      /\b(verifyToken\(|requireRole\(|requireAuth\(|isAuthenticated|jwt\.verify\(|passport\.|auth[Mm]iddleware|\.useGuard\(|@Authorized|canActivate)/.test(l),
+    ),
+  },
+  {
+    name: 'security headers',
+    score: 7,
+    isConcern: false,
+    technicalDetail: 'Security headers — HTTP headers like CSP, HSTS, and X-Frame-Options that instruct browsers to enforce security policies.',
+    explanation: 'Security headers tell the browser what to trust. Helmet sets them all in one line — CSP blocks injected scripts, HSTS forces HTTPS, X-Frame-Options prevents clickjacking.',
+    detect: (lines) => lines.some((l) =>
+      /\b(helmet\(|cors\(|csp\(|Content-Security-Policy|X-Frame-Options|Strict-Transport-Security|\.enableCors\()/.test(l),
+    ),
+  },
+];
+
+export class SecurityModule implements CodeAnalyzer {
+  readonly id = 'security';
+  readonly name = 'Security Patterns';
+  readonly category = 'security' as const;
+
+  async analyze(ctx: AnalysisContext): Promise<Finding | null> {
+    for (const diff of ctx.diffs) {
+      if (!diff.patch || diff.status === 'removed') continue;
+
+      const addedLines = diff.patch
+        .split('\n')
+        .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+        .map((l) => l.slice(1));
+
+      if (addedLines.length === 0) continue;
+
+      for (const pattern of PATTERNS) {
+        if (pattern.detect(addedLines, diff.filename)) {
+          const prefix = pattern.isConcern ? 'Potential concern' : 'Added';
+          return {
+            moduleId: this.id,
+            aspect: pattern.name,
+            finding: `${prefix}: ${pattern.name} in ${diff.filename}`,
+            technicalDetail: pattern.technicalDetail,
+            plainLanguage: pattern.explanation,
+            interestScore: pattern.score,
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -6,7 +6,8 @@ export type AnalysisCategory =
   | 'integration'
   | 'testing'
   | 'ai_assisted'
-  | 'performance';
+  | 'performance'
+  | 'security';
 
 export interface FileDiff {
   filename: string;

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -13,7 +13,8 @@ export type AnalysisCategory =
   | 'observability'
   | 'concurrency'
   | 'dx'
-  | 'dependency_health';
+  | 'dependency_health'
+  | 'evolutionary';
 
 export interface FileDiff {
   filename: string;

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -14,7 +14,8 @@ export type AnalysisCategory =
   | 'concurrency'
   | 'dx'
   | 'dependency_health'
-  | 'evolutionary';
+  | 'evolutionary'
+  | 'js_advanced';
 
 export interface FileDiff {
   filename: string;

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -7,7 +7,8 @@ export type AnalysisCategory =
   | 'testing'
   | 'ai_assisted'
   | 'performance'
-  | 'security';
+  | 'security'
+  | 'api_design';
 
 export interface FileDiff {
   filename: string;

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -10,7 +10,8 @@ export type AnalysisCategory =
   | 'security'
   | 'api_design'
   | 'error_resilience'
-  | 'observability';
+  | 'observability'
+  | 'concurrency';
 
 export interface FileDiff {
   filename: string;

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -12,7 +12,8 @@ export type AnalysisCategory =
   | 'error_resilience'
   | 'observability'
   | 'concurrency'
-  | 'dx';
+  | 'dx'
+  | 'dependency_health';
 
 export interface FileDiff {
   filename: string;

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -11,7 +11,8 @@ export type AnalysisCategory =
   | 'api_design'
   | 'error_resilience'
   | 'observability'
-  | 'concurrency';
+  | 'concurrency'
+  | 'dx';
 
 export interface FileDiff {
   filename: string;

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -8,7 +8,8 @@ export type AnalysisCategory =
   | 'ai_assisted'
   | 'performance'
   | 'security'
-  | 'api_design';
+  | 'api_design'
+  | 'error_resilience';
 
 export interface FileDiff {
   filename: string;

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -5,7 +5,8 @@ export type AnalysisCategory =
   | 'type_system'
   | 'integration'
   | 'testing'
-  | 'ai_assisted';
+  | 'ai_assisted'
+  | 'performance';
 
 export interface FileDiff {
   filename: string;

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -9,7 +9,8 @@ export type AnalysisCategory =
   | 'performance'
   | 'security'
   | 'api_design'
-  | 'error_resilience';
+  | 'error_resilience'
+  | 'observability';
 
 export interface FileDiff {
   filename: string;


### PR DESCRIPTION
## Summary

- Add 10 new analysis modules to the pipeline, bringing the total from 7 to 17
- Each module detects code patterns via regex heuristics on Git diffs and returns ranked Finding objects
- Fix 5 bugs found during review across both new and existing modules

## New modules

| Module | Key patterns |
|--------|-------------|
| Performance | N+1 query, sequential await, DB index, batch, memo, lazy loading, event loop blocking, streams |
| Security | Hardcoded secrets, SQL injection, input validation, auth, security headers |
| API Design | RESTful routes, error contracts, versioning, rate limiting, pagination |
| Error Resilience | Circuit breaker, retry with backoff, graceful degradation, timeout, health check, graceful shutdown |
| Observability | Distributed tracing, structured logging, metrics, error tracking, correlation ID |
| Concurrency | Mutex/semaphore, Atomics, worker threads, concurrency control, race condition guards |
| DX | Custom error class, config schema validation, CLI setup, env validation, assertions, util.promisify |
| Dependency Health | Security deps, major version bumps, new/removed deps, engine constraints |
| Evolutionary | Module extraction, file rename, migration, deprecation, large deletion |
| JS Advanced | Proxy/Reflect, WeakRef/FinalizationRegistry, iterator/generator protocol |

## Bug fixes

1. Observability metrics false positives: removed `.inc()`/`.set()` matchers (collided with Map/Set)
2. DependencyHealth undefined guard for `noUncheckedIndexedAccess`
3. AI SDK dedup: Integration module skips AI category to avoid overlap with AiAssistedModule
4. CleanCode false positive on deleted files: added `status === 'removed'` guard
5. Security `.parse()` narrowed to `schema.parse()` to avoid JSON.parse matches

## Score calibration

Lowered scores for common patterns (RESTful routes, file renames, correlation ID, new dependency, engine constraint) from 7-8 to 5.

## Test plan

- [ ] `npm run typecheck` passes clean
- [ ] `npm run test-analyze` against real commits
- [ ] Monitor first batch of generated posts for quality