### PR TITLE
feat: add contextHint to all 17 analysis modules

### DIFF
--- a/src/ai/prompt-builder.ts
+++ b/src/ai/prompt-builder.ts
@@ -123,6 +123,9 @@ export function buildUserPrompt(
     parts.push(`  What: ${finding.finding}`);
     parts.push(`  Technical detail: ${finding.technicalDetail}`);
     parts.push(`  Plain language: ${finding.plainLanguage}`);
+    if (finding.contextHint) {
+      parts.push(`  Context: ${finding.contextHint}`);
+    }
     if (finding.evidence?.before || finding.evidence?.after) {
       parts.push(`  Evidence: before="${finding.evidence.before ?? ''}" after="${finding.evidence.after ?? ''}"`);
     }
@@ -142,7 +145,9 @@ Steps:
 1. Feature the highest interest_score finding. Mention others only if they add context.
 2. Include project context — don't assume the reader saw previous posts.
 3. Use specific details from each finding's technical_detail. Real data, real names.
-4. Match the rhythm and style of <voice_history> if present.
+4. Use each finding's Context to name specific files and projects in the narrative.
+   Say "In my scraper project, ReconciliationService.ts" not "in a service file".
+5. Match the rhythm and style of <voice_history> if present.
 ${websiteRef}
 
 Generate for these platforms: ${platforms.join(', ')}
@@ -168,6 +173,7 @@ SELF-CHECK before responding:
 - Is there project context for a first-time reader?
 - Does it match the voice examples and the <voice_identity> rules?
 - Is the closing a direct statement, not a question?
+- Does it name the specific file and project, not generic placeholders?
 </task>`);
 
   return parts.join('\n');

--- a/src/analysis/modules/ai-assisted.ts
+++ b/src/analysis/modules/ai-assisted.ts
@@ -68,6 +68,7 @@ export class AiAssistedModule implements CodeAnalyzer {
         technicalDetail: `${sdkName} integration. AI-assisted development, human-AI collaboration. SDK initialized in the diff.`,
         plainLanguage: `The commit adds ${sdkName} as a capability layer in the application. The interesting design decisions are usually not the SDK setup itself — it\'s the prompt structure, token budget, retry strategy, and where AI fits in the overall flow.`,
         interestScore: 8,
+        contextHint: `${ctx.diffs[0]?.filename ?? 'unknown'} in ${ctx.repo}`,
       };
     }
 
@@ -80,6 +81,7 @@ export class AiAssistedModule implements CodeAnalyzer {
         technicalDetail: 'Prompt engineering, AI workflow design. Prompt files added or modified in the diff.',
         plainLanguage: 'Prompts are code. This commit adds or refines the instructions that shape how the AI behaves — the structure, constraints, examples, and task framing that turn a general model into a specialized tool.',
         interestScore: 7,
+        contextHint: `${aiFiles[0]?.filename ?? 'unknown'} in ${ctx.repo}`,
       };
     }
 
@@ -91,6 +93,7 @@ export class AiAssistedModule implements CodeAnalyzer {
       technicalDetail: 'AI-assisted development, human-AI collaboration. Detected from commit message.',
       plainLanguage: 'The developer used AI assistance for this commit. The real story is usually the human judgment involved: what the AI wrote, what the developer changed, and why.',
       interestScore: 6,
+      contextHint: `${ctx.diffs[0]?.filename ?? 'unknown'} in ${ctx.repo}`,
     };
   }
 }

--- a/src/analysis/modules/api-design.ts
+++ b/src/analysis/modules/api-design.ts
@@ -99,6 +99,7 @@ export class ApiDesignModule implements CodeAnalyzer {
             technicalDetail: pattern.technicalDetail,
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
+            contextHint: `${diff.filename} in ${ctx.repo}`,
           };
         }
       }

--- a/src/analysis/modules/clean-code.ts
+++ b/src/analysis/modules/clean-code.ts
@@ -29,6 +29,7 @@ export class CleanCodeModule implements CodeAnalyzer {
             technicalDetail: `KISS principle, ${usesLookup ? 'lookup table pattern, ' : ''}cognitive complexity reduction. ${totalBefore}→${totalAfter} lines (${percentReduced}% reduction).`,
             plainLanguage: `The commit made the code significantly simpler — ${percentReduced}% fewer lines with the same behavior. ${usesLookup ? 'A nested conditional tree was replaced with a lookup table, which is readable as data rather than traced as logic.' : 'The simplification reduces the cognitive load for anyone reading or modifying this code in the future.'}`,
             interestScore: Math.min(9, 5 + Math.floor(reductionRatio * 8)),
+            contextHint: `${diff.filename} in ${ctx.repo}`,
             evidence: {
               before: `~${totalBefore} lines`,
               after: `~${totalAfter} lines (${percentReduced}% reduction)`,
@@ -49,6 +50,7 @@ export class CleanCodeModule implements CodeAnalyzer {
           technicalDetail: `DRY principle, single responsibility principle, extract method refactoring. ${newFunctions.length} new functions added.`,
           plainLanguage: `The commit broke a larger block of logic into ${newFunctions.length} focused functions, each with one job. Each function can now be read, tested, and changed independently.`,
           interestScore: 6,
+          contextHint: `${diff.filename} in ${ctx.repo}`,
         };
       }
     }

--- a/src/analysis/modules/complexity.ts
+++ b/src/analysis/modules/complexity.ts
@@ -53,6 +53,7 @@ export class ComplexityModule implements CodeAnalyzer {
         technicalDetail: `McCabe cyclomatic complexity, extract method refactoring, single-responsibility principle. Decision delta: -${delta}`,
         plainLanguage: `The commit simplified branching logic significantly. Fewer if/else/switch branches means fewer paths a bug can take, fewer test cases needed, and code that's easier to read and change.`,
         interestScore: score,
+        contextHint: `${primaryFile} in ${ctx.repo}`,
         evidence: {
           before: `~${removedDecisions} decision branches`,
           after: `~${addedDecisions} decision branches (reduced by ${delta})`,
@@ -70,6 +71,7 @@ export class ComplexityModule implements CodeAnalyzer {
         technicalDetail: `McCabe cyclomatic complexity. Decision delta: +${increase}. May warrant future refactoring.`,
         plainLanguage: `The commit added significant branching logic. This may be intentional (handling more cases) but is worth noting as an area to watch.`,
         interestScore: score,
+        contextHint: `${affectedFiles[0] ?? 'the codebase'} in ${ctx.repo}`,
       };
     }
   }

--- a/src/analysis/modules/concurrency.ts
+++ b/src/analysis/modules/concurrency.ts
@@ -91,6 +91,7 @@ export class ConcurrencyModule implements CodeAnalyzer {
             technicalDetail: pattern.technicalDetail,
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
+            contextHint: `${diff.filename} in ${ctx.repo}`,
           };
         }
       }

--- a/src/analysis/modules/dependency-health.ts
+++ b/src/analysis/modules/dependency-health.ts
@@ -117,6 +117,7 @@ export class DependencyHealthModule implements CodeAnalyzer {
             technicalDetail: pattern.technicalDetail,
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
+            contextHint: `${diff.filename} in ${ctx.repo}`,
           };
         }
       }

--- a/src/analysis/modules/design-patterns.ts
+++ b/src/analysis/modules/design-patterns.ts
@@ -90,6 +90,7 @@ export class DesignPatternsModule implements CodeAnalyzer {
     if (addedLines.length === 0) return null;
 
     const addedText = addedLines.join('\n');
+    const primaryFile = ctx.diffs[0]?.filename ?? 'unknown';
 
     for (const pattern of PATTERNS) {
       const matches = pattern.addedPatterns.filter(p => p.test(addedText));
@@ -101,6 +102,7 @@ export class DesignPatternsModule implements CodeAnalyzer {
           technicalDetail: `${pattern.name} pattern, ${pattern.principle}. Detected via structural signatures in the diff.`,
           plainLanguage: pattern.explanation,
           interestScore: pattern.interestScore,
+          contextHint: `${primaryFile} in ${ctx.repo}`,
         };
       }
     }

--- a/src/analysis/modules/dx.ts
+++ b/src/analysis/modules/dx.ts
@@ -100,6 +100,7 @@ export class DxModule implements CodeAnalyzer {
             technicalDetail: pattern.technicalDetail,
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
+            contextHint: `${diff.filename} in ${ctx.repo}`,
           };
         }
       }

--- a/src/analysis/modules/error-resilience.ts
+++ b/src/analysis/modules/error-resilience.ts
@@ -96,6 +96,7 @@ export class ErrorResilienceModule implements CodeAnalyzer {
             technicalDetail: pattern.technicalDetail,
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
+            contextHint: `${diff.filename} in ${ctx.repo}`,
           };
         }
       }

--- a/src/analysis/modules/evolutionary.ts
+++ b/src/analysis/modules/evolutionary.ts
@@ -105,10 +105,16 @@ export class EvolutionaryModule implements CodeAnalyzer {
   readonly category = 'evolutionary' as const;
 
   async analyze(ctx: AnalysisContext): Promise<Finding | null> {
-    return detectModuleExtraction(ctx.diffs)
+    const finding = detectModuleExtraction(ctx.diffs)
       ?? detectFileRename(ctx.diffs)
       ?? detectMigration(ctx.diffs)
       ?? detectDeprecation(ctx.diffs)
       ?? detectLargeDeletion(ctx.diffs);
+
+    if (finding) {
+      finding.contextHint = `${ctx.diffs[0]?.filename ?? 'unknown'} in ${ctx.repo}`;
+    }
+
+    return finding;
   }
 }

--- a/src/analysis/modules/integration.ts
+++ b/src/analysis/modules/integration.ts
@@ -110,6 +110,7 @@ export class IntegrationModule implements CodeAnalyzer {
           technicalDetail: `${service.name}, ${service.category}. New import/client initialization detected in the diff.`,
           plainLanguage: service.explanation,
           interestScore: service.score,
+          contextHint: `${ctx.diffs[0]?.filename ?? 'unknown'} in ${ctx.repo}`,
         };
       }
     }

--- a/src/analysis/modules/js-advanced.ts
+++ b/src/analysis/modules/js-advanced.ts
@@ -69,6 +69,7 @@ export class JsAdvancedModule implements CodeAnalyzer {
             technicalDetail: pattern.technicalDetail,
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
+            contextHint: `${diff.filename} in ${ctx.repo}`,
           };
         }
       }

--- a/src/analysis/modules/observability.ts
+++ b/src/analysis/modules/observability.ts
@@ -86,6 +86,7 @@ export class ObservabilityModule implements CodeAnalyzer {
             technicalDetail: pattern.technicalDetail,
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
+            contextHint: `${diff.filename} in ${ctx.repo}`,
           };
         }
       }

--- a/src/analysis/modules/performance.ts
+++ b/src/analysis/modules/performance.ts
@@ -127,6 +127,7 @@ export class PerformanceModule implements CodeAnalyzer {
             technicalDetail: pattern.technicalDetail,
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
+            contextHint: `${diff.filename} in ${ctx.repo}`,
           };
         }
       }

--- a/src/analysis/modules/security.ts
+++ b/src/analysis/modules/security.ts
@@ -94,6 +94,7 @@ export class SecurityModule implements CodeAnalyzer {
             technicalDetail: pattern.technicalDetail,
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
+            contextHint: `${diff.filename} in ${ctx.repo}`,
           };
         }
       }

--- a/src/analysis/modules/testing.ts
+++ b/src/analysis/modules/testing.ts
@@ -39,6 +39,7 @@ export class TestingModule implements CodeAnalyzer {
         technicalDetail: `Parametrized testing (test.each/pytest.parametrize), data-driven test cases, boundary value analysis. ~${testCount} test cases added.`,
         plainLanguage: 'Parametrized tests express "for all these inputs, I expect these outputs" in one readable block. They make it explicit which specific values were chosen for testing and why — especially useful for numeric boundaries, currency rounding, and state transitions.',
         interestScore: 8,
+        contextHint: `${testDiffs[0]?.filename ?? 'unknown'} in ${ctx.repo}`,
       };
     }
 
@@ -52,6 +53,7 @@ export class TestingModule implements CodeAnalyzer {
         technicalDetail: `Edge case testing, boundary value analysis. Keywords detected: ${uniqueKeywords.join(', ')}. ~${testCount} test cases.`,
         plainLanguage: `The tests specifically target the scenarios that most implementations get wrong: ${uniqueKeywords.join(', ')}. Edge cases don't throw exceptions — they produce plausible-looking wrong answers until someone checks the math.`,
         interestScore: 7,
+        contextHint: `${testDiffs[0]?.filename ?? 'unknown'} in ${ctx.repo}`,
       };
     }
 
@@ -63,6 +65,7 @@ export class TestingModule implements CodeAnalyzer {
         technicalDetail: `Unit testing${hasMocks ? ', mock/stub isolation' : ''}. ${testCount} test cases, ${testDiffs.reduce((s, d) => s + d.additions, 0)} lines added.`,
         plainLanguage: `The commit expanded the test suite with ${testCount} new cases${hasMocks ? ', using mocks to isolate the unit under test from its dependencies' : ''}. More tests mean faster feedback when something breaks.`,
         interestScore: 6,
+        contextHint: `${testDiffs[0]?.filename ?? 'unknown'} in ${ctx.repo}`,
       };
     }
 

--- a/src/analysis/modules/type-system.ts
+++ b/src/analysis/modules/type-system.ts
@@ -62,8 +62,8 @@ export class TypeSystemModule implements CodeAnalyzer {
   async analyze(ctx: AnalysisContext): Promise<Finding | null> {
     if (!ctx.languages.includes('TypeScript')) return null;
 
-    const addedText = ctx.diffs
-      .filter(d => d.language === 'TypeScript')
+    const tsDiffs = ctx.diffs.filter(d => d.language === 'TypeScript');
+    const addedText = tsDiffs
       .flatMap(d =>
         d.patch.split('\n')
           .filter(l => l.startsWith('+') && !l.startsWith('+++'))
@@ -72,6 +72,8 @@ export class TypeSystemModule implements CodeAnalyzer {
       .join('\n');
 
     if (!addedText) return null;
+
+    const primaryFile = tsDiffs[0]?.filename ?? 'unknown';
 
     for (const tp of TYPE_PATTERNS) {
       if (tp.pattern.test(addedText)) {
@@ -82,6 +84,7 @@ export class TypeSystemModule implements CodeAnalyzer {
           technicalDetail: tp.technicalDetail,
           plainLanguage: tp.explanation,
           interestScore: tp.score,
+          contextHint: `${primaryFile} in ${ctx.repo}`,
         };
       }
     }

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -41,6 +41,7 @@ export interface Finding {
   technicalDetail: string; // technical terms, metrics, named concepts
   plainLanguage: string;   // what Claude should explain in the post
   interestScore: number;   // 1–10
+  contextHint?: string;    // e.g. "ReconciliationService.ts in vialabs-net/scrappers"
   evidence?: {
     before?: string;       // code snippet or description of before state
     after?: string;        // code snippet or description of after state


### PR DESCRIPTION
## Summary

- Added `contextHint?: string` to the `Finding` interface in `types.ts`
- All 17 analysis modules now populate `contextHint` with `filename in repo`
- Updated `prompt-builder.ts` to render contextHint in finding blocks and added task instruction for Claude to cite specific files/projects

## Motivation

Claude-generated posts used generic placeholders ("in a service file") instead of naming specific files and projects. contextHint gives Claude a citeable phrase per finding so posts reference real filenames and repos.

## Test plan

- [x] `npm run typecheck` passes
- [ ] Trigger pipeline on a real commit and verify the generated post references specific filenames