### PR TITLE
feat: add react-patterns and devops analysis modules

### DIFF
--- a/src/analysis/modules/api-design.ts
+++ b/src/analysis/modules/api-design.ts
@@ -25,7 +25,7 @@ function hasPaginationCoOccurrence(lines: readonly string[]): boolean {
 const PATTERNS: readonly ApiPattern[] = [
   {
     name: 'RESTful route definition',
-    score: 5,
+    score: 7,
     technicalDetail: 'RESTful routing — HTTP verbs mapped to resource endpoints following REST conventions.',
     explanation: 'REST routes use HTTP verbs (GET, POST, PUT, DELETE) to express intent. A well-named route like GET /users/:id is self-documenting — the verb says the action, the path says the resource.',
     detect: (lines) => lines.some((l) =>

--- a/src/analysis/modules/concurrency.ts
+++ b/src/analysis/modules/concurrency.ts
@@ -48,9 +48,7 @@ const PATTERNS: readonly ConcurrencyPattern[] = [
     technicalDetail: 'Concurrency limiting — bounding the number of parallel operations to prevent resource exhaustion.',
     explanation: 'Running 10,000 requests in parallel crashes the process. A concurrency limiter runs them in controlled batches — fast enough to be useful, bounded enough to stay stable.',
     detect: (lines) => lines.some((l) =>
-      /\b(p-limit|p-queue|p-map|PQueue|pLimit)\b/.test(l) ||
-      /\bPromise\.allSettled\s*\(/.test(l) ||
-      /\bPromise\.all\s*\(\s*\w+\.map\s*\(/.test(l),
+      /\b(p-limit|p-queue|p-map|PQueue|pLimit)\b/.test(l),
     ),
   },
   {

--- a/src/analysis/modules/devops.ts
+++ b/src/analysis/modules/devops.ts
@@ -1,0 +1,136 @@
+import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+
+interface DevopsPattern {
+  readonly name: string;
+  readonly score: number;
+  readonly technicalDetail: string;
+  readonly explanation: string;
+  detect(addedLines: readonly string[], filename: string): boolean;
+}
+
+const DEVOPS_FILE_REGEX = /(?:Dockerfile|\.ya?ml$|\.github\/workflows|Makefile|Jenkinsfile|\.gitlab-ci|Helm|Chart\.yaml|values.*\.yaml)/i;
+
+const PATTERNS: readonly DevopsPattern[] = [
+  {
+    name: 'multi-stage Docker build',
+    score: 9,
+    technicalDetail: 'Multi-stage Dockerfile — separates build and runtime stages to produce minimal production images without build tools or source code.',
+    explanation: 'A multi-stage build compiles in one stage and copies only the binary to the final image. The production container has no compiler, no source code, no dev dependencies — smaller, faster, more secure.',
+    detect: (lines, filename) => {
+      if (!/Dockerfile/i.test(filename)) return false;
+      const fromCount = lines.filter((l) => /^\s*FROM\s+/i.test(l)).length;
+      return fromCount >= 2;
+    },
+  },
+  {
+    name: 'CI workflow',
+    score: 7,
+    technicalDetail: 'CI/CD pipeline — automated build, test, and deploy steps triggered by code changes.',
+    explanation: 'A CI workflow runs tests and builds on every push. Bugs are caught before merge, deploys are automated, and "works on my machine" stops being an excuse.',
+    detect: (lines, filename) => {
+      if (!/(\.github\/workflows|\.gitlab-ci|Jenkinsfile)/i.test(filename)) return false;
+      return lines.some((l) =>
+        /\b(runs-on|steps|jobs|stage|pipeline)\b/.test(l),
+      );
+    },
+  },
+  {
+    name: 'health check',
+    score: 8,
+    technicalDetail: 'Container health check — a periodic probe that tells the orchestrator whether the container is alive and ready to serve traffic.',
+    explanation: 'A HEALTHCHECK in Docker or a livenessProbe in Kubernetes tells the orchestrator when a container is broken. Without it, traffic keeps flowing to a dead process.',
+    detect: (lines, filename) => {
+      if (!/Dockerfile|values.*\.ya?ml|deployment/i.test(filename)) return false;
+      return lines.some((l) =>
+        /\bHEALTHCHECK\b/.test(l) ||
+        /\b(livenessProbe|readinessProbe|startupProbe)\b/.test(l),
+      );
+    },
+  },
+  {
+    name: 'non-root container',
+    score: 8,
+    technicalDetail: 'Non-root container user — running the process as a non-privileged user to limit the blast radius of container escapes.',
+    explanation: 'Running as root inside a container means a vulnerability gives the attacker root access. A non-root USER directive limits the damage — the process can only access what it owns.',
+    detect: (lines, filename) => {
+      if (!/Dockerfile/i.test(filename)) return false;
+      return lines.some((l) =>
+        /^\s*USER\s+(?!root)\w+/.test(l),
+      );
+    },
+  },
+  {
+    name: 'Helm chart',
+    score: 8,
+    technicalDetail: 'Helm chart — templated Kubernetes manifests with configurable values for reproducible, version-controlled deployments.',
+    explanation: 'Helm charts template Kubernetes YAML so one chart serves dev, staging, and production. Values change per environment, but the structure is consistent and versioned.',
+    detect: (lines, filename) => {
+      if (!/Chart\.ya?ml|values.*\.ya?ml|templates\//i.test(filename)) return false;
+      return lines.some((l) =>
+        /\bapiVersion\s*:\s*v\d|^\s*name\s*:\s*\w|^\s*{{/.test(l),
+      );
+    },
+  },
+  {
+    name: 'secret management',
+    score: 8,
+    technicalDetail: 'Infrastructure secret management — using sealed secrets, external secret operators, or vault references instead of plaintext secrets in manifests.',
+    explanation: 'Plaintext secrets in YAML end up in git history forever. Sealed secrets or external secret operators fetch credentials at deploy time — the secret never touches the repo.',
+    detect: (lines, filename) => {
+      if (!/\.ya?ml$/i.test(filename)) return false;
+      return lines.some((l) =>
+        /\b(SealedSecret|ExternalSecret|SecretProviderClass|vault\.hashicorp)\b/.test(l) ||
+        /\bsecretKeyRef\b/.test(l),
+      );
+    },
+  },
+  {
+    name: 'resource limits',
+    score: 7,
+    technicalDetail: 'Kubernetes resource limits — CPU and memory bounds that prevent a single pod from consuming all cluster resources.',
+    explanation: 'Without resource limits, one pod with a memory leak can starve the entire cluster. Limits and requests ensure fair scheduling and prevent one workload from killing others.',
+    detect: (lines, filename) => {
+      if (!/\.ya?ml$/i.test(filename)) return false;
+      return lines.some((l) =>
+        /\b(resources|limits|requests)\s*:/.test(l) &&
+        /\b(cpu|memory)\b/.test(lines.join('\n')),
+      );
+    },
+  },
+];
+
+export class DevopsModule implements CodeAnalyzer {
+  readonly id = 'devops';
+  readonly name = 'DevOps Patterns';
+  readonly category = 'devops' as const;
+
+  async analyze(ctx: AnalysisContext): Promise<Finding | null> {
+    for (const diff of ctx.diffs) {
+      if (!diff.patch || diff.status === 'removed') continue;
+      if (!DEVOPS_FILE_REGEX.test(diff.filename)) continue;
+
+      const addedLines = diff.patch
+        .split('\n')
+        .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+        .map((l) => l.slice(1));
+
+      if (addedLines.length === 0) continue;
+
+      for (const pattern of PATTERNS) {
+        if (pattern.detect(addedLines, diff.filename)) {
+          return {
+            moduleId: this.id,
+            aspect: pattern.name,
+            finding: `${pattern.name} in ${diff.filename}`,
+            technicalDetail: pattern.technicalDetail,
+            plainLanguage: pattern.explanation,
+            interestScore: pattern.score,
+            contextHint: `${diff.filename} in ${ctx.repo}`,
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/analysis/modules/index.ts
+++ b/src/analysis/modules/index.ts
@@ -26,6 +26,8 @@ import { DxModule }              from './dx.js';
 import { DependencyHealthModule } from './dependency-health.js';
 import { EvolutionaryModule }    from './evolutionary.js';
 import { JsAdvancedModule }      from './js-advanced.js';
+import { ReactPatternsModule }  from './react-patterns.js';
+import { DevopsModule }         from './devops.js';
 
 export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new ComplexityModule(),
@@ -45,4 +47,6 @@ export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new DependencyHealthModule(),
   new EvolutionaryModule(),
   new JsAdvancedModule(),
+  new ReactPatternsModule(),
+  new DevopsModule(),
 ];

--- a/src/analysis/modules/react-patterns.ts
+++ b/src/analysis/modules/react-patterns.ts
@@ -1,0 +1,124 @@
+import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+
+interface ReactPattern {
+  readonly name: string;
+  readonly score: number;
+  readonly technicalDetail: string;
+  readonly explanation: string;
+  detect(addedLines: readonly string[]): boolean;
+}
+
+const REACT_FILE_REGEX = /\.(tsx|jsx)$/;
+
+const PATTERNS: readonly ReactPattern[] = [
+  {
+    name: 'custom hook',
+    score: 8,
+    technicalDetail: 'Custom React hook — encapsulates reusable stateful logic in a function prefixed with "use", separating behavior from UI.',
+    explanation: 'A custom hook extracts stateful logic that multiple components share. Instead of duplicating useState + useEffect in every component, one hook encapsulates the pattern and each component calls it.',
+    detect: (lines) => lines.some((l) =>
+      /\bexport\s+(default\s+)?function\s+use[A-Z]\w*\s*\(/.test(l) ||
+      /\bconst\s+use[A-Z]\w*\s*=\s*\(/.test(l),
+    ),
+  },
+  {
+    name: 'React context provider',
+    score: 8,
+    technicalDetail: 'React Context — provides dependency injection for component trees without prop drilling through intermediate components.',
+    explanation: 'Context replaces the "pass props through 5 levels" problem. A provider at the top, a useContext call at the bottom, and every layer in between stays clean.',
+    detect: (lines) => lines.some((l) =>
+      /\bcreateContext\s*[<(]/.test(l) ||
+      /\bContext\.Provider\b/.test(l) ||
+      /\buseContext\s*\(/.test(l),
+    ),
+  },
+  {
+    name: 'React.memo optimization',
+    score: 7,
+    technicalDetail: 'React.memo — prevents unnecessary re-renders by memoizing the component output when props have not changed.',
+    explanation: 'React.memo skips re-rendering a component if its props are the same. For expensive renders or frequently updating parents, this prevents wasted work.',
+    detect: (lines) => lines.some((l) =>
+      /\bReact\.memo\s*\(/.test(l) ||
+      /\bmemo\s*\(\s*function/.test(l) ||
+      /\bmemo\s*\(\s*\(/.test(l),
+    ),
+  },
+  {
+    name: 'Suspense boundary',
+    score: 8,
+    technicalDetail: 'React Suspense — declarative loading states that replace imperative isLoading flags with component-level boundaries.',
+    explanation: 'Suspense replaces the "if loading return spinner" pattern. The boundary catches the loading state declaratively — the component inside just renders as if data is ready.',
+    detect: (lines) => lines.some((l) =>
+      /\b<Suspense\b/.test(l) ||
+      /\bSuspense\s/.test(l),
+    ),
+  },
+  {
+    name: 'useReducer state machine',
+    score: 8,
+    technicalDetail: 'useReducer — manages complex component state with explicit actions and transitions, making state changes predictable and debuggable.',
+    explanation: 'useReducer makes state transitions explicit. Instead of scattered setState calls, every state change goes through a reducer with named actions — easier to debug, test, and reason about.',
+    detect: (lines) => lines.some((l) =>
+      /\buseReducer\s*\(/.test(l),
+    ),
+  },
+  {
+    name: 'error boundary',
+    score: 9,
+    technicalDetail: 'React Error Boundary — catches JavaScript errors in the component tree and renders a fallback UI instead of crashing the entire application.',
+    explanation: 'An error boundary prevents one broken component from taking down the whole page. The error is caught, a fallback UI renders, and the rest of the app keeps working.',
+    detect: (lines) => lines.some((l) =>
+      /\bcomponentDidCatch\s*\(/.test(l) ||
+      /\bstatic\s+getDerivedStateFromError\b/.test(l) ||
+      /\bErrorBoundary\b/.test(l),
+    ),
+  },
+  {
+    name: 'server component',
+    score: 9,
+    technicalDetail: 'React Server Component — renders on the server with zero client-side JavaScript, reducing bundle size and enabling direct data access.',
+    explanation: 'Server components run only on the server. No JavaScript ships to the browser, data fetching happens without API calls, and the client bundle stays small. The "use client" directive marks the boundary.',
+    detect: (lines) => lines.some((l) =>
+      /^['"]use client['"]/.test(l.trim()) ||
+      /^['"]use server['"]/.test(l.trim()),
+    ),
+  },
+];
+
+export class ReactPatternsModule implements CodeAnalyzer {
+  readonly id = 'react_patterns';
+  readonly name = 'React Patterns';
+  readonly category = 'react_patterns' as const;
+
+  async analyze(ctx: AnalysisContext): Promise<Finding | null> {
+    const reactDiffs = ctx.diffs.filter((d) => REACT_FILE_REGEX.test(d.filename));
+    if (reactDiffs.length === 0) return null;
+
+    for (const diff of reactDiffs) {
+      if (!diff.patch || diff.status === 'removed') continue;
+
+      const addedLines = diff.patch
+        .split('\n')
+        .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+        .map((l) => l.slice(1));
+
+      if (addedLines.length === 0) continue;
+
+      for (const pattern of PATTERNS) {
+        if (pattern.detect(addedLines)) {
+          return {
+            moduleId: this.id,
+            aspect: pattern.name,
+            finding: `${pattern.name} in ${diff.filename}`,
+            technicalDetail: pattern.technicalDetail,
+            plainLanguage: pattern.explanation,
+            interestScore: pattern.score,
+            contextHint: `${diff.filename} in ${ctx.repo}`,
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -15,7 +15,9 @@ export type AnalysisCategory =
   | 'dx'
   | 'dependency_health'
   | 'evolutionary'
-  | 'js_advanced';
+  | 'js_advanced'
+  | 'react_patterns'
+  | 'devops';
 
 export interface FileDiff {
   filename: string;


### PR DESCRIPTION
## Summary

- New `react-patterns` module (7 patterns): custom hooks, context provider, React.memo, Suspense, useReducer, error boundaries, server components
- New `devops` module (7 patterns): multi-stage Docker, CI workflows, health checks, non-root containers, Helm charts, secret management, resource limits
- Score adjustment: `api-design` REST routes 5->7 (was too low to reach top 3)
- False positive fix: removed `Promise.all`/`Promise.allSettled` from `concurrency` control detector (too generic, triggered on normal parallel code)

Total modules: 19

## Test plan

- [x] `npm run typecheck` passes
- [ ] Trigger pipeline on a React commit and verify react-patterns detection
- [ ] Trigger pipeline on a Dockerfile change and verify devops detection