### PR TITLE
fix: discard broken drafts, fix voice retriever pool

### DIFF
--- a/src/ai/post-generator.ts
+++ b/src/ai/post-generator.ts
@@ -35,11 +35,14 @@ export async function generatePosts(
 
   if (platforms.length === 0) throw new Error('No platforms enabled in config');
 
-  // Retrieve voice examples for both platforms (use linkedin examples for both — shared voice)
-  const voiceExamples = await storage.getTopVoiceExamples(
-    'linkedin',
-    config.posting.voice_examples_count,
+  // Retrieve voice examples from all enabled platforms and pick top N by edit_ratio
+  const voiceResults = await Promise.all(
+    platforms.map((p) => storage.getTopVoiceExamples(p, config.posting.voice_examples_count)),
   );
+  const voiceExamples = voiceResults
+    .flat()
+    .sort((a, b) => (b.edit_ratio ?? 0) - (a.edit_ratio ?? 0))
+    .slice(0, config.posting.voice_examples_count);
 
   const systemPrompt = buildSystemPrompt(config);
   const userPrompt = buildUserPrompt(commit, findings, voiceExamples, platforms, config);
@@ -87,14 +90,8 @@ function parseResponse(raw: string): { linkedin: string; instagram: string } {
   const instagramMatch = raw.match(/<instagram_draft>([\s\S]*?)<\/instagram_draft>/);
 
   if (!linkedinMatch || !instagramMatch) {
-    // Fallback: split by a separator or use full text for both
-    logger.warn('ai.parse.missing_tags', { preview: raw.slice(0, 200) });
-
-    const half = Math.floor(raw.length / 2);
-    return {
-      linkedin: raw.slice(0, half).trim(),
-      instagram: raw.slice(half).trim() || raw.trim(),
-    };
+    logger.error('ai.parse.missing_tags', { preview: raw.slice(0, 200) });
+    throw new Error('Claude response missing XML tags — draft discarded to avoid broken posts');
   }
 
   return {

--- a/src/analysis/modules/evolutionary.ts
+++ b/src/analysis/modules/evolutionary.ts
@@ -14,7 +14,7 @@ function getDirectory(filename: string): string {
   return slash === -1 ? '' : filename.slice(0, slash);
 }
 
-function detectModuleExtraction(diffs: readonly FileDiff[]): Finding | null {
+function detectModuleExtraction(diffs: readonly FileDiff[], repo: string): Finding | null {
   const addedFiles = diffs.filter((d) => d.status === 'added' && d.additions >= MIN_EXTRACTION_LINES);
   const modifiedWithDeletions = diffs.filter((d) => d.status === 'modified' && d.deletions >= MIN_EXTRACTION_LINES);
 
@@ -30,6 +30,7 @@ function detectModuleExtraction(diffs: readonly FileDiff[]): Finding | null {
           technicalDetail: 'Module extraction — splitting a large file into smaller, focused modules with single responsibilities.',
           plainLanguage: 'Extracting code into its own module is a sign of a codebase maturing. A file that does too much gets split into focused pieces — each easier to test, read, and change independently.',
           interestScore: 9,
+          contextHint: `${added.filename} in ${repo}`,
         };
       }
     }
@@ -38,7 +39,7 @@ function detectModuleExtraction(diffs: readonly FileDiff[]): Finding | null {
   return null;
 }
 
-function detectFileRename(diffs: readonly FileDiff[]): Finding | null {
+function detectFileRename(diffs: readonly FileDiff[], repo: string): Finding | null {
   const renamed = diffs.find((d) => d.status === 'renamed');
   if (!renamed) return null;
   return {
@@ -48,10 +49,11 @@ function detectFileRename(diffs: readonly FileDiff[]): Finding | null {
     technicalDetail: 'File rename — improving naming to better reflect the module\'s responsibility and make the codebase more navigable.',
     plainLanguage: 'Renaming a file signals that the team is investing in clarity. Good names reduce the time it takes a new developer to find what they are looking for.',
     interestScore: 5,
+    contextHint: `${renamed.filename} in ${repo}`,
   };
 }
 
-function detectMigration(diffs: readonly FileDiff[]): Finding | null {
+function detectMigration(diffs: readonly FileDiff[], repo: string): Finding | null {
   const migration = diffs.find((d) => d.status === 'added' && MIGRATION_REGEX.test(d.filename));
   if (!migration) return null;
   return {
@@ -61,10 +63,11 @@ function detectMigration(diffs: readonly FileDiff[]): Finding | null {
     technicalDetail: 'Database migration — a versioned schema change that evolves the database structure alongside application code.',
     plainLanguage: 'Migrations keep the database in sync with the code. Each migration is a reversible step — if something breaks, you roll back one version, not the entire schema.',
     interestScore: 8,
+    contextHint: `${migration.filename} in ${repo}`,
   };
 }
 
-function detectDeprecation(diffs: readonly FileDiff[]): Finding | null {
+function detectDeprecation(diffs: readonly FileDiff[], repo: string): Finding | null {
   for (const diff of diffs) {
     if (!diff.patch || diff.status === 'removed') continue;
     const addedLines = diff.patch
@@ -80,13 +83,14 @@ function detectDeprecation(diffs: readonly FileDiff[]): Finding | null {
         technicalDetail: 'Deprecation — marking code as obsolete with a clear signal to stop using it before it is removed.',
         plainLanguage: 'Deprecation warnings give consumers time to migrate. Instead of a breaking removal, you mark it deprecated, document the replacement, and remove it in the next major version.',
         interestScore: 7,
+        contextHint: `${diff.filename} in ${repo}`,
       };
     }
   }
   return null;
 }
 
-function detectLargeDeletion(diffs: readonly FileDiff[]): Finding | null {
+function detectLargeDeletion(diffs: readonly FileDiff[], repo: string): Finding | null {
   const large = diffs.find((d) => d.status === 'modified' && d.deletions >= MIN_LARGE_DELETION);
   if (!large) return null;
   return {
@@ -96,6 +100,7 @@ function detectLargeDeletion(diffs: readonly FileDiff[]): Finding | null {
     technicalDetail: 'Large-scale deletion — significant code removal indicating simplification, dead code cleanup, or responsibility transfer.',
     plainLanguage: 'Deleting code is underrated. Every line removed is a line that no longer needs tests, reviews, or maintenance. The best refactor often makes the codebase smaller, not bigger.',
     interestScore: 7,
+    contextHint: `${large.filename} in ${repo}`,
   };
 }
 
@@ -105,16 +110,10 @@ export class EvolutionaryModule implements CodeAnalyzer {
   readonly category = 'evolutionary' as const;
 
   async analyze(ctx: AnalysisContext): Promise<Finding | null> {
-    const finding = detectModuleExtraction(ctx.diffs)
-      ?? detectFileRename(ctx.diffs)
-      ?? detectMigration(ctx.diffs)
-      ?? detectDeprecation(ctx.diffs)
-      ?? detectLargeDeletion(ctx.diffs);
-
-    if (finding) {
-      finding.contextHint = `${ctx.diffs[0]?.filename ?? 'unknown'} in ${ctx.repo}`;
-    }
-
-    return finding;
+    return detectModuleExtraction(ctx.diffs, ctx.repo)
+      ?? detectFileRename(ctx.diffs, ctx.repo)
+      ?? detectMigration(ctx.diffs, ctx.repo)
+      ?? detectDeprecation(ctx.diffs, ctx.repo)
+      ?? detectLargeDeletion(ctx.diffs, ctx.repo);
   }
 }


### PR DESCRIPTION
## Summary

- **Parser fallback removed**: if Claude omits XML tags, throw error instead of naive mid-point split. Draft is discarded, commit retryable next cron run.
- **Voice retriever**: retrieves examples from all enabled platforms (was hardcoded to `linkedin`), merges by `edit_ratio DESC`, picks top N. Instagram now benefits from its own published posts.
- **Evolutionary contextHint**: each helper function receives `repo` and sets `contextHint` with the exact filename that triggered the finding (was using `diffs[0]` which could be wrong).

## Risk

- Parser change means commits where Claude doesn't use XML tags will produce no draft instead of a broken one. This is intentional — broken posts are worse than no posts.
- Voice retriever change is additive — if only linkedin has published posts, behavior is unchanged.

## Test plan

- [x] `npm run typecheck` passes
- [ ] Trigger pipeline and verify XML tag parsing works normally
- [ ] Verify voice examples include both platforms when available