### PR TITLE
fix: events-poller off-by-one, regex validation, Anthropic 4xx handling

### DIFF
--- a/src/ai/client.ts
+++ b/src/ai/client.ts
@@ -45,6 +45,10 @@ export class AnthropicClient {
         const e = err as { status?: number; message?: string };
         if (e.status === 400) throw new PromptError(`Bad request: ${e.message}`);
         if (e.status === 401) throw new Error('Anthropic API: Unauthorized. Check ANTHROPIC_API_KEY.');
+        // All other 4xx are non-retriable (403 Forbidden, 404 Not Found, etc.)
+        if (e.status && e.status >= 402 && e.status < 500) {
+          throw new PromptError(`Anthropic API ${e.status}: ${e.message}`);
+        }
         throw err;
       }
     }, ANTHROPIC_RETRY_POLICY, 'anthropic.complete');

--- a/src/github/events-poller.ts
+++ b/src/github/events-poller.ts
@@ -58,12 +58,16 @@ export async function pollNewPushEvents(
   const rawEvents = events as RawEvent[];
   const pushEvents = rawEvents.filter((e) => e.type === 'PushEvent');
 
-  // Find new events since last seen
+  // Find new events since last seen.
+  // Events are in reverse chronological order (newest first).
+  // findIndex returns: -1 (not found), 0 (no new events), N (N new events before marker).
   const lastSeenIdx = state.lastEventId
     ? pushEvents.findIndex((e) => e.id === state.lastEventId)
-    : pushEvents.length; // treat all as new if no state
+    : -1; // no state = treat all as new
 
-  const newPushEvents = lastSeenIdx > 0 ? pushEvents.slice(0, lastSeenIdx) : pushEvents;
+  const newPushEvents = lastSeenIdx === -1
+    ? pushEvents                      // not found or no state: process all
+    : pushEvents.slice(0, lastSeenIdx); // 0 = empty (no new), N = first N are new
 
   logger.info('events.poll.result', {
     username,

--- a/src/utils/commit-filter.ts
+++ b/src/utils/commit-filter.ts
@@ -58,8 +58,12 @@ export function isInteresting(
 
   // Skip commits matching user-configured exclude patterns
   for (const pattern of config.excludePatterns) {
-    if (new RegExp(pattern).test(commit.message)) {
-      return { interesting: false, reason: `matches exclude pattern: ${pattern}` };
+    try {
+      if (new RegExp(pattern).test(commit.message)) {
+        return { interesting: false, reason: `matches exclude pattern: ${pattern}` };
+      }
+    } catch {
+      // Invalid regex in config — skip this pattern, don't crash the pipeline
     }
   }
 


### PR DESCRIPTION
## Summary

- **events-poller off-by-one**: `findIndex` returning `0` means the last-seen event is the newest — no new events. Old logic treated `0` same as `-1` (not found), reprocessing ALL events as duplicates every poll cycle.
- **commit-filter regex crash**: invalid regex in `config.excludePatterns` threw uncaught error, crashing the pipeline. Now wrapped in try-catch — invalid patterns are silently skipped.
- **Anthropic 4xx non-retriable**: only 400/401 were handled explicitly. Other 4xx (403 Forbidden, 404 Not Found, 422, etc.) fell through to the retry loop. Now all 4xx throw immediately.

## Risk analysis

The events-poller fix is the most critical change. Four scenarios verified:
| Scenario | `findIndex` returns | `newPushEvents` | Correct? |
|---|---|---|---|
| No state (first run) | -1 | all events | Yes |
| Last seen not in current page | -1 | all events | Yes |
| Last seen is newest (no new) | 0 | `slice(0,0)` = empty | Yes |
| N new events before marker | N | `slice(0,N)` = first N | Yes |

## Test plan

- [ ] `npm run typecheck` passes
- [ ] Manual test with `npm run poll` — verify no duplicate processing
- [ ] Verify events-poller logs show `newEvents: 0` when nothing changed