### PR TITLE
docs: update skills and CLAUDE.md for 19 modules

### DIFF
--- a/.claude/skills/devcast-code/SKILL.md
+++ b/.claude/skills/devcast-code/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: devcast-code
+description: >
+  Coding workflow skill for the devcast project. Trigger this skill whenever the user
+  asks to implement, fix, refactor, review, or debug any code in the social-engagement
+  repository. Also trigger when the user asks to add a module, change the pipeline,
+  modify Buffer integration, update scheduling logic, or any other code change request.
+  This skill enforces a strict, incremental, adversarial-quality engineering workflow.
+---
+
+# devcast — Engineering Workflow
+
+> Global CLAUDE.md rules apply automatically: commit workflow, code review, response format,
+> incremental implementation, adversarial quality stance. This skill adds devcast-specific
+> constraints only.
+
+---
+
+## Code Standards (Project-Specific)
+
+In addition to global standards:
+
+- **`date-fns-tz`** for all timezone logic — never hardcode UTC offsets
+- **No magic strings** — use `const STATUS = { PENDING: 'pending' } as const`
+- Structured logs (JSON) — use `logger` object, never `console.log`
+
+---
+
+## Code Review Focus (devcast-Specific)
+
+In addition to global review checklist:
+
+### Reliability
+- Retry logic aligned with per-service policy (see devcast context skill)
+- Idempotency: duplicate SHA detection, slot uniqueness
+- Partial failure in `Promise.allSettled` — does caller handle null correctly?
+
+### Observability
+- Structured JSON logs with: commit SHA, repo, platform in every relevant log
+- No sensitive data in log fields (tokens, API keys)
+
+---
+
+## devcast-Specific Constraints
+
+- **Never call Claude more than once per commit** — if you see code that calls the AI per module, flag it
+- **MODULE_REGISTRY is the only file to edit** when adding a module — no other plumbing changes
+- **Buffer queue depth check** must precede every `publisher.ts` call — never skip it
+- **Slot claiming** must use the DB UNIQUE constraint, not in-memory locks
+- **Posting window enforcement** lives in `slot-manager.ts` — do not duplicate it in callers
+- **max_tokens=1600** in `ai/client.ts` is hardcoded and must never be increased
+- **19 modules** in MODULE_REGISTRY — update count in docs when adding/removing
+
+---
+
+## Adding a New Module (Template)
+
+1. Create `src/analysis/modules/your-module.ts`:
+
+```typescript
+import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+
+const FILE_REGEX = /\.(ts|js)$/; // adjust per module scope
+
+export class YourModule implements CodeAnalyzer {
+  readonly id = 'your_module';
+  readonly name = 'Your Module';
+  readonly category = 'your_category' as const;
+
+  async analyze(ctx: AnalysisContext): Promise<Finding | null> {
+    const relevantDiffs = ctx.diffs.filter((d) => FILE_REGEX.test(d.filename));
+    if (relevantDiffs.length === 0) return null;
+
+    for (const diff of relevantDiffs) {
+      if (!diff.patch || diff.status === 'removed') continue;
+      const addedLines = diff.patch
+        .split('\n')
+        .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+        .map((l) => l.slice(1));
+      if (addedLines.length === 0) continue;
+
+      // Detection logic here
+      // if (detected) return { moduleId, aspect, finding, technicalDetail, plainLanguage, interestScore, contextHint };
+    }
+    return null;
+  }
+}
+```
+
+2. Add to `src/analysis/modules/index.ts`: import + one line in MODULE_REGISTRY array
+3. Add category to `AnalysisCategory` union in `src/analysis/types.ts` if new
+4. Test with `npm run test-analyze -- <commit-sha>`
+
+---
+
+## Debugging Guide
+
+| Symptom | Check |
+|---------|-------|
+| No posts generated | `npm run test-analyze -- <sha>` — are modules finding anything? |
+| Duplicate events processed | Check `events-poller.ts` logs for `newEvents` count. Verify `last_event_id` in DB. |
+| Claude returns empty/malformed | Check prompt size. Look for XML tag parsing in `post-generator.ts`. |
+| Buffer 401 | Token expired. Run `npm run setup-buffer` to verify. Regenerate at buffer.com. |
+| Module returns null unexpectedly | Run `npm run test-analyze` — check if file regex matches, if patch has added lines. |
+| Typecheck fails after module add | Verify `AnalysisCategory` union includes new category in `types.ts`. |

--- a/.claude/skills/devcast/SKILL.md
+++ b/.claude/skills/devcast/SKILL.md
@@ -39,7 +39,7 @@ Buffer "sent" API → Match by text similarity → computeEditRatio → Voice Hi
 github/events-poller.ts       GET /users/{username}/events (ETag-cached)
 github/commit-enricher.ts     GET /repos/{o}/{r}/commits/{sha} → FileDiff[]
 utils/commit-filter.ts        isInteresting() — rule-based, zero API cost
-analysis/pipeline.ts          ALL 17 modules run IN PARALLEL (Promise.allSettled)
+analysis/pipeline.ts          ALL 19 modules run IN PARALLEL (Promise.allSettled)
   ├── complexity.ts            Cyclomatic complexity, deep nesting
   ├── design-patterns.ts       Strategy, observer, factory, builder, decorator, singleton
   ├── clean-code.ts            KISS line reduction, DRY function extraction
@@ -56,7 +56,9 @@ analysis/pipeline.ts          ALL 17 modules run IN PARALLEL (Promise.allSettled
   ├── dx.ts                    Custom errors, config validation, CLI, env validation
   ├── dependency-health.ts     Security deps, major bumps, new/removed deps
   ├── evolutionary.ts          Module extraction, renames, migrations, deprecation
-  └── js-advanced.ts           Proxy/Reflect, WeakRef, generators/iterators
+  ├── js-advanced.ts           Proxy/Reflect, WeakRef, generators/iterators
+  ├── react-patterns.ts        Custom hooks, context, memo, Suspense, error boundary, server components
+  └── devops.ts                Multi-stage Docker, CI workflows, health checks, Helm, secrets
   → top 3 findings by interestScore DESC
   → 0 findings → SKIP (no Claude call, no Buffer post)
 ai/prompt-builder.ts          voice examples TOP + commit + findings (with contextHint) + task BOTTOM
@@ -103,7 +105,7 @@ src/
 │   ├── pipeline.ts           parallel execution, ranking, top-N slice
 │   ├── diff-parser.ts        raw Git patch → FileDiff[]
 │   └── modules/
-│       └── index.ts          MODULE_REGISTRY (17 modules) ← only file to edit
+│       └── index.ts          MODULE_REGISTRY (19 modules) ← only file to edit
 ├── ai/
 │   ├── client.ts             Anthropic SDK (sonnet, max_tokens=1600)
 │   ├── prompt-builder.ts     voice TOP + commit + findings + task BOTTOM

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ These two crons are kept separate for independent debuggability.
 │       NOT interesting → skipped (pending_batch write not yet implemented)
 │       IS interesting → analysis pipeline
 │
-├── analysis/pipeline.ts (ALL 17 modules run IN PARALLEL)
+├── analysis/pipeline.ts (ALL 19 modules run IN PARALLEL)
 │   ├── ComplexityModule.analyze(ctx)
 │   ├── DesignPatternsModule.analyze(ctx)
 │   ├── CleanCodeModule.analyze(ctx)
@@ -107,7 +107,9 @@ These two crons are kept separate for independent debuggability.
 │   ├── DxModule.analyze(ctx)                ← custom errors, config validation
 │   ├── DependencyHealthModule.analyze(ctx)  ← major bumps, security deps
 │   ├── EvolutionaryModule.analyze(ctx)      ← extraction, migration, deprecation
-│   └── JsAdvancedModule.analyze(ctx)        ← Proxy, WeakRef, generators
+│   ├── JsAdvancedModule.analyze(ctx)        ← Proxy, WeakRef, generators
+│   ├── ReactPatternsModule.analyze(ctx)     ← hooks, context, memo, Suspense (.tsx/.jsx)
+│   └── DevopsModule.analyze(ctx)            ← Docker, CI, Helm, health checks
 │   → Promise.allSettled (one failure = null, not crash)
 │   → Sort by interestScore DESC → top 3 findings
 │   → If 0 findings → SKIP (no Claude call, no Buffer post)
@@ -386,7 +388,7 @@ devcast/
 │   │   ├── diff-parser.ts           # raw Git patch → FileDiff[]
 │   │   ├── language-detector.ts     # file extensions → language list
 │   │   └── modules/
-│   │       ├── index.ts             # MODULE_REGISTRY (17 modules) ← only file to edit
+│   │       ├── index.ts             # MODULE_REGISTRY (19 modules) ← only file to edit
 │   │       ├── complexity.ts
 │   │       ├── design-patterns.ts
 │   │       ├── clean-code.ts
@@ -403,7 +405,9 @@ devcast/
 │   │       ├── dx.ts                # custom errors, config validation, CLI
 │   │       ├── dependency-health.ts # major bumps, security deps, removals
 │   │       ├── evolutionary.ts      # extraction, renames, migrations, deprecation
-│   │       └── js-advanced.ts       # Proxy/Reflect, WeakRef, generators
+│   │       ├── js-advanced.ts       # Proxy/Reflect, WeakRef, generators
+│   │       ├── react-patterns.ts   # hooks, context, memo, Suspense, server components
+│   │       └── devops.ts            # Docker, CI, Helm, health checks, secrets
 │   ├── github/
 │   │   ├── client.ts                # Octokit + ETag state
 │   │   ├── events-poller.ts         # poll /users/{u}/events
@@ -463,7 +467,7 @@ Build in this sequence — each layer depends on the previous:
 4. `src/scheduling/slot-manager.ts` (date-fns-tz)
 5. `src/utils/` — logger, retry, commit-filter
 6. `src/analysis/types.ts` + `diff-parser.ts` + `language-detector.ts`
-7. `src/analysis/modules/` — all 17 modules + index.ts
+7. `src/analysis/modules/` — all 19 modules + index.ts
 8. `src/analysis/pipeline.ts`
 9. `src/github/client.ts` + `events-poller.ts` + `commit-enricher.ts`
 10. `src/ai/client.ts` + `prompt-builder.ts` + `post-generator.ts`


### PR DESCRIPTION
## Summary

- Update module count from 17 to 19 across all documentation (CLAUDE.md, devcast skill, devcast-code skill)
- Add react-patterns and devops to pipeline diagram and directory structure in CLAUDE.md
- Add module template and debugging guide to devcast-code skill
- Commit the devcast-code skill file that was created but untracked

## Files changed

- `CLAUDE.md` — 17→19 modules, added react-patterns.ts and devops.ts to directory structure
- `.claude/skills/devcast/SKILL.md` — 17→19 in pipeline listing, added 2 new module entries
- `.claude/skills/devcast-code/SKILL.md` — new file with module template + debugging table

## Test plan

- [ ] Documentation only — no runtime impact
- [ ] Verify module count matches `MODULE_REGISTRY` in `src/analysis/modules/index.ts` (19)