### PR TITLE
fix: voice convergence — dedup, scanner, structural prompt

### DIFF
--- a/src/ai/post-generator.ts
+++ b/src/ai/post-generator.ts
@@ -2,7 +2,7 @@ import { logger } from '../utils/logger.js';
 import { buildSystemPrompt, buildUserPrompt } from './prompt-builder.js';
 import type { AnthropicClient, PromptError } from './client.js';
 import type { Finding } from '../analysis/types.js';
-import type { IVoiceStorage, Platform } from '../voice/storage.js';
+import type { IVoiceStorage, VoicePost, Platform } from '../voice/storage.js';
 import type { EnrichedCommit } from '../github/commit-enricher.js';
 import type { Config } from '../config/schema.js';
 
@@ -39,10 +39,10 @@ export async function generatePosts(
   const voiceResults = await Promise.all(
     platforms.map((p) => storage.getTopVoiceExamples(p, config.posting.voice_examples_count)),
   );
-  const voiceExamples = voiceResults
-    .flat()
-    .sort((a, b) => (b.edit_ratio ?? 0) - (a.edit_ratio ?? 0))
-    .slice(0, config.posting.voice_examples_count);
+  const voiceExamples = deduplicateVoiceExamples(
+    voiceResults.flat(),
+    config.posting.voice_examples_count,
+  );
 
   const systemPrompt = buildSystemPrompt(config);
   const userPrompt = buildUserPrompt(commit, findings, voiceExamples, platforms, config);
@@ -98,6 +98,29 @@ function parseResponse(raw: string): { linkedin: string; instagram: string } {
     linkedin: (linkedinMatch[1] ?? '').trim(),
     instagram: (instagramMatch[1] ?? '').trim(),
   };
+}
+
+/**
+ * Deduplicates voice examples by published text (first 100 chars).
+ * Keeps the entry with the highest edit_ratio per unique text.
+ */
+function deduplicateVoiceExamples(
+  posts: VoicePost[],
+  limit: number,
+): VoicePost[] {
+  const sorted = posts.sort((a, b) => (b.edit_ratio ?? 0) - (a.edit_ratio ?? 0));
+  const seen = new Set<string>();
+  const unique: VoicePost[] = [];
+
+  for (const post of sorted) {
+    const key = (post.published ?? post.ai_draft).slice(0, 100);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(post);
+    if (unique.length >= limit) break;
+  }
+
+  return unique;
 }
 
 export type { PromptError };

--- a/src/ai/prompt-builder.ts
+++ b/src/ai/prompt-builder.ts
@@ -16,69 +16,91 @@ export function buildSystemPrompt(config: Config): string {
   const { name, website } = config.author;
   const websiteLine = website ? `Site: ${website} — "The Art of Improving Without Starting Over"\n` : '';
 
-  return `You are a code translator and social media ghostwriter.
-You receive structured analysis of code changes from specialized modules.
-Your job is to WRITE — take the technical findings and wrap them in ${name}'s voice.
-You don't analyze code. That work is already done by the modules.
+  return `You are a ghostwriter. You write social media posts in ${name}'s voice.
+You receive findings from code analysis modules. Your job is to WRITE, not analyze.
 
 <author>
-${name} — Software Architect. 10+ years experience.
-${websiteLine}Background: Financial systems, Kubernetes, AI/ML, cloud architecture.
+${name} — Software Architect. 10+ years.
+${websiteLine}Financial systems, Kubernetes, AI/ML, cloud architecture.
 </author>
 
-<voice_identity>
-Serious engineering explained by someone charismatic, funny, and deliberate.
+<voice_devices>
+These are the specific writing devices that define ${name}'s voice.
+Use them. Vary which ones you use per post, but every post must use at least 3.
 
-Real technical authority. Playful self-hype. Theatrical, punchy sentences.
-Dry, self-parodic humor. Concrete engineering explanations.
-Strong thesis at the end.
+STACCATO QUALIFIERS: Chain 2-3 single-word sentences after a statement.
+  "Clean. Disciplined. Strong."
+  "Beautiful. Humiliating. Exactly what you want, frankly."
+  "Cascading. Silent. Very bad. The worst kind."
 
-Sounds like an engineer who actually builds things, explains concrete decisions,
-and narrates bugs, refactors, and architecture choices with intentional dramatization,
-short sentences, exaggerated confidence, and memorable closings.
+VERY CRESCENDO: "Very X. Very Y." as self-aware commentary. 2-3 per post max.
+  "Very fast. Very convenient. Also: a complete disaster in about three weeks."
+  "Very exciting. Very useful."
+  "Very glamorous? No. Very effective? Absolutely."
 
-Always grounded in something real.
-Theatrical but controlled. Not formal. Deliberately performatic.
-Self-promotion with humor, not pure arrogance. Strong tone, but likeable.
-Teaches without sounding like a professor.
-Punchy thesis at the end.
-</voice_identity>
+SELF-AWARE Q&A: Ask and answer in two beats.
+  "Very glamorous? No. Very effective? Absolutely."
+  "The best part? The wrong path is no longer unlikely. It's impossible to compile."
 
-<rhythm>
-Short sentences. Short paragraphs. Line breaks as emphasis.
-Repetition as a device: "Very real. Very bad. Very unnecessary."
-Contrast as a tool: before/after, messy/clean, runtime/compile-time.
-One-liners that land: "Two words changed in the SQL query."
-Direct closings: "Use it." / "Rocks, you." — never a question.
-</rhythm>
+CONTRADICTORY PAIRS: Two adjectives that clash on purpose.
+  "Very disciplined. Very slow."
+  "Beautiful. Humiliating."
+
+ONE-WORD PUNCTURE: A single word as its own sentence to break rhythm.
+  "Wrong."
+  "Gone."
+  "Incredible."
+
+PARENTHETICAL REPETITION: Repeat a word for emphasis inside an aside.
+  "which changes constantly, by the way, constantly"
+
+FRANKLY DROP: "frankly" as a confidence marker mid-sentence.
+  "Exactly what you want, frankly."
+
+DIRECT CLOSING: End with a short declarative. Never a question.
+  "Use it."
+  "Rocks, you."
+  "Probably first."
+  "That's where the good stuff is."
+  "Architecture first. Then AI."
+</voice_devices>
+
+<structure>
+HOOK: One concrete fact. No preamble. No "Today I..." or "I'm excited to..."
+  "9,699 lines added. One line removed."
+  "A type guard stopped a cascading client deactivation bug."
+  "I shipped a module that finds performance bugs in code. Very exciting. Very useful."
+
+CONTEXT: 2-3 short sentences. Project name, what was happening. No long explanations.
+
+THE WORK: What changed and why. Use specific details from the findings.
+  Name files, name patterns, name numbers. Never vague.
+
+LESSON: One transferable principle. Named concept when applicable.
+  "Make the bad path impossible."
+  "The refactor window is real."
+
+CLOSING: Direct statement. See DIRECT CLOSING device above.
+</structure>
 
 <never>
+- Format headers like "**LINKEDIN**" or "## LinkedIn" in the output
+- Self-check reasoning or meta-commentary about the task
+- "Here's the context:" or "Let me explain:" setup paragraphs
+- "I'm building Devcast" in every post — only when the commit is about Devcast
 - Generic LinkedIn motivation ("excited to share", "humbled", "on a journey")
 - Engagement-bait questions ("thoughts?", "what do you think?")
 - Corporate buzzwords ("leverage", "synergy")
-- Cold academic explanations
-- Cruel sarcasm or attacking other developers
-- Chaotic meme humor
 - Emojis
+- Code blocks (they don't render on LinkedIn)
 </never>
 
-<preferred_ingredients>
-Every post should aim for these four elements:
-1. One concrete bug, refactor, or design decision
-2. One small technical detail that proves credibility (function name, line count, metric)
-3. One funny or dramatic line that earns its place
-4. One general lesson that transfers beyond this specific case
-</preferred_ingredients>
-
 <format>
-LinkedIn: 1200-1800 characters.
-  First line must work standalone — earns the "see more" click.
-  Short paragraphs, aggressive line breaks. Mobile-first.
-  Arrow bullets (→) for technical lists embedded in narrative.
+LinkedIn: 1200-1800 characters. Each sentence is its own paragraph.
+  Short paragraphs with aggressive line breaks ARE the format — do NOT compress.
   3-5 hashtags at the end. Always include #lilicurl.
-  No CTA questions. Direct closing or sign-off.
 
-Instagram: 150-300 words. Same substance, more storytelling.
+Instagram: 150-300 words. Same voice, more storytelling.
   Suggest a visual concept (code screenshot, before/after, diagram).
   15-20 hashtags.
 </format>`;
@@ -156,7 +178,7 @@ Wrap each draft in XML tags exactly as shown:
 
 <linkedin_draft>
 1200-1800 characters. First line earns the "see more" click.
-Short paragraphs, aggressive line breaks. Arrow bullets (→) for lists.
+Each sentence is its own paragraph. Aggressive line breaks.
 3-5 hashtags at the end. Always #lilicurl.
 Direct closing — never a question CTA.
 </linkedin_draft>
@@ -171,7 +193,7 @@ SELF-CHECK before responding:
 - Does the post use specific data from the findings? (not generic)
 - Would a developer learn something concrete?
 - Is there project context for a first-time reader?
-- Does it match the voice examples and the <voice_identity> rules?
+- Does it use at least 3 devices from <voice_devices>?
 - Is the closing a direct statement, not a question?
 - Does it name the specific file and project, not generic placeholders?
 </task>`);

--- a/src/buffer/sent-scanner.ts
+++ b/src/buffer/sent-scanner.ts
@@ -4,7 +4,7 @@ import type { BufferClient } from './client.js';
 import type { IVoiceStorage, Platform } from '../voice/storage.js';
 import type { Config } from '../config/schema.js';
 
-const MATCH_THRESHOLD = 0.3;  // min similarity to count as a match
+const MATCH_THRESHOLD = 0.4;  // min similarity to count as a match
 
 /**
  * Polls Buffer's "sent" feed and updates voice history for newly published posts.
@@ -54,19 +54,25 @@ async function scanPlatform(
 
   let matched = 0;
 
+  // Copy to mutable list so matched drafts can be removed
+  const remaining = [...unmatched];
+
   for (const sentPost of sentPosts) {
     let bestScore = 0;
-    let bestDraft: (typeof unmatched)[number] | null = null;
+    let bestIdx = -1;
 
-    for (const draft of unmatched) {
+    for (let i = 0; i < remaining.length; i++) {
+      const draft = remaining[i];
+      if (!draft) continue;
       const score = computeEditRatio(draft.ai_draft, sentPost.text);
       if (score > bestScore) {
         bestScore = score;
-        bestDraft = draft;
+        bestIdx = i;
       }
     }
 
-    if (bestDraft && bestScore >= MATCH_THRESHOLD) {
+    if (bestIdx >= 0 && bestScore >= MATCH_THRESHOLD) {
+      const bestDraft = remaining[bestIdx]!;
       const publishedAt = sentPost.createdAt;
       await storage.updatePublished({
         id: bestDraft.id,
@@ -79,6 +85,8 @@ async function scanPlatform(
         editRatio: bestScore.toFixed(2),
         platform,
       });
+      // Remove matched draft so it can't be claimed by another sent post
+      remaining.splice(bestIdx, 1);
       matched++;
     }
   }


### PR DESCRIPTION
## Summary

Voice output was not converging to Liliana's actual voice. Root cause analysis revealed three compounding issues:

- **Sent-scanner duplication**: one published Buffer post matched against 12+ AI drafts (threshold 0.3 too low, matched drafts not removed from candidate pool). Caused 17 false rows in voice_posts — cleaned via SQL, code fix prevents recurrence.
- **Voice example pollution**: `getTopVoiceExamples` could return duplicate texts, wasting 2-3 of 5 context slots on identical examples.
- **Prompt described voice with adjectives instead of structure**: "theatrical, punchy" is ambiguous. The rewritten prompt shows 8 named devices extracted from comparing ai_draft vs published text across 23 real posts (e.g., STACCATO QUALIFIERS, VERY CRESCENDO, CONTRADICTORY PAIRS). Also bans `**LINKEDIN**` headers and self-check reasoning that appeared in real drafts.

## Changes

| File | What |
|------|------|
| `src/buffer/sent-scanner.ts` | Splice matched draft from pool after each match; raise threshold 0.3 → 0.4 |
| `src/ai/post-generator.ts` | Deduplicate voice examples by published text before sending to Claude |
| `src/ai/prompt-builder.ts` | Replace adjective-based voice description with 8 structural devices; ban format headers and meta-commentary; remove arrow bullets instruction (not used in real published posts) |

## Data cleanup (already applied)

17 falsely-matched rows in `voice_posts` reset to `status='scheduled'` via SQL UPDATE. DB now has 6 correct published rows + 4 bootstrap.

## Test plan

- [ ] `npm run typecheck` passes (verified)
- [ ] Trigger `poll-and-generate` workflow manually on a commit with findings
- [ ] Verify AI draft uses structural voice devices (staccato qualifiers, Very crescendo, direct closing)
- [ ] Verify no `**LINKEDIN**` headers or self-check reasoning in output
- [ ] Run `scan-sent-posts` after publishing a Buffer post — verify only 1 draft matched per sent post
- [ ] Check `voice_posts` table — no new duplicates after scanner run