### PR TITLE
feat: smart topic-aware voice retrieval and reduce complexity noise

### DIFF
--- a/src/ai/post-generator.ts
+++ b/src/ai/post-generator.ts
@@ -1,5 +1,6 @@
 import { logger } from '../utils/logger.js';
 import { buildSystemPrompt, buildUserPrompt } from './prompt-builder.js';
+import { computeEditRatio } from '../voice/similarity.js';
 import type { AnthropicClient, PromptError } from './client.js';
 import type { Finding } from '../analysis/types.js';
 import type { IVoiceStorage, VoicePost, Platform } from '../voice/storage.js';
@@ -35,12 +36,14 @@ export async function generatePosts(
 
   if (platforms.length === 0) throw new Error('No platforms enabled in config');
 
-  // Retrieve voice examples from all enabled platforms and pick top N by edit_ratio
+  // Fetch a larger pool so topic selection has enough candidates
+  const poolSize = config.posting.voice_examples_count * 3;
   const voiceResults = await Promise.all(
-    platforms.map((p) => storage.getTopVoiceExamples(p, config.posting.voice_examples_count)),
+    platforms.map((p) => storage.getTopVoiceExamples(p, poolSize)),
   );
-  const voiceExamples = deduplicateVoiceExamples(
+  const voiceExamples = selectVoiceExamples(
     voiceResults.flat(),
+    findings,
     config.posting.voice_examples_count,
   );
 
@@ -101,26 +104,56 @@ function parseResponse(raw: string): { linkedin: string; instagram: string } {
 }
 
 /**
- * Deduplicates voice examples by published text (first 100 chars).
- * Keeps the entry with the highest edit_ratio per unique text.
+ * Selects voice examples using a two-pass strategy:
+ *
+ * Pass 1 — Anchors (style fidelity): pick the top 2 posts by edit_ratio.
+ *   These ground Claude in the user's best-preserved voice patterns.
+ *
+ * Pass 2 — Topic match (relevance): from the remaining pool, rank by
+ *   text similarity between post.top_finding and the current findings
+ *   headlines. Fill remaining slots with the most topically similar posts.
+ *
+ * Final deduplication by published text prevents repeated examples.
  */
-function deduplicateVoiceExamples(
+function selectVoiceExamples(
   posts: VoicePost[],
+  findings: Finding[],
   limit: number,
 ): VoicePost[] {
-  const sorted = posts.sort((a, b) => (b.edit_ratio ?? 0) - (a.edit_ratio ?? 0));
+  // Deduplicate pool by published text first
   const seen = new Set<string>();
-  const unique: VoicePost[] = [];
-
-  for (const post of sorted) {
+  const pool: VoicePost[] = [];
+  for (const post of posts.sort((a, b) => (b.edit_ratio ?? 0) - (a.edit_ratio ?? 0))) {
     const key = (post.published ?? post.ai_draft).slice(0, 100);
     if (seen.has(key)) continue;
     seen.add(key);
-    unique.push(post);
-    if (unique.length >= limit) break;
+    pool.push(post);
   }
 
-  return unique;
+  if (pool.length === 0) return [];
+
+  // Pass 1: anchors — top 2 by edit_ratio
+  const anchorCount = Math.min(2, Math.floor(limit / 2), pool.length);
+  const anchors = pool.slice(0, anchorCount);
+  const anchorIds = new Set(anchors.map((p) => p.id));
+
+  // Pass 2: topic match from the remaining candidates
+  const topicSlots = limit - anchors.length;
+  if (topicSlots <= 0) return anchors;
+
+  const topicQuery = findings.map((f) => f.finding).join(' ');
+  const candidates = pool.filter((p) => !anchorIds.has(p.id));
+
+  const ranked = candidates
+    .map((p) => ({
+      post: p,
+      score: computeEditRatio(p.top_finding ?? '', topicQuery),
+    }))
+    .sort((a, b) => b.score - a.score);
+
+  const topicMatches = ranked.slice(0, topicSlots).map((r) => r.post);
+
+  return [...anchors, ...topicMatches];
 }
 
 export type { PromptError };

--- a/src/analysis/modules/complexity.ts
+++ b/src/analysis/modules/complexity.ts
@@ -60,10 +60,10 @@ export class ComplexityModule implements CodeAnalyzer {
         },
       };
     } else {
-      // Complexity increase — less interesting, only flag if large
+      // Complexity increase — low signal, only flag if very large
       const increase = Math.abs(delta);
-      if (increase < 6) return null;
-      const score = Math.min(6, 2 + Math.floor(increase / 4));
+      if (increase < 10) return null;
+      const score = Math.min(4, 1 + Math.floor(increase / 8));
       return {
         moduleId: this.id,
         aspect: 'cyclomatic complexity increase',


### PR DESCRIPTION
## What

**A+C — Smart voice retrieval** (`src/ai/post-generator.ts`)
- Two-pass `selectVoiceExamples` replaces flat edit_ratio sort
- Pass 1: top 2 posts by edit_ratio as **style anchors**
- Pass 2: remaining 3 slots filled by text similarity between `post.top_finding` and current findings headlines
- Pool fetched at 3x limit for enough ranking candidates
- Zero new dependencies — reuses `computeEditRatio`

**B — Complexity noise** (`src/analysis/modules/complexity.ts`)
- Threshold raised from 6 → 10 decision points
- Max score capped from 6 → 4
- "Added ~N decision points" now only surfaces on genuinely heavy branching

**D — Bootstrap POST 002 removal**
Manual SQL to run in Supabase (meta-post wastes a voice example slot):
```sql
DELETE FROM voice_posts WHERE status = 'published' AND published LIKE 'These are the seed examples.%';
```

## Why
- Voice examples were always the same 5 highest edit_ratio posts regardless of topic — posts about security got design-pattern examples
- Complexity-increase was the most frequent finding (7 times), drowning out more interesting modules
- POST 002 is a meta-post about the training system, not real content voice