### PR TITLE
feat: smart voice convergence + Buffer externalLink capture

### DIFF
--- a/src/ai/post-generator.ts
+++ b/src/ai/post-generator.ts
@@ -3,15 +3,13 @@ import { buildSystemPrompt, buildUserPrompt } from './prompt-builder.js';
 import { computeEditRatio } from '../voice/similarity.js';
 import type { AnthropicClient, PromptError } from './client.js';
 import type { Finding } from '../analysis/types.js';
-import type { IVoiceStorage, VoicePost, Platform } from '../voice/storage.js';
+import type { IVoiceStorage, VoicePost } from '../voice/storage.js';
 import type { EnrichedCommit } from '../github/commit-enricher.js';
 import type { Config } from '../config/schema.js';
 
 export interface GeneratedPosts {
-  linkedin: string;
-  instagram: string;
-  linkedinDraftId: string;
-  instagramDraftId: string;
+  bufferText: string;
+  draftId: string;
 }
 
 /**
@@ -30,76 +28,53 @@ export async function generatePosts(
     throw new Error('generatePosts called with 0 findings — caller should skip this call');
   }
 
-  const platforms: Platform[] = [];
-  if (config.platforms.linkedin.enabled) platforms.push('linkedin');
-  if (config.platforms.instagram.enabled) platforms.push('instagram');
-
-  if (platforms.length === 0) throw new Error('No platforms enabled in config');
-
-  // Fetch a larger pool so topic selection has enough candidates
+  // Fetch voice examples (linkedin as primary training platform)
   const poolSize = config.posting.voice_examples_count * 3;
-  const voiceResults = await Promise.all(
-    platforms.map((p) => storage.getTopVoiceExamples(p, poolSize)),
-  );
-  const voiceExamples = selectVoiceExamples(
-    voiceResults.flat(),
-    findings,
-    config.posting.voice_examples_count,
-  );
+  const voicePool = await storage.getTopVoiceExamples('linkedin', poolSize);
+  const voiceExamples = selectVoiceExamples(voicePool, findings, config.posting.voice_examples_count);
 
   const systemPrompt = buildSystemPrompt(config);
-  const userPrompt = buildUserPrompt(commit, findings, voiceExamples, platforms, config);
+  const userPrompt = buildUserPrompt(commit, findings, voiceExamples, config);
 
   logger.info('ai.generate.start', { sha: commit.sha, repo: commit.repo, findings: findings.length });
 
   const rawResponse = await client.complete(systemPrompt, userPrompt);
 
-  const { linkedin, instagram } = parseResponse(rawResponse);
+  const { post, shortPost } = parseResponse(rawResponse);
 
   const topFinding = findings[0]?.finding;
   const findingsCount = findings.length;
 
-  // Store drafts immediately
-  const [linkedinDraftId, instagramDraftId] = await Promise.all([
-    config.platforms.linkedin.enabled
-      ? storage.saveDraft({
-          commit_sha: commit.sha,
-          repo: commit.repo,
-          platform: 'linkedin',
-          ai_draft: linkedin,
-          top_finding: topFinding,
-          findings_count: findingsCount,
-        })
-      : Promise.resolve(''),
-    config.platforms.instagram.enabled
-      ? storage.saveDraft({
-          commit_sha: commit.sha,
-          repo: commit.repo,
-          platform: 'instagram',
-          ai_draft: instagram,
-          top_finding: topFinding,
-          findings_count: findingsCount,
-        })
-      : Promise.resolve(''),
-  ]);
+  // One record per commit — ai_draft stores the full post for voice training
+  const draftId = await storage.saveDraft({
+    commit_sha: commit.sha,
+    repo: commit.repo,
+    platform: 'linkedin',
+    ai_draft: post,
+    top_finding: topFinding,
+    findings_count: findingsCount,
+  });
 
-  logger.info('ai.generate.done', { sha: commit.sha, linkedinDraftId, instagramDraftId });
+  // Buffer Idea text includes both variants so Liliana can copy per platform in the UI
+  const bufferText = `${post}\n\n─────────────────\n🐦 Twitter:\n${shortPost}`;
 
-  return { linkedin, instagram, linkedinDraftId, instagramDraftId };
+  logger.info('ai.generate.done', { sha: commit.sha, draftId });
+
+  return { bufferText, draftId };
 }
 
-function parseResponse(raw: string): { linkedin: string; instagram: string } {
-  const linkedinMatch = raw.match(/<linkedin_draft>([\s\S]*?)<\/linkedin_draft>/);
-  const instagramMatch = raw.match(/<instagram_draft>([\s\S]*?)<\/instagram_draft>/);
+function parseResponse(raw: string): { post: string; shortPost: string } {
+  const postMatch = raw.match(/<post_draft>([\s\S]*?)<\/post_draft>/);
+  const shortMatch = raw.match(/<short_draft>([\s\S]*?)<\/short_draft>/);
 
-  if (!linkedinMatch || !instagramMatch) {
+  if (!postMatch || !shortMatch) {
     logger.error('ai.parse.missing_tags', { preview: raw.slice(0, 200) });
     throw new Error('Claude response missing XML tags — draft discarded to avoid broken posts');
   }
 
   return {
-    linkedin: (linkedinMatch[1] ?? '').trim(),
-    instagram: (instagramMatch[1] ?? '').trim(),
+    post: (postMatch[1] ?? '').trim(),
+    shortPost: (shortMatch[1] ?? '').trim(),
   };
 }
 

--- a/src/ai/prompt-builder.ts
+++ b/src/ai/prompt-builder.ts
@@ -1,5 +1,5 @@
 import type { Finding } from '../analysis/types.js';
-import type { VoicePost, Platform } from '../voice/storage.js';
+import type { VoicePost } from '../voice/storage.js';
 import type { EnrichedCommit } from '../github/commit-enricher.js';
 import type { Config } from '../config/schema.js';
 
@@ -96,13 +96,13 @@ CLOSING: Direct statement. See DIRECT CLOSING device above.
 </never>
 
 <format>
-LinkedIn: 1200-1800 characters. Each sentence is its own paragraph.
+Post: 1200-1800 characters. Each sentence is its own paragraph.
   Short paragraphs with aggressive line breaks ARE the format — do NOT compress.
   3-5 hashtags at the end. Always include #lilicurl.
 
-Instagram: 150-300 words. Same voice, more storytelling.
-  Suggest a visual concept (code screenshot, before/after, diagram).
-  15-20 hashtags.
+Short version (Twitter): 3-5 staccato lines max. No hashtags. No preamble.
+  The single hook that makes someone stop. Nothing else.
+  Example: "A type guard stopped a cascading bug.\nNot a try/catch. A type guard.\nMake the bad path impossible."
 </format>`;
 }
 
@@ -110,7 +110,6 @@ export function buildUserPrompt(
   commit: EnrichedCommit,
   findings: Finding[],
   voiceExamples: VoicePost[],
-  platforms: Platform[],
   config: Config,
 ): string {
   const parts: string[] = [];
@@ -172,22 +171,19 @@ Steps:
 5. Match the rhythm and style of <voice_history> if present.
 ${websiteRef}
 
-Generate for these platforms: ${platforms.join(', ')}
-
 Wrap each draft in XML tags exactly as shown:
 
-<linkedin_draft>
+<post_draft>
 1200-1800 characters. First line earns the "see more" click.
 Each sentence is its own paragraph. Aggressive line breaks.
 3-5 hashtags at the end. Always #lilicurl.
 Direct closing — never a question CTA.
-</linkedin_draft>
+</post_draft>
 
-<instagram_draft>
-150-300 words. Same substance, more storytelling.
-Suggest a visual (code screenshot / before-after / diagram).
-15-20 hashtags.
-</instagram_draft>
+<short_draft>
+3-5 staccato lines. No hashtags. No preamble. Pure signal.
+The one hook that makes someone stop. Nothing else.
+</short_draft>
 
 SELF-CHECK before responding:
 - Does the post use specific data from the findings? (not generic)

--- a/src/analysis/modules/performance.ts
+++ b/src/analysis/modules/performance.ts
@@ -5,6 +5,7 @@ interface PerformancePattern {
   readonly score: number;
   readonly technicalDetail: string;
   readonly explanation: string;
+  readonly skipOnNewFile?: boolean;
   detect(addedLines: readonly string[], filePatch: string): boolean;
 }
 
@@ -42,7 +43,8 @@ const PATTERNS: readonly PerformancePattern[] = [
     score: 8,
     technicalDetail: 'Sequential async/await inside a loop — each iteration waits for the previous one to finish instead of running in parallel.',
     explanation: 'Awaiting inside a loop means each step waits for the previous one. If the operations are independent, running them in parallel with Promise.all cuts total time dramatically.',
-    detect: (lines) => hasProximityMatch(lines, LOOP_KEYWORDS, /\bawait\s+/, 8),
+    detect: (lines) => hasProximityMatch(lines, LOOP_KEYWORDS, /\bawait\s+/, 4),
+    skipOnNewFile: true,
   },
   {
     name: 'database index creation',
@@ -56,6 +58,7 @@ const PATTERNS: readonly PerformancePattern[] = [
     score: 8,
     technicalDetail: 'Batch processing — groups multiple operations into a single call to reduce round-trips and overhead.',
     explanation: 'Instead of sending requests one by one, batching groups them into a single call. Fewer round-trips means less latency and lower resource usage.',
+    skipOnNewFile: true,
     detect: (lines) => lines.some((l) =>
       /\b(Promise\.all\(|Promise\.allSettled\(|\$in\b|\.insertMany\(|\.bulkWrite\(|\.createMany\(|\.batchWrite\()/.test(l),
     ),
@@ -119,6 +122,7 @@ export class PerformanceModule implements CodeAnalyzer {
       if (addedLines.length === 0) continue;
 
       for (const pattern of PATTERNS) {
+        if (pattern.skipOnNewFile && diff.status === 'added') continue;
         if (pattern.detect(addedLines, diff.patch)) {
           return {
             moduleId: this.id,

--- a/src/analysis/pipeline.ts
+++ b/src/analysis/pipeline.ts
@@ -52,7 +52,10 @@ export async function runPipeline(
     }
   }
 
-  const sorted = findings.sort((a, b) => b.interestScore - a.interestScore);
+  const MIN_INTEREST_SCORE = 5;
+  const sorted = findings
+    .filter((f) => f.interestScore >= MIN_INTEREST_SCORE)
+    .sort((a, b) => b.interestScore - a.interestScore);
   const top = sorted.slice(0, topN);
 
   logger.info('analysis.pipeline.done', {

--- a/src/buffer/client.ts
+++ b/src/buffer/client.ts
@@ -13,6 +13,7 @@ export interface BufferPost {
   id: string;
   text: string;
   createdAt: string;  // ISO 8601 timestamp from GraphQL
+  externalLink: string | null;  // published post URL at destination (e.g. LinkedIn) — null if unsupported
 }
 
 export class BufferClient {
@@ -97,7 +98,7 @@ export class BufferClient {
       `query GetSentPosts($input: PostsInput!, $first: Int) {
         posts(input: $input, first: $first) {
           edges {
-            node { id text createdAt }
+            node { id text createdAt externalLink }
           }
         }
       }`,

--- a/src/buffer/publisher.ts
+++ b/src/buffer/publisher.ts
@@ -1,18 +1,17 @@
 import { logger } from '../utils/logger.js';
 import type { BufferClient } from './client.js';
-import type { IVoiceStorage, Platform } from '../voice/storage.js';
+import type { IVoiceStorage } from '../voice/storage.js';
 import type { Config } from '../config/schema.js';
 
 export interface PublishResult {
-  platform: Platform;
   draftId: string;
   bufferIdeaId: string;
 }
 
 /**
- * Creates a Buffer Idea for the draft post.
- * Liliana reviews in Buffer's Ideas UI, converts to a scheduled post when ready.
- * No queue management or slot claiming needed — Ideas have no publish queue limit.
+ * Creates a single Buffer Idea per commit.
+ * Text includes the full post + short (Twitter) variant separated by a divider.
+ * Liliana reviews in Buffer's Ideas UI, sets per-platform text there, then publishes.
  */
 export async function publishToBuffer(
   bufferClient: BufferClient,
@@ -20,15 +19,10 @@ export async function publishToBuffer(
   config: Config,
   draftId: string,
   text: string,
-  platform: Platform,
   commitMessage?: string,
 ): Promise<PublishResult | null> {
   const orgId = config.buffer.organization_id;
-  const platformLabel = platform === 'linkedin' ? 'LinkedIn' : 'Instagram';
-  const titleSuffix = commitMessage
-    ? commitMessage.slice(0, 60)
-    : draftId.slice(0, 8);
-  const title = `[${platformLabel}] ${titleSuffix}`;
+  const title = commitMessage ? commitMessage.slice(0, 80) : draftId.slice(0, 8);
 
   const { id: bufferIdeaId } = await bufferClient.createIdea(orgId, title, text);
 
@@ -39,7 +33,7 @@ export async function publishToBuffer(
     status: 'scheduled',
   });
 
-  logger.info('buffer.idea.created', { platform, bufferIdeaId, title });
+  logger.info('buffer.idea.created', { bufferIdeaId, title });
 
-  return { platform, draftId, bufferIdeaId };
+  return { draftId, bufferIdeaId };
 }

--- a/src/buffer/sent-scanner.ts
+++ b/src/buffer/sent-scanner.ts
@@ -84,6 +84,7 @@ async function scanPlatform(
         draftId: bestDraft.id,
         editRatio: bestScore.toFixed(2),
         platform,
+        externalLink: sentPost.externalLink,  // verification: null = Buffer doesn't expose LinkedIn URL
       });
       // Remove matched draft so it can't be claimed by another sent post
       remaining.splice(bestIdx, 1);

--- a/src/main-poll.ts
+++ b/src/main-poll.ts
@@ -110,27 +110,17 @@ async function main(): Promise<void> {
         continue;
       }
 
-      // Generate posts (ONE Claude call)
-      const { linkedin, instagram, linkedinDraftId, instagramDraftId } = await generatePosts(
+      // Generate post (ONE Claude call — returns full post + Twitter short variant)
+      const { bufferText, draftId } = await generatePosts(
         anthropic, commit, findings, storage, config,
       );
 
-      // Publish to Buffer
-      const publishResults = [];
-
-      if (config.platforms.linkedin.enabled && linkedinDraftId) {
-        const result = await publishToBuffer(bufferClient, storage, config, linkedinDraftId, linkedin, 'linkedin', commit.message);
-        if (result) publishResults.push(result);
-      }
-
-      if (config.platforms.instagram.enabled && instagramDraftId) {
-        const result = await publishToBuffer(bufferClient, storage, config, instagramDraftId, instagram, 'instagram', commit.message);
-        if (result) publishResults.push(result);
-      }
+      // Publish ONE Buffer Idea with both variants in the text
+      const publishResult = await publishToBuffer(bufferClient, storage, config, draftId, bufferText, commit.message);
 
       // Notification issue (non-fatal)
-      if (publishResults.length > 0) {
-        await notifyNewDraft(github, owner, repo, commit, publishResults);
+      if (publishResult) {
+        await notifyNewDraft(github, owner, repo, commit, [publishResult]);
       }
     }
   }

--- a/src/review/notifier.ts
+++ b/src/review/notifier.ts
@@ -19,11 +19,10 @@ export async function notifyNewDraft(
 ): Promise<void> {
   if (results.length === 0) return;
 
-  const [repoOwner, repoName] = commit.repo.split('/');
   const commitUrl = `https://github.com/${commit.repo}/commit/${commit.sha}`;
 
-  const platformLines = results.map(r =>
-    `- **${r.platform}**: Buffer Idea ID \`${r.bufferIdeaId}\``,
+  const ideaLines = results.map(r =>
+    `- Buffer Idea ID \`${r.bufferIdeaId}\``,
   );
 
   const body = `## New draft in Buffer Ideas
@@ -31,8 +30,8 @@ export async function notifyNewDraft(
 Commit: [\`${commit.sha.slice(0, 7)}\`](${commitUrl}) in \`${commit.repo}\`
 Message: _${commit.message}_
 
-### Ideas created
-${platformLines.join('\n')}
+### Idea created
+${ideaLines.join('\n')}
 
 ---
 Review in [Buffer Ideas](https://publish.buffer.com/ideas), convert to a post, and schedule.


### PR DESCRIPTION
## Summary

- Consolidate post generation to a single Buffer Idea per commit (LinkedIn post + Twitter short variant in one text block)
- Replace naive `edit_ratio DESC` voice selection with a two-pass strategy: top 2 anchors by fidelity + topically similar examples from remaining pool
- Remove per-platform generation (Instagram draft eliminated — Liliana adapts from the LinkedIn post in Buffer UI)
- Capture `externalLink` from Buffer GraphQL on sent posts — confirmed returns LinkedIn URN URL (prerequisite for engagement loop)

## Verified

`npm run scan` confirmed `externalLink` returns `https://www.linkedin.com/feed/update/urn:li:share:...` — unblocks Phase 9 (engagement feedback loop).

## Test plan

- [ ] Run `npm run poll` locally and verify a single Buffer Idea is created per commit
- [ ] Run `npm run scan` and verify `sent_scanner.matched` logs include `externalLink`
- [ ] Run `npm run typecheck` — must pass clean