### PR TITLE
feat: engagement loop foundation — schema, storage, URN capture

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -16,7 +16,10 @@ CREATE TABLE IF NOT EXISTS voice_posts (
   scheduled_at    TIMESTAMPTZ,             -- UTC time Buffer will publish
   status          TEXT NOT NULL DEFAULT 'pending', -- 'pending'|'scheduled'|'published'|'queued'
   top_finding     TEXT,                    -- headline of the top module finding
-  findings_count  INTEGER NOT NULL DEFAULT 0
+  findings_count  INTEGER NOT NULL DEFAULT 0,
+  linkedin_urn    TEXT,                    -- urn:li:share:... captured from Buffer externalLink
+  reactions_count INTEGER NOT NULL DEFAULT 0, -- LinkedIn reactions fetched from socialActions API
+  engagement_score REAL                   -- composite: edit_ratio*0.6 + normalized_reactions*0.4
 );
 
 -- Uninteresting commits saved for optional weekly roundup
@@ -46,8 +49,9 @@ CREATE TABLE IF NOT EXISTS scheduled_slots (
 );
 
 -- Fast retrieval of voice examples for prompt assembly
+-- engagement_score takes precedence when available; falls back to edit_ratio
 CREATE INDEX IF NOT EXISTS idx_voice_retrieval
-  ON voice_posts(platform, edit_ratio DESC)
+  ON voice_posts(platform, engagement_score DESC NULLS LAST, edit_ratio DESC NULLS LAST)
   WHERE status = 'published';
 
 -- Prevent processing the same commit twice
@@ -65,3 +69,16 @@ ALTER TABLE voice_posts      ENABLE ROW LEVEL SECURITY;
 ALTER TABLE pending_batch    ENABLE ROW LEVEL SECURITY;
 ALTER TABLE events_state     ENABLE ROW LEVEL SECURITY;
 ALTER TABLE scheduled_slots  ENABLE ROW LEVEL SECURITY;
+
+-- ─────────────────────────────────────────────────────────
+-- MIGRATION — run this block on existing Supabase installations
+-- Safe to run multiple times (IF NOT EXISTS / IF EXISTS guards)
+-- ─────────────────────────────────────────────────────────
+ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS linkedin_urn     TEXT;
+ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS reactions_count  INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS engagement_score REAL;
+
+DROP INDEX IF EXISTS idx_voice_retrieval;
+CREATE INDEX IF NOT EXISTS idx_voice_retrieval
+  ON voice_posts(platform, engagement_score DESC NULLS LAST, edit_ratio DESC NULLS LAST)
+  WHERE status = 'published';

--- a/src/buffer/sent-scanner.ts
+++ b/src/buffer/sent-scanner.ts
@@ -6,6 +6,12 @@ import type { Config } from '../config/schema.js';
 
 const MATCH_THRESHOLD = 0.4;  // min similarity to count as a match
 
+function extractLinkedInUrn(externalLink: string | null): string | undefined {
+  if (!externalLink) return undefined;
+  const match = externalLink.match(/urn:li:share:\d+/);
+  return match?.[0];
+}
+
 /**
  * Polls Buffer's "sent" feed and updates voice history for newly published posts.
  *
@@ -74,17 +80,19 @@ async function scanPlatform(
     if (bestIdx >= 0 && bestScore >= MATCH_THRESHOLD) {
       const bestDraft = remaining[bestIdx]!;
       const publishedAt = sentPost.createdAt;
+      const linkedinUrn = extractLinkedInUrn(sentPost.externalLink);
       await storage.updatePublished({
         id: bestDraft.id,
         published: sentPost.text,
         edit_ratio: bestScore,
         published_at: publishedAt,
+        linkedin_urn: linkedinUrn,
       });
       logger.info('sent_scanner.matched', {
         draftId: bestDraft.id,
         editRatio: bestScore.toFixed(2),
         platform,
-        externalLink: sentPost.externalLink,  // verification: null = Buffer doesn't expose LinkedIn URL
+        linkedinUrn: linkedinUrn ?? null,
       });
       // Remove matched draft so it can't be claimed by another sent post
       remaining.splice(bestIdx, 1);

--- a/src/voice/sqlite-storage.ts
+++ b/src/voice/sqlite-storage.ts
@@ -91,9 +91,11 @@ export class SqliteStorage implements IVoiceStorage {
   updatePublished(input: UpdatePublishedInput): Promise<void> {
     this.db.prepare(`
       UPDATE voice_posts
-      SET published = ?, edit_ratio = ?, published_at = ?, status = 'published'
+      SET published = ?, edit_ratio = ?, published_at = ?, status = 'published',
+          linkedin_urn = COALESCE(?, linkedin_urn)
       WHERE id = ?
-    `).run(input.published, input.edit_ratio, input.published_at, input.id);
+    `).run(input.published, input.edit_ratio, input.published_at,
+           input.linkedin_urn ?? null, input.id);
     return Promise.resolve();
   }
 

--- a/src/voice/sqlite-storage.ts
+++ b/src/voice/sqlite-storage.ts
@@ -8,6 +8,7 @@ import type {
   SaveDraftInput,
   UpdatePublishedInput,
   UpdateScheduledInput,
+  UpdateEngagementInput,
   Platform,
   PostStatus,
   SlottedPost,
@@ -39,8 +40,15 @@ export class SqliteStorage implements IVoiceStorage {
         scheduled_at    TEXT,
         status          TEXT NOT NULL DEFAULT 'pending',
         top_finding     TEXT,
-        findings_count  INTEGER NOT NULL DEFAULT 0
+        findings_count  INTEGER NOT NULL DEFAULT 0,
+        linkedin_urn    TEXT,
+        reactions_count INTEGER NOT NULL DEFAULT 0,
+        engagement_score REAL
       );
+
+      ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS linkedin_urn     TEXT;
+      ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS reactions_count  INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS engagement_score REAL;
 
       CREATE UNIQUE INDEX IF NOT EXISTS idx_sha_platform
         ON voice_posts(commit_sha, platform);
@@ -107,9 +115,27 @@ export class SqliteStorage implements IVoiceStorage {
     const rows = this.db.prepare(`
       SELECT * FROM voice_posts
       WHERE platform = ? AND status = 'published' AND edit_ratio IS NOT NULL
-      ORDER BY edit_ratio DESC
+      ORDER BY engagement_score DESC NULLS LAST, edit_ratio DESC NULLS LAST
       LIMIT ?
     `).all(platform, limit) as VoicePost[];
+    return Promise.resolve(rows);
+  }
+
+  updateEngagement(input: UpdateEngagementInput): Promise<void> {
+    this.db.prepare(`
+      UPDATE voice_posts
+      SET linkedin_urn = ?, reactions_count = ?, engagement_score = ?
+      WHERE id = ?
+    `).run(input.linkedin_urn, input.reactions_count, input.engagement_score, input.id);
+    return Promise.resolve();
+  }
+
+  getPostsPendingEngagement(platform: Platform): Promise<VoicePost[]> {
+    const rows = this.db.prepare(`
+      SELECT * FROM voice_posts
+      WHERE platform = ? AND status = 'published'
+        AND linkedin_urn IS NOT NULL AND engagement_score IS NULL
+    `).all(platform) as VoicePost[];
     return Promise.resolve(rows);
   }
 

--- a/src/voice/storage.ts
+++ b/src/voice/storage.ts
@@ -16,6 +16,9 @@ export interface VoicePost {
   status: PostStatus;
   top_finding: string | null;
   findings_count: number;
+  linkedin_urn: string | null;
+  reactions_count: number;
+  engagement_score: number | null;
 }
 
 export interface SaveDraftInput {
@@ -41,6 +44,13 @@ export interface UpdateScheduledInput {
   status: PostStatus;
 }
 
+export interface UpdateEngagementInput {
+  id: string;
+  linkedin_urn: string;
+  reactions_count: number;
+  engagement_score: number;
+}
+
 export interface SlottedPost {
   platform: Platform;
   scheduled_at: Date;
@@ -60,8 +70,14 @@ export interface IVoiceStorage {
   /** Mark a post as 'queued' (Buffer queue is full). */
   markQueued(id: string): Promise<void>;
 
-  /** Retrieve top published posts for voice examples, ordered by edit_ratio DESC. */
+  /** Retrieve top published posts for voice examples, ordered by engagement_score DESC NULLS LAST, edit_ratio DESC. */
   getTopVoiceExamples(platform: Platform, limit: number): Promise<VoicePost[]>;
+
+  /** Update engagement data after fetching from LinkedIn socialActions API. */
+  updateEngagement(input: UpdateEngagementInput): Promise<void>;
+
+  /** Get published posts that have a linkedin_urn but no engagement_score yet. */
+  getPostsPendingEngagement(platform: Platform): Promise<VoicePost[]>;
 
   /** Check if a commit SHA + platform already has a processed post. */
   hasDraft(commit_sha: string, platform: Platform): Promise<boolean>;

--- a/src/voice/storage.ts
+++ b/src/voice/storage.ts
@@ -35,6 +35,7 @@ export interface UpdatePublishedInput {
   published: string;
   edit_ratio: number;
   published_at: string;
+  linkedin_urn?: string;  // extracted from Buffer externalLink when available
 }
 
 export interface UpdateScheduledInput {

--- a/src/voice/supabase-storage.ts
+++ b/src/voice/supabase-storage.ts
@@ -5,6 +5,7 @@ import type {
   SaveDraftInput,
   UpdatePublishedInput,
   UpdateScheduledInput,
+  UpdateEngagementInput,
   Platform,
   PostStatus,
   SlottedPost,
@@ -79,10 +80,37 @@ export class SupabaseStorage implements IVoiceStorage {
       .eq('platform', platform)
       .eq('status', 'published')
       .not('edit_ratio', 'is', null)
-      .order('edit_ratio', { ascending: false })
+      .order('engagement_score', { ascending: false, nullsFirst: false })
+      .order('edit_ratio', { ascending: false, nullsFirst: false })
       .limit(limit);
 
     if (error) throw new Error(`getTopVoiceExamples failed: ${error.message}`);
+    return (data ?? []) as VoicePost[];
+  }
+
+  async updateEngagement(input: UpdateEngagementInput): Promise<void> {
+    const { error } = await this.db
+      .from('voice_posts')
+      .update({
+        linkedin_urn: input.linkedin_urn,
+        reactions_count: input.reactions_count,
+        engagement_score: input.engagement_score,
+      })
+      .eq('id', input.id);
+
+    if (error) throw new Error(`updateEngagement failed: ${error.message}`);
+  }
+
+  async getPostsPendingEngagement(platform: Platform): Promise<VoicePost[]> {
+    const { data, error } = await this.db
+      .from('voice_posts')
+      .select('*')
+      .eq('platform', platform)
+      .eq('status', 'published')
+      .not('linkedin_urn', 'is', null)
+      .is('engagement_score', null);
+
+    if (error) throw new Error(`getPostsPendingEngagement failed: ${error.message}`);
     return (data ?? []) as VoicePost[];
   }
 

--- a/src/voice/supabase-storage.ts
+++ b/src/voice/supabase-storage.ts
@@ -45,6 +45,7 @@ export class SupabaseStorage implements IVoiceStorage {
         edit_ratio: input.edit_ratio,
         published_at: input.published_at,
         status: 'published' satisfies PostStatus,
+        ...(input.linkedin_urn !== undefined && { linkedin_urn: input.linkedin_urn }),
       })
       .eq('id', input.id);
 


### PR DESCRIPTION
## Summary

Foundation for Phase 9 (engagement feedback loop). Three incremental changes:

- **Schema**: add `linkedin_urn`, `reactions_count`, `engagement_score` to `voice_posts`. Update `idx_voice_retrieval` to order by `engagement_score DESC NULLS LAST, edit_ratio DESC`. Includes migration block for existing Supabase installations.
- **Storage**: add `UpdateEngagementInput`, `updateEngagement()`, and `getPostsPendingEngagement()` to `IVoiceStorage` and both implementations. `getTopVoiceExamples` now orders by engagement score when available.
- **URN capture**: `sent-scanner` extracts `urn:li:share:...` from Buffer `externalLink` on every matched post and persists it via `updatePublished`. Verified live — Buffer returns the full LinkedIn URL.

## What's next (Increment 4 — separate PR)

`scripts/collect-engagement.ts` + `collect-engagement.yml` workflow that calls LinkedIn `GET /v2/socialActions/{urn}` and computes `engagement_score`.

## Test plan

- [ ] Run migration block in Supabase SQL Editor
- [ ] Run `npm run scan` — verify `sent_scanner.matched` logs show `linkedinUrn` field
- [ ] Run `npm run typecheck` — must pass clean