### PR TITLE
feat: engagement loop — manual input, LinkedIn OAuth setup, prompt update

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "setup-buffer": "tsx --env-file=.env.local scripts/setup-buffer.ts",
+    "setup-linkedin": "tsx --env-file=.env.local scripts/setup-linkedin.ts",
+    "update-engagement": "tsx --env-file=.env.local scripts/update-engagement.ts",
     "bootstrap": "tsx --env-file=.env.local scripts/bootstrap-voice.ts",
     "test-analyze": "tsx --env-file=.env.local scripts/test-analyze.ts",
     "poll": "tsx --env-file=.env.local src/main-poll.ts",

--- a/scripts/setup-linkedin.ts
+++ b/scripts/setup-linkedin.ts
@@ -1,0 +1,113 @@
+/**
+ * setup-linkedin.ts
+ *
+ * One-time OAuth flow to obtain a LinkedIn access token.
+ * Starts a local HTTP server on port 8000 to receive the callback.
+ *
+ * Usage:
+ *   LINKEDIN_CLIENT_ID=... LINKEDIN_CLIENT_SECRET=... tsx --env-file=.env.local scripts/setup-linkedin.ts
+ */
+
+import { createServer } from 'http';
+import { createInterface } from 'readline';
+
+const CLIENT_ID = process.env['LINKEDIN_CLIENT_ID'] ?? '';
+const CLIENT_SECRET = process.env['LINKEDIN_CLIENT_SECRET'] ?? '';
+const REDIRECT_URI = 'http://localhost:8000/callback';
+const SCOPES = ['w_member_social', 'openid', 'profile'].join(' ');
+
+if (!CLIENT_ID || !CLIENT_SECRET) {
+  console.error('Missing LINKEDIN_CLIENT_ID or LINKEDIN_CLIENT_SECRET');
+  process.exit(1);
+}
+
+const state = Math.random().toString(36).slice(2);
+
+const authUrl =
+  `https://www.linkedin.com/oauth/v2/authorization` +
+  `?response_type=code` +
+  `&client_id=${encodeURIComponent(CLIENT_ID)}` +
+  `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}` +
+  `&scope=${encodeURIComponent(SCOPES)}` +
+  `&state=${state}`;
+
+console.log('\n── LinkedIn OAuth Setup ──────────────────────────');
+console.log('Open this URL in your browser:\n');
+console.log(authUrl);
+console.log('\nWaiting for callback on http://localhost:8000/callback ...\n');
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url ?? '/', `http://localhost:8000`);
+
+  if (url.pathname !== '/callback') {
+    res.writeHead(404);
+    res.end();
+    return;
+  }
+
+  const code = url.searchParams.get('code');
+  const returnedState = url.searchParams.get('state');
+  const error = url.searchParams.get('error');
+
+  if (error) {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end(`Error: ${error} — ${url.searchParams.get('error_description') ?? ''}`);
+    console.error(`\nLinkedIn OAuth error: ${error}`);
+    server.close();
+    process.exit(1);
+  }
+
+  if (!code || returnedState !== state) {
+    res.writeHead(400, { 'Content-Type': 'text/plain' });
+    res.end('Invalid state or missing code.');
+    server.close();
+    process.exit(1);
+  }
+
+  // Exchange code for access token
+  const tokenRes = await fetch('https://www.linkedin.com/oauth/v2/accessToken', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: REDIRECT_URI,
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+    }),
+  });
+
+  const json = await tokenRes.json() as {
+    access_token?: string;
+    expires_in?: number;
+    error?: string;
+    error_description?: string;
+  };
+
+  if (!tokenRes.ok || !json.access_token) {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end(`Token exchange failed: ${json.error_description ?? JSON.stringify(json)}`);
+    console.error('\nToken exchange failed:', json);
+    server.close();
+    process.exit(1);
+  }
+
+  const expiresInDays = json.expires_in ? Math.floor(json.expires_in / 86400) : 60;
+
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('Done. You can close this tab.');
+
+  console.log('\n── Success ───────────────────────────────────────');
+  console.log(`Access token (expires in ~${expiresInDays} days):\n`);
+  console.log(json.access_token);
+  console.log('\nAdd this to GitHub Actions secrets:');
+  console.log('  Name:  LINKEDIN_ACCESS_TOKEN');
+  console.log(`  Value: ${json.access_token}`);
+  console.log('\nAlso add to .env.local for local dev:');
+  console.log(`  LINKEDIN_ACCESS_TOKEN=${json.access_token}`);
+  console.log('──────────────────────────────────────────────────\n');
+
+  server.close();
+});
+
+server.listen(8000);

--- a/scripts/update-engagement.ts
+++ b/scripts/update-engagement.ts
@@ -1,0 +1,105 @@
+/**
+ * update-engagement.ts
+ *
+ * CLI tool to manually enter LinkedIn reaction counts for published posts.
+ * Run after checking LinkedIn notifications or post analytics.
+ *
+ * Usage:
+ *   npm run update-engagement
+ */
+
+import { createInterface } from 'readline/promises';
+import { loadConfig } from '../src/config/loader.js';
+import { logger } from '../src/utils/logger.js';
+import { SqliteStorage } from '../src/voice/sqlite-storage.js';
+import { SupabaseStorage } from '../src/voice/supabase-storage.js';
+import type { IVoiceStorage, VoicePost } from '../src/voice/storage.js';
+
+const MAX_NORM_REACTIONS = 20;  // reactions count considered "excellent" for personal profile
+
+function computeEngagementScore(editRatio: number, reactions: number, publishedAt: string): number {
+  const ageMs = Date.now() - new Date(publishedAt).getTime();
+  const ageDays = Math.max(ageMs / (1000 * 60 * 60 * 24), 1);
+  const normalized = reactions / Math.sqrt(ageDays + 1) / MAX_NORM_REACTIONS;
+  const capped = Math.min(normalized, 1.0);
+  return editRatio * 0.6 + capped * 0.4;
+}
+
+function formatPost(post: VoicePost): string {
+  const preview = (post.published ?? post.ai_draft).slice(0, 120).replace(/\n/g, ' ');
+  const date = post.published_at ? new Date(post.published_at).toLocaleDateString('es-CL') : '?';
+  const urn = post.linkedin_urn ?? '(no URN)';
+  return [
+    `  Date:       ${date}`,
+    `  Repo:       ${post.repo}`,
+    `  edit_ratio: ${post.edit_ratio?.toFixed(2) ?? '?'}`,
+    `  URN:        ${urn}`,
+    `  Preview:    "${preview}..."`,
+  ].join('\n');
+}
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+
+  const storage: IVoiceStorage = process.env['SUPABASE_URL']
+    ? new SupabaseStorage(process.env['SUPABASE_URL'], process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '')
+    : new SqliteStorage(process.env['SQLITE_PATH'] ?? 'data/devcast.db');
+
+  const posts = await storage.getPostsPendingEngagement('linkedin');
+
+  if (posts.length === 0) {
+    console.log('\nNo published LinkedIn posts pending engagement data.\n');
+    process.exit(0);
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+  console.log(`\n── Engagement Update (${posts.length} posts pending) ──────────────`);
+  console.log('Enter reaction count from LinkedIn. Press Enter to skip.\n');
+
+  let updated = 0;
+
+  for (let i = 0; i < posts.length; i++) {
+    const post = posts[i]!;
+    console.log(`\n[${i + 1}/${posts.length}]`);
+    console.log(formatPost(post));
+
+    const answer = await rl.question('  Reactions (Enter to skip): ');
+    const trimmed = answer.trim();
+
+    if (!trimmed) {
+      console.log('  Skipped.');
+      continue;
+    }
+
+    const reactions = parseInt(trimmed, 10);
+    if (isNaN(reactions) || reactions < 0) {
+      console.log('  Invalid number — skipped.');
+      continue;
+    }
+
+    const editRatio = post.edit_ratio ?? 0.5;
+    const publishedAt = post.published_at ?? post.created_at;
+    const engagementScore = computeEngagementScore(editRatio, reactions, publishedAt);
+
+    await storage.updateEngagement({
+      id: post.id,
+      linkedin_urn: post.linkedin_urn ?? '',
+      reactions_count: reactions,
+      engagement_score: engagementScore,
+    });
+
+    console.log(`  Saved — engagement_score: ${engagementScore.toFixed(3)}`);
+    logger.info('engagement.updated', { id: post.id, reactions, engagementScore });
+    updated++;
+  }
+
+  rl.close();
+
+  console.log(`\n── Done — ${updated} of ${posts.length} posts updated ──────────────\n`);
+}
+
+main().catch((err) => {
+  logger.error('update_engagement.fatal', { error: String(err) });
+  process.exit(1);
+});

--- a/src/ai/prompt-builder.ts
+++ b/src/ai/prompt-builder.ts
@@ -117,10 +117,12 @@ export function buildUserPrompt(
   // Voice examples at TOP (Anthropic best practice for long context)
   if (voiceExamples.length > 0) {
     parts.push('<voice_history>');
-    parts.push(`Published posts ordered by edit ratio (1.0 = unchanged from AI draft = good match).\n`);
+    parts.push(`Published posts ordered by engagement score. edit_ratio=1.0 means unchanged. reactions= LinkedIn reactions.\n`);
     for (const post of voiceExamples) {
       const ratio = post.edit_ratio !== null ? ` edit_ratio="${post.edit_ratio.toFixed(2)}"` : '';
-      parts.push(`<published_post platform="${post.platform}"${ratio}>`);
+      const engagement = post.engagement_score !== null ? ` engagement_score="${post.engagement_score.toFixed(2)}"` : '';
+      const reactions = post.reactions_count > 0 ? ` reactions="${post.reactions_count}"` : '';
+      parts.push(`<published_post platform="${post.platform}"${ratio}${reactions}${engagement}>`);
       parts.push(post.published ?? post.ai_draft);
       parts.push('</published_post>');
     }


### PR DESCRIPTION
## Summary

Closes the engagement feedback loop using manual input (LinkedIn API `r_member_social` not available on Default Tier).

- **`scripts/setup-linkedin.ts`**: OAuth flow to obtain LinkedIn access token (`w_member_social + openid + profile`). Starts local server on port 8000, exchanges code for token, prints instructions for GitHub secret.
- **`scripts/update-engagement.ts`**: CLI that lists published posts without engagement data, prompts for reaction count, computes `engagement_score = edit_ratio*0.6 + normalized_reactions*0.4`, persists via `updateEngagement()`.
- **`prompt-builder.ts`**: voice_history now shows `reactions` and `engagement_score` attributes so Claude can learn which posts connected with the audience, not just which ones sounded right.

## Usage

```bash
# One-time LinkedIn OAuth (token lasts 60 days)
npm run setup-linkedin

# Run after checking LinkedIn notifications
npm run update-engagement
```

## Test plan

- [ ] Run `npm run setup-linkedin` — verify OAuth flow completes and token is printed
- [ ] Run `npm run scan` then `npm run update-engagement` — verify posts appear and score is saved
- [ ] Run `npm run poll` — verify voice_history in logs includes reactions/engagement_score attributes
- [ ] Run `npm run typecheck` — must pass clean