### PR TITLE
fix: use printf with env var to write config.yaml safely

### DIFF
--- a/.github/workflows/voice-report.yml
+++ b/.github/workflows/voice-report.yml
@@ -25,7 +25,9 @@ jobs:
         run: npm ci
 
       - name: Write config
-        run: echo "${{ secrets.CONFIG_YAML }}" > config.yaml
+        env:
+          CONFIG_YAML: ${{ secrets.CONFIG_YAML }}
+        run: printf '%s' "$CONFIG_YAML" > config.yaml
 
       - name: Generate Markdown report
         env:


### PR DESCRIPTION
echo "${{ secrets.CONFIG_YAML }}" fails when the secret contains shell metacharacters like parentheses. Pass through env var and use printf to avoid shell interpolation issues.