### PR TITLE
feat: multi-language analysis modules (Python, Go, Java/Quarkus, Elixir, Architecture)

### DIFF
--- a/src/analysis/language-detector.ts
+++ b/src/analysis/language-detector.ts
@@ -28,6 +28,8 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   '.md': 'Markdown',
   '.tf': 'Terraform',
   '.dockerfile': 'Dockerfile',
+  '.ex': 'Elixir',
+  '.exs': 'Elixir',
 };
 
 export function detectLanguage(filename: string): string | undefined {

--- a/src/analysis/modules/architecture-patterns.ts
+++ b/src/analysis/modules/architecture-patterns.ts
@@ -1,0 +1,134 @@
+import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+
+interface ArchPattern {
+  readonly name: string;
+  readonly score: number;
+  readonly technicalDetail: string;
+  readonly explanation: string;
+  detect(addedLines: readonly string[], filename: string, allFilenames: readonly string[]): boolean;
+}
+
+const PATTERNS: readonly ArchPattern[] = [
+  {
+    name: 'hexagonal architecture (ports & adapters)',
+    score: 9,
+    technicalDetail: 'Hexagonal architecture — the domain defines Port interfaces; Adapters implement them. Business logic has zero dependencies on frameworks, databases, or transport.',
+    explanation: 'Hexagonal architecture puts the domain at the center. Ports are interfaces the domain defines; adapters implement them. Swap a database adapter without touching a single line of business logic.',
+    detect: (_, filename, allFilenames) => {
+      const dirs = allFilenames.join(' ').toLowerCase();
+      const hasHexagonal =
+        /\b(ports?|adapters?|infrastructure|application|domain)\b/.test(dirs);
+      const isPortOrAdapter =
+        /(?:port|adapter|repository|gateway|handler)\.(ts|js|py|go|java|kt|ex|exs)$/i.test(
+          filename,
+        );
+      return hasHexagonal || isPortOrAdapter;
+    },
+  },
+  {
+    name: 'CQRS (command/query separation)',
+    score: 9,
+    technicalDetail: 'CQRS — Commands mutate state, Queries read state. Each has its own model, allowing independent scaling, optimization, and evolution of reads and writes.',
+    explanation: 'CQRS separates read and write models. The write side optimizes for consistency and validation; the read side optimizes for query performance. Scale them independently.',
+    detect: (lines, filename) => {
+      const hasCommandQuery =
+        /(?:command|query)(?:handler|bus|dispatcher)/i.test(filename) ||
+        lines.some(
+          (l) =>
+            /\b(CommandBus|QueryBus|CommandHandler|QueryHandler|ICommand|IQuery)\b/.test(l) ||
+            /\bclass\s+\w+(Command|Query|Handler)\b/.test(l),
+        );
+      return hasCommandQuery;
+    },
+  },
+  {
+    name: 'event sourcing',
+    score: 9,
+    technicalDetail: 'Event sourcing — state derived from an append-only log of domain events. The current state is a projection of all past events.',
+    explanation: 'Event sourcing stores every state change as an immutable event. Replay the event log to rebuild state at any point in time — full audit trail, time travel, multiple projections.',
+    detect: (lines, filename) =>
+      /(?:event.?store|domain.?event|aggregate.?root|event.?stream)/i.test(filename) ||
+      lines.some(
+        (l) =>
+          /\b(EventStore|DomainEvent|AggregateRoot|EventStream|EventSourcing)\b/.test(l) ||
+          /\bclass\s+\w+Event\b/.test(l),
+      ),
+  },
+  {
+    name: 'clean architecture use cases',
+    score: 8,
+    technicalDetail: 'Clean Architecture use cases — application-layer interactors encapsulating a single business operation, with no framework dependencies.',
+    explanation: 'Use cases contain one business operation. They depend on abstract repositories, not concrete databases. Test them without spinning up a server or database.',
+    detect: (lines, filename) =>
+      /(?:use.?case|interactor|application.?service)/i.test(filename) ||
+      lines.some(
+        (l) =>
+          /\bclass\s+\w+(UseCase|Interactor|ApplicationService)\b/.test(l) ||
+          /\binterface\s+I\w+(Repository|Gateway|Service)\b/.test(l),
+      ),
+  },
+  {
+    name: 'event-driven messaging',
+    score: 8,
+    technicalDetail: 'Event-driven architecture — components communicate via published events (Kafka, RabbitMQ, NATS, EventBus) instead of direct calls, decoupling producers from consumers.',
+    explanation: 'Event-driven systems decouple producers from consumers. Publishing an event does not wait for a response — consumers process at their own pace, and new consumers can be added without touching the producer.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /\b(EventBus|MessageBus|DomainEventPublisher|EventEmitter)\b/.test(l) ||
+          /\b(KafkaProducer|KafkaConsumer|RabbitMQ|nats\.connect)\b/.test(l) ||
+          /\b(publish|subscribe|emit|dispatch)\s*\([^)]*[Ee]vent/.test(l),
+      ),
+  },
+  {
+    name: 'saga / process manager',
+    score: 8,
+    technicalDetail: 'Saga pattern — long-running distributed transactions coordinated through a sequence of local transactions, each publishing events or commands to trigger the next step.',
+    explanation: 'A saga coordinates a distributed transaction without a two-phase commit. Each step publishes an event; if one fails, compensating transactions undo the previous steps.',
+    detect: (lines, filename) =>
+      /(?:saga|process.?manager|orchestrat|choreograph)/i.test(filename) ||
+      lines.some(
+        (l) =>
+          /\bclass\s+\w+(Saga|ProcessManager|Orchestrator)\b/.test(l) ||
+          /\b(compensat|rollback|compensating)\w*Transaction/i.test(l),
+      ),
+  },
+];
+
+export class ArchitecturePatternsModule implements CodeAnalyzer {
+  readonly id = 'architecture_patterns';
+  readonly name = 'Architecture Patterns';
+  readonly category = 'architecture_patterns' as const;
+  // No applicableLanguages — runs on all commits
+
+  async analyze(ctx: AnalysisContext): Promise<Finding | null> {
+    const allFilenames = ctx.diffs.map((d) => d.filename);
+
+    for (const diff of ctx.diffs) {
+      if (!diff.patch || diff.status === 'removed') continue;
+
+      const addedLines = diff.patch
+        .split('\n')
+        .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+        .map((l) => l.slice(1));
+
+      if (addedLines.length === 0) continue;
+
+      for (const pattern of PATTERNS) {
+        if (pattern.detect(addedLines, diff.filename, allFilenames)) {
+          return {
+            moduleId: this.id,
+            aspect: pattern.name,
+            finding: `Detected ${pattern.name} in ${diff.filename}`,
+            technicalDetail: pattern.technicalDetail,
+            plainLanguage: pattern.explanation,
+            interestScore: pattern.score,
+            contextHint: `${diff.filename} in ${ctx.repo}`,
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/analysis/modules/elixir-patterns.ts
+++ b/src/analysis/modules/elixir-patterns.ts
@@ -1,0 +1,138 @@
+import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+
+interface ElixirPattern {
+  readonly name: string;
+  readonly score: number;
+  readonly technicalDetail: string;
+  readonly explanation: string;
+  detect(addedLines: readonly string[]): boolean;
+}
+
+const PATTERNS: readonly ElixirPattern[] = [
+  {
+    name: 'pipe operator',
+    score: 7,
+    technicalDetail: 'Elixir pipe operator (|>) — chains function calls left-to-right, passing the result of each expression as the first argument to the next.',
+    explanation: 'The pipe operator eliminates nested function calls. Data flows left to right through a pipeline of transformations — each step is clear and composable.',
+    detect: (lines) => lines.filter((l) => /\|>/.test(l)).length >= 2,
+  },
+  {
+    name: 'GenServer',
+    score: 9,
+    technicalDetail: 'GenServer (OTP behaviour) — a generic server process with client/server separation, built-in message queuing, and supervision integration.',
+    explanation: 'GenServer handles messages one at a time with a queue built in. It integrates with the supervisor tree automatically — crash it, the supervisor restarts it in a clean state.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /\buse\s+GenServer\b/.test(l) ||
+          /\bdef\s+handle_call\b/.test(l) ||
+          /\bdef\s+handle_cast\b/.test(l) ||
+          /\bGenServer\.start_link\b/.test(l),
+      ),
+  },
+  {
+    name: 'Supervisor tree',
+    score: 9,
+    technicalDetail: 'OTP Supervisor — manages child processes with restart strategies (one_for_one, one_for_all, rest_for_one) and supervision trees for fault isolation.',
+    explanation: 'A supervisor watches its children and restarts crashed ones. With nested supervisors, a failure in one subsystem restarts only that part — the rest keeps running.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /\buse\s+Supervisor\b/.test(l) ||
+          /\bchildren\s*=\s*\[/.test(l) ||
+          /\bSupervisor\.start_link\b/.test(l) ||
+          /strategy:\s*:one_for_one|:one_for_all|:rest_for_one/.test(l),
+      ),
+  },
+  {
+    name: 'pattern matching',
+    score: 8,
+    technicalDetail: 'Elixir pattern matching — using `case`, `with`, or function clauses to match on data shape and bind variables simultaneously.',
+    explanation: 'Pattern matching in Elixir goes far beyond switch statements. A `with` chain handles a sequence of operations that each return `{:ok, value}` or `{:error, reason}` — short-circuit on the first failure.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /\bcase\s+\w/.test(l) ||
+          /\bwith\s+{:ok,\s*/.test(l) ||
+          /\b->\s*{:ok,/.test(l) ||
+          /\b->\s*{:error,/.test(l),
+      ),
+  },
+  {
+    name: 'Phoenix LiveView',
+    score: 9,
+    technicalDetail: 'Phoenix LiveView — server-rendered real-time UI over WebSockets, with handle_event and handle_info callbacks updating state and re-rendering diffs.',
+    explanation: 'LiveView keeps the UI state on the server and pushes minimal HTML diffs over a WebSocket. Real-time features without a JavaScript framework — one language, one process.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /\buse\s+\w+Web,\s*:live_view\b/.test(l) ||
+          /\bPhoenix\.LiveView\b/.test(l) ||
+          /\bdef\s+handle_event\b/.test(l) ||
+          /\bdef\s+mount\b/.test(l),
+      ),
+  },
+  {
+    name: 'Task async / concurrency',
+    score: 8,
+    technicalDetail: 'Task.async / Task.await / Task.async_stream — spawning supervised async tasks and collecting results, with automatic cleanup on timeout.',
+    explanation: 'Task.async_stream runs a function concurrently over a collection with a configurable concurrency limit. Results arrive in order; tasks that crash are isolated.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /\bTask\.async\b/.test(l) ||
+          /\bTask\.await\b/.test(l) ||
+          /\bTask\.async_stream\b/.test(l),
+      ),
+  },
+  {
+    name: 'Telemetry instrumentation',
+    score: 7,
+    technicalDetail: ':telemetry.execute / :telemetry.attach — Erlang/Elixir telemetry events for metrics, tracing, and observability without coupling to a specific backend.',
+    explanation: 'Telemetry decouples instrumentation from reporting. Emit an event anywhere; attach handlers in the config. Swap Prometheus for Datadog without touching business logic.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /\b:telemetry\.execute\b/.test(l) ||
+          /\b:telemetry\.attach\b/.test(l) ||
+          /\bTelemetry\.Metrics\b/.test(l),
+      ),
+  },
+];
+
+export class ElixirPatternsModule implements CodeAnalyzer {
+  readonly id = 'elixir_patterns';
+  readonly name = 'Elixir / OTP Patterns';
+  readonly category = 'elixir_patterns' as const;
+  readonly applicableLanguages = ['Elixir'];
+
+  async analyze(ctx: AnalysisContext): Promise<Finding | null> {
+    for (const diff of ctx.diffs) {
+      if (!diff.patch || diff.status === 'removed') continue;
+      if (diff.language !== 'Elixir') continue;
+
+      const addedLines = diff.patch
+        .split('\n')
+        .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+        .map((l) => l.slice(1));
+
+      if (addedLines.length === 0) continue;
+
+      for (const pattern of PATTERNS) {
+        if (pattern.detect(addedLines)) {
+          return {
+            moduleId: this.id,
+            aspect: pattern.name,
+            finding: `Detected ${pattern.name} in ${diff.filename}`,
+            technicalDetail: pattern.technicalDetail,
+            plainLanguage: pattern.explanation,
+            interestScore: pattern.score,
+            contextHint: `${diff.filename} in ${ctx.repo}`,
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/analysis/modules/go-patterns.ts
+++ b/src/analysis/modules/go-patterns.ts
@@ -1,0 +1,146 @@
+import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+
+interface GoPattern {
+  readonly name: string;
+  readonly score: number;
+  readonly technicalDetail: string;
+  readonly explanation: string;
+  detect(addedLines: readonly string[]): boolean;
+}
+
+const PATTERNS: readonly GoPattern[] = [
+  {
+    name: 'goroutine',
+    score: 8,
+    technicalDetail: 'Goroutine — a lightweight thread managed by the Go runtime, launched with `go`, costing ~2KB of stack vs ~1MB for an OS thread.',
+    explanation: 'A goroutine starts in two kilobytes of stack and costs almost nothing to spawn. Go programs routinely run hundreds of thousands of goroutines concurrently on a handful of OS threads.',
+    detect: (lines) =>
+      lines.some((l) => /\bgo\s+func\s*\(/.test(l) || /\bgo\s+[a-z]\w*\s*\(/.test(l)),
+  },
+  {
+    name: 'channel communication',
+    score: 8,
+    technicalDetail: 'Go channels — typed conduits for goroutine communication, enforcing message-passing concurrency instead of shared memory.',
+    explanation: "Go channels enforce the rule: don't communicate by sharing memory, share memory by communicating. Data ownership transfers through the channel — no locks needed.",
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /\bmake\s*\(\s*chan\b/.test(l) ||
+          /\bchan\s+\w/.test(l) ||
+          /\b<-\s*\w/.test(l) ||
+          /\w\s*<-/.test(l),
+      ),
+  },
+  {
+    name: 'context cancellation',
+    score: 8,
+    technicalDetail: 'context.WithCancel / context.WithTimeout — propagates cancellation and deadlines through the call stack without modifying function signatures.',
+    explanation: 'Context threads cancellation signals through every layer of the call stack. When a request is cancelled, every goroutine doing work for it stops — no wasted resources.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /\bcontext\.WithCancel\b/.test(l) ||
+          /\bcontext\.WithTimeout\b/.test(l) ||
+          /\bcontext\.WithDeadline\b/.test(l) ||
+          /\bctx\.Done\(\)/.test(l),
+      ),
+  },
+  {
+    name: 'interface definition',
+    score: 7,
+    technicalDetail: 'Go interface — implicitly satisfied structural typing: any type implementing the methods satisfies the interface without declaration.',
+    explanation: 'Go interfaces are satisfied implicitly — no `implements` keyword. If a type has the methods, it satisfies the interface. This keeps dependencies minimal and enables easy mocking.',
+    detect: (lines) =>
+      lines.some((l) => /\btype\s+\w+\s+interface\s*\{/.test(l)),
+  },
+  {
+    name: 'error wrapping',
+    score: 7,
+    technicalDetail: 'Go error wrapping with %w (fmt.Errorf) — creates error chains that callers can inspect with errors.Is and errors.As without parsing strings.',
+    explanation: 'Wrapping errors with %w builds a chain of context. The caller can use errors.Is to check for a specific error type anywhere in the chain, without string matching.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /fmt\.Errorf\s*\(.*%w/.test(l) ||
+          /\berrors\.As\s*\(/.test(l) ||
+          /\berrors\.Is\s*\(/.test(l) ||
+          /\berrors\.Unwrap\s*\(/.test(l),
+      ),
+  },
+  {
+    name: 'sync primitives',
+    score: 7,
+    technicalDetail: 'sync.WaitGroup / sync.Mutex / sync.RWMutex — coordinating goroutine lifecycle and protecting shared state in concurrent code.',
+    explanation: 'WaitGroup waits for a group of goroutines to finish. Mutex protects shared data. RWMutex allows concurrent reads but exclusive writes — standard concurrency tools.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /\bsync\.WaitGroup\b/.test(l) ||
+          /\bsync\.Mutex\b/.test(l) ||
+          /\bsync\.RWMutex\b/.test(l) ||
+          /\bsync\.Once\b/.test(l),
+      ),
+  },
+  {
+    name: 'table-driven tests',
+    score: 8,
+    technicalDetail: 'Table-driven tests — Go idiom of defining test cases as a slice of structs and iterating over them with t.Run, maximizing coverage with minimal code.',
+    explanation: 'Table-driven tests define dozens of cases as a data table. Adding a new edge case is one line. Failures report which row failed — no guessing which test broke.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /\[\]struct\s*\{/.test(l) ||
+          (/\bt\.Run\s*\(/.test(l) && /\btest(s|Cases|Data|Table)\b/i.test(lines.join('\n'))),
+      ),
+  },
+  {
+    name: 'defer for resource cleanup',
+    score: 7,
+    technicalDetail: 'defer statement — schedules a function call to run when the surrounding function returns, ensuring cleanup regardless of the return path.',
+    explanation: 'defer guarantees cleanup runs when the function exits — whether via return or panic. Open a resource, immediately defer its close, and the code is always correct.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /\bdefer\s+\w+\.Close\(\)/.test(l) ||
+          /\bdefer\s+\w+\.Unlock\(\)/.test(l) ||
+          /\bdefer\s+cancel\(\)/.test(l),
+      ),
+  },
+];
+
+export class GoPatternsModule implements CodeAnalyzer {
+  readonly id = 'go_patterns';
+  readonly name = 'Go Patterns';
+  readonly category = 'go_patterns' as const;
+  readonly applicableLanguages = ['Go'];
+
+  async analyze(ctx: AnalysisContext): Promise<Finding | null> {
+    for (const diff of ctx.diffs) {
+      if (!diff.patch || diff.status === 'removed') continue;
+      if (diff.language !== 'Go') continue;
+
+      const addedLines = diff.patch
+        .split('\n')
+        .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+        .map((l) => l.slice(1));
+
+      if (addedLines.length === 0) continue;
+
+      for (const pattern of PATTERNS) {
+        if (pattern.detect(addedLines)) {
+          return {
+            moduleId: this.id,
+            aspect: pattern.name,
+            finding: `Detected ${pattern.name} in ${diff.filename}`,
+            technicalDetail: pattern.technicalDetail,
+            plainLanguage: pattern.explanation,
+            interestScore: pattern.score,
+            contextHint: `${diff.filename} in ${ctx.repo}`,
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/analysis/modules/index.ts
+++ b/src/analysis/modules/index.ts
@@ -28,6 +28,11 @@ import { EvolutionaryModule }    from './evolutionary.js';
 import { JsAdvancedModule }      from './js-advanced.js';
 import { ReactPatternsModule }  from './react-patterns.js';
 import { DevopsModule }         from './devops.js';
+import { PythonPatternsModule }       from './python-patterns.js';
+import { GoPatternsModule }           from './go-patterns.js';
+import { JavaPatternsModule }         from './java-patterns.js';
+import { ElixirPatternsModule }       from './elixir-patterns.js';
+import { ArchitecturePatternsModule } from './architecture-patterns.js';
 
 export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new ComplexityModule(),
@@ -49,4 +54,9 @@ export const MODULE_REGISTRY: CodeAnalyzer[] = [
   new JsAdvancedModule(),
   new ReactPatternsModule(),
   new DevopsModule(),
+  new PythonPatternsModule(),
+  new GoPatternsModule(),
+  new JavaPatternsModule(),
+  new ElixirPatternsModule(),
+  new ArchitecturePatternsModule(),
 ];

--- a/src/analysis/modules/java-patterns.ts
+++ b/src/analysis/modules/java-patterns.ts
@@ -1,0 +1,150 @@
+import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+
+interface JavaPattern {
+  readonly name: string;
+  readonly score: number;
+  readonly technicalDetail: string;
+  readonly explanation: string;
+  detect(addedLines: readonly string[], fullPatch: string): boolean;
+}
+
+const PATTERNS: readonly JavaPattern[] = [
+  {
+    name: 'Java record',
+    score: 8,
+    technicalDetail: 'Java record (JEP 395, Java 16+) — a transparent, immutable data carrier that auto-generates constructor, accessors, equals, hashCode, and toString.',
+    explanation: 'A record replaces a 40-line data class with a single line. It is immutable by default, generates all boilerplate automatically, and makes the intent crystal clear.',
+    detect: (lines) => lines.some((l) => /\brecord\s+\w+\s*\(/.test(l)),
+  },
+  {
+    name: 'sealed class / pattern matching',
+    score: 8,
+    technicalDetail: 'Sealed classes (JEP 409) and pattern matching for switch (JEP 441) — exhaustive type hierarchies checked at compile time, enabling safe instanceof patterns.',
+    explanation: 'Sealed classes declare exactly which subtypes exist. Combined with pattern matching, the compiler enforces that all cases are handled — no runtime surprises.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /\bsealed\s+(class|interface)\b/.test(l) ||
+          /\bpermits\b/.test(l) ||
+          /\binstanceof\s+\w+\s+\w+/.test(l),
+      ),
+  },
+  {
+    name: 'virtual threads',
+    score: 9,
+    technicalDetail: 'Virtual threads (JEP 444, Java 21) — lightweight threads managed by the JVM, enabling millions of concurrent threads without the overhead of OS threads.',
+    explanation: 'Virtual threads run on carrier threads managed by the JVM. A single machine can handle a million virtual threads — the same concurrency as async code, with blocking I/O syntax.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /\bThread\.ofVirtual\(\)/.test(l) ||
+          /\bExecutors\.newVirtualThreadPerTaskExecutor\(\)/.test(l) ||
+          /\bThread\.startVirtualThread\b/.test(l),
+      ),
+  },
+  {
+    name: 'Stream API',
+    score: 7,
+    technicalDetail: 'Java Stream API — functional-style pipeline operations (filter, map, reduce, collect) on collections, with optional parallel execution.',
+    explanation: 'Stream pipelines process collections functionally. The same code runs sequentially or in parallel with .parallelStream() — and the intent is clear without loops.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /\.(stream|parallelStream)\s*\(\s*\)/.test(l) ||
+          (/\.collect\s*\(/.test(l) && /\bCollectors\./.test(l)),
+      ),
+  },
+  {
+    name: 'Quarkus reactive (Mutiny)',
+    score: 9,
+    technicalDetail: 'Quarkus Mutiny reactive types (Uni<T>, Multi<T>) — non-blocking reactive streams integrated with the Vert.x event loop, zero threads blocked on I/O.',
+    explanation: 'Uni handles a single async result; Multi handles a stream of them. The event loop thread never blocks — Quarkus handles thousands of requests on a handful of threads.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /\bUni\s*</.test(l) ||
+          /\bMulti\s*</.test(l) ||
+          /\bio\.smallrye\.mutiny\b/.test(l) ||
+          /\bUni\.createFrom\b/.test(l),
+      ),
+  },
+  {
+    name: 'Quarkus CDI / injection',
+    score: 7,
+    technicalDetail: 'Quarkus CDI — @ApplicationScoped, @RequestScoped, @Inject, @ConfigProperty for dependency injection and configuration binding at compile time (ArC).',
+    explanation: 'Quarkus CDI is resolved at build time, not runtime. The container wiring happens during compilation — startup is instant and no classpath scanning at runtime.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /^\s*@ApplicationScoped\b/.test(l) ||
+          /^\s*@RequestScoped\b/.test(l) ||
+          /^\s*@Inject\b/.test(l) ||
+          /^\s*@ConfigProperty\b/.test(l) ||
+          /^\s*@QuarkusTest\b/.test(l),
+      ),
+  },
+  {
+    name: 'Panache ORM',
+    score: 8,
+    technicalDetail: 'Quarkus Panache — active record or repository pattern over Hibernate, reducing boilerplate with built-in find, persist, and listAll methods.',
+    explanation: 'Panache lets an entity extend PanacheEntity and immediately gains find, persist, count, and listAll. The repository pattern is one class, not three layers of interfaces.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /\bPanacheEntity\b/.test(l) ||
+          /\bPanacheRepository\b/.test(l) ||
+          /^\s*@Entity\b/.test(l) ||
+          /\bPanacheEntityBase\b/.test(l),
+      ),
+  },
+  {
+    name: 'Optional chaining',
+    score: 6,
+    technicalDetail: 'Java Optional — a container type for nullable values that forces explicit handling of the absent case, eliminating null checks and NullPointerExceptions.',
+    explanation: 'Optional makes the possibility of a missing value explicit in the type system. The caller cannot ignore it — they must handle both the present and absent cases.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /\bOptional\.(of|ofNullable|empty)\s*\(/.test(l) ||
+          /\b\.orElseThrow\s*\(/.test(l) ||
+          /\b\.orElseGet\s*\(/.test(l),
+      ),
+  },
+];
+
+export class JavaPatternsModule implements CodeAnalyzer {
+  readonly id = 'java_patterns';
+  readonly name = 'Java / Quarkus Patterns';
+  readonly category = 'java_patterns' as const;
+  readonly applicableLanguages = ['Java', 'Kotlin'];
+
+  async analyze(ctx: AnalysisContext): Promise<Finding | null> {
+    for (const diff of ctx.diffs) {
+      if (!diff.patch || diff.status === 'removed') continue;
+      if (diff.language !== 'Java' && diff.language !== 'Kotlin') continue;
+
+      const addedLines = diff.patch
+        .split('\n')
+        .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+        .map((l) => l.slice(1));
+
+      if (addedLines.length === 0) continue;
+
+      for (const pattern of PATTERNS) {
+        if (pattern.detect(addedLines, diff.patch)) {
+          return {
+            moduleId: this.id,
+            aspect: pattern.name,
+            finding: `Detected ${pattern.name} in ${diff.filename}`,
+            technicalDetail: pattern.technicalDetail,
+            plainLanguage: pattern.explanation,
+            interestScore: pattern.score,
+            contextHint: `${diff.filename} in ${ctx.repo}`,
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/analysis/modules/python-patterns.ts
+++ b/src/analysis/modules/python-patterns.ts
@@ -1,0 +1,149 @@
+import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+
+interface PythonPattern {
+  readonly name: string;
+  readonly score: number;
+  readonly technicalDetail: string;
+  readonly explanation: string;
+  detect(addedLines: readonly string[]): boolean;
+}
+
+const PATTERNS: readonly PythonPattern[] = [
+  {
+    name: 'type hints',
+    score: 7,
+    technicalDetail: 'PEP 484 type hints — annotating function signatures and variables with types for static analysis and IDE support.',
+    explanation: 'Python type hints let mypy or pyright catch type errors before runtime. The code stays dynamic but tools can reason about it statically — the best of both worlds.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /def\s+\w+\s*\([^)]*:\s*\w/.test(l) ||
+          /\)\s*->\s*\w/.test(l) ||
+          /^from\s+typing\s+import/.test(l) ||
+          /^from\s+__future__\s+import\s+annotations/.test(l),
+      ),
+  },
+  {
+    name: 'dataclass',
+    score: 7,
+    technicalDetail: 'Python dataclass (PEP 557) — auto-generates `__init__`, `__repr__`, `__eq__` from annotated fields, reducing boilerplate.',
+    explanation: 'A @dataclass eliminates the manual `__init__` and `__repr__` boilerplate. Declare the fields once with types — Python generates the rest.',
+    detect: (lines) =>
+      lines.some((l) => /^\s*@dataclass/.test(l) || /from\s+dataclasses\s+import/.test(l)),
+  },
+  {
+    name: 'Pydantic model',
+    score: 8,
+    technicalDetail: 'Pydantic BaseModel — runtime data validation and serialization using Python type annotations, with automatic coercion and error messages.',
+    explanation: 'Pydantic validates incoming data at runtime using the same type annotations mypy reads. One model definition handles validation, serialization, and schema generation.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /class\s+\w+\s*\(\s*BaseModel\s*\)/.test(l) ||
+          /from\s+pydantic\s+import/.test(l) ||
+          /^\s*@validator\b/.test(l) ||
+          /^\s*@model_validator\b/.test(l),
+      ),
+  },
+  {
+    name: 'async/await',
+    score: 8,
+    technicalDetail: 'Python asyncio — cooperative multitasking with async def and await, enabling non-blocking I/O without threads.',
+    explanation: 'Async Python handles thousands of concurrent I/O operations on a single thread. No threads, no locks — the event loop switches coroutines when they yield control.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /^\s*async\s+def\s+/.test(l) ||
+          /\bawait\s+\w/.test(l) ||
+          /\basyncio\b/.test(l) ||
+          /^import\s+asyncio/.test(l),
+      ),
+  },
+  {
+    name: 'Protocol structural typing',
+    score: 8,
+    technicalDetail: 'typing.Protocol (PEP 544) — structural subtyping (duck typing) checked statically by mypy, without explicit inheritance.',
+    explanation: 'Protocol lets you define an interface without requiring explicit inheritance. Any class with the right methods satisfies it — duck typing made static.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /class\s+\w+\s*\(\s*Protocol\s*\)/.test(l) ||
+          /from\s+typing\s+import.*\bProtocol\b/.test(l),
+      ),
+  },
+  {
+    name: 'lru_cache / functools optimization',
+    score: 7,
+    technicalDetail: 'functools.lru_cache or functools.cache — memoizes function results with a Least Recently Used cache, trading memory for CPU time.',
+    explanation: 'A single decorator makes a function remember its previous results. Repeated calls with the same arguments return instantly from cache instead of recomputing.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /^\s*@lru_cache/.test(l) ||
+          /^\s*@functools\.lru_cache/.test(l) ||
+          /^\s*@cache\b/.test(l) ||
+          /^\s*@functools\.cache/.test(l),
+      ),
+  },
+  {
+    name: 'context manager',
+    score: 7,
+    technicalDetail: 'Custom context manager — __enter__/__exit__ or @contextmanager, ensuring deterministic resource cleanup via the `with` statement.',
+    explanation: 'A context manager guarantees cleanup runs even if an exception is raised. Files, locks, and connections open and close reliably without try/finally boilerplate.',
+    detect: (lines) =>
+      lines.some(
+        (l) =>
+          /def\s+__enter__\s*\(/.test(l) ||
+          /def\s+__exit__\s*\(/.test(l) ||
+          /^\s*@contextmanager/.test(l) ||
+          /from\s+contextlib\s+import/.test(l),
+      ),
+  },
+  {
+    name: 'generator / lazy evaluation',
+    score: 7,
+    technicalDetail: 'Python generator — functions using yield to produce values lazily, processing data one item at a time without loading the entire sequence into memory.',
+    explanation: 'Generators produce values one at a time instead of building the full list. Processing a million-row CSV becomes constant memory — the generator never holds more than one row.',
+    detect: (lines) =>
+      lines.some(
+        (l) => /\byield\s+from\b/.test(l) || (/\byield\b/.test(l) && !/yield_/.test(l)),
+      ),
+  },
+];
+
+export class PythonPatternsModule implements CodeAnalyzer {
+  readonly id = 'python_patterns';
+  readonly name = 'Python Patterns';
+  readonly category = 'python_patterns' as const;
+  readonly applicableLanguages = ['Python'];
+
+  async analyze(ctx: AnalysisContext): Promise<Finding | null> {
+    for (const diff of ctx.diffs) {
+      if (!diff.patch || diff.status === 'removed') continue;
+      if (diff.language !== 'Python') continue;
+
+      const addedLines = diff.patch
+        .split('\n')
+        .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+        .map((l) => l.slice(1));
+
+      if (addedLines.length === 0) continue;
+
+      for (const pattern of PATTERNS) {
+        if (pattern.detect(addedLines)) {
+          return {
+            moduleId: this.id,
+            aspect: pattern.name,
+            finding: `Detected ${pattern.name} in ${diff.filename}`,
+            technicalDetail: pattern.technicalDetail,
+            plainLanguage: pattern.explanation,
+            interestScore: pattern.score,
+            contextHint: `${diff.filename} in ${ctx.repo}`,
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/analysis/types.ts
+++ b/src/analysis/types.ts
@@ -17,7 +17,12 @@ export type AnalysisCategory =
   | 'evolutionary'
   | 'js_advanced'
   | 'react_patterns'
-  | 'devops';
+  | 'devops'
+  | 'python_patterns'
+  | 'go_patterns'
+  | 'java_patterns'
+  | 'elixir_patterns'
+  | 'architecture_patterns';
 
 export interface FileDiff {
   filename: string;


### PR DESCRIPTION
## Summary

Adds 5 new analysis modules to the pipeline (24 total, from 19).

| Module | Language | Patterns detected |
|--------|----------|-------------------|
| `PythonPatternsModule` | Python | type hints, dataclasses, Pydantic, async/await, Protocol, lru_cache, context managers, generators |
| `GoPatternsModule` | Go | goroutines, channels, context cancellation, interfaces, error wrapping (%w), sync primitives, table-driven tests, defer |
| `JavaPatternsModule` | Java / Kotlin | records, sealed classes, virtual threads (JEP 444), Stream API, Quarkus Mutiny (Uni/Multi), CDI injection, Panache ORM |
| `ElixirPatternsModule` | Elixir | pipe operator, GenServer, Supervisor tree, pattern matching, Phoenix LiveView, Task async, Telemetry |
| `ArchitecturePatternsModule` | All languages | hexagonal/ports+adapters, CQRS, event sourcing, clean arch use cases, event-driven messaging, saga |

## Supporting changes

- `language-detector.ts`: added `.ex`/`.exs` → `Elixir`
- `types.ts`: 5 new `AnalysisCategory` entries

## Test plan

- [ ] `npm run typecheck` — passes (verified locally)
- [ ] Merge to trunk
- [ ] Run `npm run test-analyze` on a Python/Go/Java commit SHA to verify module fires