### PR TITLE
feat: plugin SDK for external devcast modules

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -37,3 +37,11 @@ posting:
 ai:
   model: "claude-sonnet-4-6"
   max_tokens: 1600
+
+# Optional: npm packages that extend devcast with custom analysis modules.
+# Each package must export a named `module` implementing CodeAnalyzer (devcast-sdk).
+# Install them first: npm install devcast-module-rust
+plugins: []
+# plugins:
+#   - devcast-module-rust
+#   - devcast-module-django

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -1,0 +1,89 @@
+/**
+ * devcast-sdk — TypeScript types for writing devcast analysis module plugins.
+ *
+ * Usage:
+ *   npm install devcast-sdk
+ *
+ * Example plugin (devcast-module-rust/index.ts):
+ *
+ *   import type { CodeAnalyzer, Finding, AnalysisContext } from 'devcast-sdk';
+ *
+ *   export const module: CodeAnalyzer = {
+ *     id: 'rust_patterns',
+ *     name: 'Rust Patterns',
+ *     category: 'rust_patterns',
+ *     applicableLanguages: ['Rust'],
+ *     async analyze(ctx) {
+ *       // inspect ctx.diffs — return Finding | null
+ *       return null;
+ *     },
+ *   };
+ *
+ * devcast discovers plugins listed in config.yaml under `plugins:` and appends
+ * them to the built-in MODULE_REGISTRY at startup. Each plugin must export a
+ * named `module` property implementing CodeAnalyzer.
+ */
+
+export interface FileDiff {
+  readonly filename: string;
+  readonly status: 'added' | 'modified' | 'removed' | 'renamed';
+  readonly additions: number;
+  readonly deletions: number;
+  readonly patch: string;
+  readonly language?: string;
+}
+
+export interface AnalysisContext {
+  readonly diffs: FileDiff[];
+  readonly commitMessage: string;
+  readonly languages: string[];
+  readonly repo: string;
+  readonly sha: string;
+}
+
+export interface Finding {
+  readonly moduleId: string;
+  readonly aspect: string;
+  readonly finding: string;
+  readonly technicalDetail: string;
+  readonly plainLanguage: string;
+  readonly interestScore: number;
+  readonly contextHint?: string;
+  readonly evidence?: {
+    readonly before?: string;
+    readonly after?: string;
+  };
+}
+
+/**
+ * The interface every devcast analysis module must implement.
+ * Export it as a named `module` property from your npm package.
+ */
+export interface CodeAnalyzer {
+  /** Unique identifier for this module (snake_case). */
+  readonly id: string;
+
+  /** Human-readable module name shown in logs. */
+  readonly name: string;
+
+  /**
+   * Category string — arbitrary for plugins (devcast core uses a fixed union,
+   * but plugins may define their own categories).
+   */
+  readonly category: string;
+
+  /**
+   * If defined, this module only runs on commits that touch files in one of
+   * these languages (e.g. ['Rust', 'C']). Undefined = runs on all commits.
+   */
+  readonly applicableLanguages?: string[];
+
+  /**
+   * Analyze the commit context. Return a Finding if something interesting was
+   * detected, or null if nothing noteworthy was found.
+   *
+   * Must not throw — unhandled rejections are caught by the pipeline and logged
+   * as warnings; the module returns null for that commit.
+   */
+  analyze(ctx: AnalysisContext): Promise<Finding | null>;
+}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "devcast-sdk",
+  "version": "1.0.0",
+  "description": "TypeScript types for writing devcast analysis module plugins",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc"
+  },
+  "keywords": ["devcast", "plugin", "sdk", "analysis", "github"],
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["index.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/src/analysis/plugin-loader.ts
+++ b/src/analysis/plugin-loader.ts
@@ -1,0 +1,69 @@
+import { logger } from '../utils/logger.js';
+import type { CodeAnalyzer } from './types.js';
+
+/**
+ * Dynamically loads devcast plugin modules listed in config.plugins.
+ *
+ * Each plugin must be an npm package that exports a named `module` property
+ * implementing CodeAnalyzer (from devcast-sdk).
+ *
+ * Failures are isolated: a plugin that fails to load is skipped with a warning.
+ * The rest of the pipeline continues normally.
+ */
+export async function loadPlugins(pluginNames: readonly string[]): Promise<CodeAnalyzer[]> {
+  if (pluginNames.length === 0) return [];
+
+  const plugins: CodeAnalyzer[] = [];
+
+  for (const name of pluginNames) {
+    if (!isValidPackageName(name)) {
+      logger.warn('plugin.invalid_name', { name });
+      continue;
+    }
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const mod: unknown = await import(name);
+      const analyzer = extractAnalyzer(mod);
+
+      if (!isValidAnalyzer(analyzer)) {
+        logger.warn('plugin.invalid_export', {
+          name,
+          hint: 'plugin must export a named `module` property implementing CodeAnalyzer',
+        });
+        continue;
+      }
+
+      plugins.push(analyzer);
+      logger.info('plugin.loaded', { name, id: analyzer.id });
+    } catch (err) {
+      logger.warn('plugin.load_failed', { name, error: String(err) });
+    }
+  }
+
+  return plugins;
+}
+
+function isValidPackageName(name: string): boolean {
+  // Allow scoped packages (@scope/name) and regular names (letters, digits, -, _, .)
+  return /^(?:@[a-z0-9\-_.]+\/)?[a-z0-9\-_.]+$/i.test(name);
+}
+
+function extractAnalyzer(mod: unknown): unknown {
+  if (!mod || typeof mod !== 'object') return undefined;
+  const m = mod as Record<string, unknown>;
+  // Named export `module` is the convention; fall back to default
+  return m['module'] ?? m['default'];
+}
+
+function isValidAnalyzer(value: unknown): value is CodeAnalyzer {
+  if (!value || typeof value !== 'object') return false;
+  const m = value as Record<string, unknown>;
+  return (
+    typeof m['id'] === 'string' &&
+    m['id'].length > 0 &&
+    typeof m['name'] === 'string' &&
+    typeof m['category'] === 'string' &&
+    typeof m['analyze'] === 'function'
+  );
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -40,6 +40,7 @@ export const ConfigSchema = z.object({
     model: z.string().default('claude-sonnet-4-6'),
     max_tokens: z.number().int().default(1600),
   }),
+  plugins: z.array(z.string()).default([]),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/src/main-poll.ts
+++ b/src/main-poll.ts
@@ -11,6 +11,8 @@ import { GitHubClient } from './github/client.js';
 import { pollNewPushEvents } from './github/events-poller.js';
 import { enrichCommit } from './github/commit-enricher.js';
 import { runPipeline } from './analysis/pipeline.js';
+import { loadPlugins } from './analysis/plugin-loader.js';
+import { MODULE_REGISTRY } from './analysis/modules/index.js';
 import { AnthropicClient } from './ai/client.js';
 import { generatePosts } from './ai/post-generator.js';
 import { BufferClient } from './buffer/client.js';
@@ -23,6 +25,9 @@ import type { IVoiceStorage } from './voice/storage.js';
 async function main(): Promise<void> {
   const config = loadConfig();
   logger.info('poll.start', { username: config.author.github_username });
+
+  const plugins = await loadPlugins(config.plugins);
+  const modules = plugins.length > 0 ? [...MODULE_REGISTRY, ...plugins] : MODULE_REGISTRY;
 
   // Storage: Supabase in production (service_role key), SQLite locally
   const storage: IVoiceStorage = process.env['SUPABASE_URL']
@@ -103,6 +108,7 @@ async function main(): Promise<void> {
       const findings = await runPipeline(
         { diffs: commit.diffs, commitMessage: commit.message, languages: commit.languages, repo: commit.repo, sha: commit.sha },
         config.posting.analysis_top_n,
+        modules,
       );
 
       if (findings.length === 0) {


### PR DESCRIPTION
## Summary

- **`packages/sdk/`** — `devcast-sdk` npm package (types only). Plugin authors install it and get `CodeAnalyzer`, `Finding`, `AnalysisContext`, `FileDiff` types.
- **`src/analysis/plugin-loader.ts`** — loads plugins listed in config at startup. Validates package name format, validates the `module` export shape, isolates failures (warn + skip).
- **`src/config/schema.ts`** — `plugins: string[]` field (default `[]`).
- **`src/main-poll.ts`** — merges loaded plugins into `MODULE_REGISTRY` before `runPipeline`.
- **`config.example.yaml`** — documents `plugins:` section.

## Plugin contract

A plugin package must export a named `module` property:

```typescript
import type { CodeAnalyzer } from 'devcast-sdk';

export const module: CodeAnalyzer = {
  id: 'rust_patterns',
  name: 'Rust Patterns',
  category: 'rust_patterns',
  applicableLanguages: ['Rust'],
  async analyze(ctx) { ... },
};
```

Install + activate:
```bash
npm install devcast-module-rust
# config.yaml
# plugins:
#   - devcast-module-rust
```

## Test plan

- [ ] `npm run typecheck` — passes (verified locally)
- [ ] Merge to trunk
- [ ] Add a plugin name to `config.yaml plugins:` and verify it loads/fails gracefully