### PR TITLE
feat: GitHub App Marketplace infrastructure (webhook + multi-tenant worker)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src/ ./src/
+
+ENV NODE_ENV=production
+
+CMD ["npx", "tsx", "src/webhook/server.ts"]

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -59,6 +59,42 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_voice_posts_sha_platform
   ON voice_posts(commit_sha, platform);
 
 -- ─────────────────────────────────────────────────────────
+-- MARKETPLACE — multi-tenant tables
+-- ─────────────────────────────────────────────────────────
+
+-- One row per GitHub App installation (one tenant per GitHub user/org)
+CREATE TABLE IF NOT EXISTS tenants (
+  id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  github_installation_id  BIGINT NOT NULL UNIQUE,  -- GitHub App installation ID
+  github_username         TEXT NOT NULL UNIQUE,    -- installing user/org login
+  plan                    TEXT NOT NULL DEFAULT 'free',
+  active                  BOOLEAN NOT NULL DEFAULT TRUE,
+  buffer_access_token     TEXT,                    -- encrypted, set during onboarding
+  config                  JSONB NOT NULL DEFAULT '{}',
+  voice_bootstrap         TEXT                     -- raw posts pasted during onboarding
+);
+
+-- Async job queue — webhook enqueues, worker picks up
+CREATE TABLE IF NOT EXISTS job_queue (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  tenant_id   UUID NOT NULL REFERENCES tenants(id),
+  repo        TEXT NOT NULL,                       -- 'owner/repo'
+  before_sha  TEXT NOT NULL,                       -- push event before SHA
+  after_sha   TEXT NOT NULL,                       -- push event after SHA
+  ref         TEXT NOT NULL,                       -- e.g. 'refs/heads/main'
+  status      TEXT NOT NULL DEFAULT 'pending',     -- 'pending'|'processing'|'done'|'failed'
+  attempts    INTEGER NOT NULL DEFAULT 0,
+  error       TEXT,
+  processed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_queue_pending
+  ON job_queue(created_at ASC)
+  WHERE status = 'pending';
+
+-- ─────────────────────────────────────────────────────────
 -- ROW LEVEL SECURITY
 -- ─────────────────────────────────────────────────────────
 -- Enable RLS on all tables. No public policies = anon key has zero access.
@@ -69,6 +105,8 @@ ALTER TABLE voice_posts      ENABLE ROW LEVEL SECURITY;
 ALTER TABLE pending_batch    ENABLE ROW LEVEL SECURITY;
 ALTER TABLE events_state     ENABLE ROW LEVEL SECURITY;
 ALTER TABLE scheduled_slots  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tenants          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE job_queue        ENABLE ROW LEVEL SECURITY;
 
 -- ─────────────────────────────────────────────────────────
 -- MIGRATION — run this block on existing Supabase installations

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "update-engagement": "tsx --env-file=.env.local scripts/update-engagement.ts",
     "bootstrap": "tsx --env-file=.env.local scripts/bootstrap-voice.ts",
     "test-analyze": "tsx --env-file=.env.local scripts/test-analyze.ts",
+    "webhook": "tsx --env-file=.env.local src/webhook/server.ts",
     "poll": "tsx --env-file=.env.local src/main-poll.ts",
     "scan": "tsx --env-file=.env.local src/main-scan.ts",
     "gen-image-prompt": "tsx --env-file=.env.local scripts/gen-image-prompt.ts",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "bootstrap": "tsx --env-file=.env.local scripts/bootstrap-voice.ts",
     "test-analyze": "tsx --env-file=.env.local scripts/test-analyze.ts",
     "webhook": "tsx --env-file=.env.local src/webhook/server.ts",
+    "worker": "tsx --env-file=.env.local src/worker/main-worker.ts",
     "poll": "tsx --env-file=.env.local src/main-poll.ts",
     "scan": "tsx --env-file=.env.local src/main-scan.ts",
     "gen-image-prompt": "tsx --env-file=.env.local scripts/gen-image-prompt.ts",

--- a/src/webhook/github-handler.ts
+++ b/src/webhook/github-handler.ts
@@ -1,0 +1,68 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+import { logger } from '../utils/logger.js';
+import { handleInstallation } from './handlers/installation.js';
+import { handlePush } from './handlers/push.js';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface WebhookDependencies {
+  readonly db: SupabaseClient;
+}
+
+/**
+ * Validates the GitHub webhook signature and routes the event to the
+ * appropriate handler. Returns an HTTP status code.
+ *
+ * GitHub sends: X-Hub-Signature-256: sha256=<hmac-sha256>
+ * We verify using timing-safe comparison to prevent timing attacks.
+ */
+export async function handleGithubWebhook(
+  event: string,
+  signature: string,
+  rawBody: string,
+  secret: string,
+  deps: WebhookDependencies,
+): Promise<{ status: number; body: string }> {
+  if (!validateSignature(secret, rawBody, signature)) {
+    logger.warn('webhook.invalid_signature', { event });
+    return { status: 401, body: 'Invalid signature' };
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    logger.warn('webhook.invalid_json', { event });
+    return { status: 400, body: 'Invalid JSON' };
+  }
+
+  logger.info('webhook.received', { event });
+
+  try {
+    switch (event) {
+      case 'installation':
+        await handleInstallation(payload, deps.db);
+        break;
+      case 'push':
+        await handlePush(payload, deps.db);
+        break;
+      default:
+        // Acknowledged but not processed — GitHub expects a 200
+        logger.info('webhook.ignored', { event });
+    }
+    return { status: 200, body: 'ok' };
+  } catch (err) {
+    logger.error('webhook.handler_error', { event, error: String(err) });
+    return { status: 500, body: 'Internal error' };
+  }
+}
+
+function validateSignature(secret: string, body: string, signature: string): boolean {
+  if (!signature.startsWith('sha256=')) return false;
+  const expected = `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
+  try {
+    return timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
+  } catch {
+    // Buffers of different length throw — means signature is invalid
+    return false;
+  }
+}

--- a/src/webhook/handlers/installation.ts
+++ b/src/webhook/handlers/installation.ts
@@ -1,0 +1,93 @@
+import { logger } from '../../utils/logger.js';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+interface InstallationAccount {
+  login: string;
+  type: string;
+}
+
+interface InstallationPayload {
+  action: string;
+  installation: {
+    id: number;
+    account: InstallationAccount;
+  };
+}
+
+function isInstallationPayload(value: unknown): value is InstallationPayload {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v['action'] !== 'string') return false;
+  const inst = v['installation'];
+  if (!inst || typeof inst !== 'object') return false;
+  const i = inst as Record<string, unknown>;
+  if (typeof i['id'] !== 'number') return false;
+  const acc = i['account'];
+  if (!acc || typeof acc !== 'object') return false;
+  const a = acc as Record<string, unknown>;
+  return typeof a['login'] === 'string';
+}
+
+/**
+ * Handles GitHub App installation events.
+ *
+ * created  → upsert tenant (safe to call multiple times)
+ * deleted  → mark tenant inactive (data preserved for potential re-install)
+ * suspend  → mark tenant inactive
+ * unsuspend → mark tenant active
+ */
+export async function handleInstallation(
+  payload: unknown,
+  db: SupabaseClient,
+): Promise<void> {
+  if (!isInstallationPayload(payload)) {
+    logger.warn('installation.invalid_payload');
+    return;
+  }
+
+  const { action, installation } = payload;
+  const installationId = installation.id;
+  const username = installation.account.login;
+
+  logger.info('installation.event', { action, installationId, username });
+
+  switch (action) {
+    case 'created': {
+      const { error } = await db.from('tenants').upsert(
+        {
+          github_installation_id: installationId,
+          github_username: username,
+          active: true,
+        },
+        { onConflict: 'github_installation_id' },
+      );
+      if (error) throw new Error(`Failed to upsert tenant: ${error.message}`);
+      logger.info('installation.tenant_created', { installationId, username });
+      break;
+    }
+
+    case 'deleted':
+    case 'suspend': {
+      const { error } = await db
+        .from('tenants')
+        .update({ active: false })
+        .eq('github_installation_id', installationId);
+      if (error) throw new Error(`Failed to deactivate tenant: ${error.message}`);
+      logger.info('installation.tenant_deactivated', { action, installationId });
+      break;
+    }
+
+    case 'unsuspend': {
+      const { error } = await db
+        .from('tenants')
+        .update({ active: true })
+        .eq('github_installation_id', installationId);
+      if (error) throw new Error(`Failed to reactivate tenant: ${error.message}`);
+      logger.info('installation.tenant_reactivated', { installationId });
+      break;
+    }
+
+    default:
+      logger.info('installation.action_ignored', { action });
+  }
+}

--- a/src/webhook/handlers/push.ts
+++ b/src/webhook/handlers/push.ts
@@ -1,0 +1,87 @@
+import { logger } from '../../utils/logger.js';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+interface PushPayload {
+  ref: string;
+  before: string;
+  after: string;
+  repository: { full_name: string };
+  installation: { id: number };
+}
+
+function isPushPayload(value: unknown): value is PushPayload {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v['ref'] !== 'string') return false;
+  if (typeof v['before'] !== 'string') return false;
+  if (typeof v['after'] !== 'string') return false;
+  const repo = v['repository'];
+  if (!repo || typeof repo !== 'object') return false;
+  if (typeof (repo as Record<string, unknown>)['full_name'] !== 'string') return false;
+  const inst = v['installation'];
+  if (!inst || typeof inst !== 'object') return false;
+  return typeof (inst as Record<string, unknown>)['id'] === 'number';
+}
+
+const ZERO_SHA = '0000000000000000000000000000000000000000';
+
+/**
+ * Handles push events from the GitHub App.
+ *
+ * Looks up the tenant by installation ID and enqueues a job.
+ * Skips branch deletions (after SHA is all zeros).
+ * Skips if tenant is not found or inactive.
+ */
+export async function handlePush(
+  payload: unknown,
+  db: SupabaseClient,
+): Promise<void> {
+  if (!isPushPayload(payload)) {
+    logger.warn('push.invalid_payload');
+    return;
+  }
+
+  const { ref, before, after, repository, installation } = payload;
+
+  // Branch deletion — no commits to process
+  if (after === ZERO_SHA) {
+    logger.info('push.branch_deleted', { ref, repo: repository.full_name });
+    return;
+  }
+
+  // Resolve tenant
+  const { data: tenant, error: tenantError } = await db
+    .from('tenants')
+    .select('id, active')
+    .eq('github_installation_id', installation.id)
+    .single();
+
+  if (tenantError || !tenant) {
+    logger.warn('push.tenant_not_found', { installationId: installation.id });
+    return;
+  }
+
+  if (!(tenant as { active: boolean }).active) {
+    logger.info('push.tenant_inactive', { installationId: installation.id });
+    return;
+  }
+
+  // Enqueue job
+  const { error: insertError } = await db.from('job_queue').insert({
+    tenant_id: (tenant as { id: string }).id,
+    repo: repository.full_name,
+    before_sha: before,
+    after_sha: after,
+    ref,
+  });
+
+  if (insertError) {
+    throw new Error(`Failed to enqueue job: ${insertError.message}`);
+  }
+
+  logger.info('push.job_enqueued', {
+    repo: repository.full_name,
+    ref,
+    after: after.slice(0, 7),
+  });
+}

--- a/src/webhook/server.ts
+++ b/src/webhook/server.ts
@@ -1,0 +1,75 @@
+import { createServer } from 'http';
+import { createClient } from '@supabase/supabase-js';
+import { handleGithubWebhook } from './github-handler.js';
+import { logger } from '../utils/logger.js';
+
+const PORT = parseInt(process.env['PORT'] ?? '3000', 10);
+const WEBHOOK_SECRET = process.env['GITHUB_WEBHOOK_SECRET'] ?? '';
+const SUPABASE_URL = process.env['SUPABASE_URL'] ?? '';
+const SUPABASE_SERVICE_ROLE_KEY = process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '';
+
+if (!WEBHOOK_SECRET) {
+  logger.error('server.missing_env', { var: 'GITHUB_WEBHOOK_SECRET' });
+  process.exit(1);
+}
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  logger.error('server.missing_env', { var: 'SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY' });
+  process.exit(1);
+}
+
+const db = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+const deps = { db };
+
+const server = createServer((req, res) => {
+  // Health check — Cloud Run requires this to mark the instance healthy
+  if (req.method === 'GET' && req.url === '/health') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('ok');
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/webhooks/github') {
+    const event = req.headers['x-github-event'];
+    const signature = req.headers['x-hub-signature-256'];
+
+    if (typeof event !== 'string' || typeof signature !== 'string') {
+      res.writeHead(400, { 'Content-Type': 'text/plain' });
+      res.end('Missing required headers');
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const rawBody = Buffer.concat(chunks).toString('utf8');
+      handleGithubWebhook(event, signature, rawBody, WEBHOOK_SECRET, deps)
+        .then(({ status, body }) => {
+          res.writeHead(status, { 'Content-Type': 'text/plain' });
+          res.end(body);
+        })
+        .catch((err: unknown) => {
+          logger.error('server.unhandled_error', { error: String(err) });
+          res.writeHead(500, { 'Content-Type': 'text/plain' });
+          res.end('Internal error');
+        });
+    });
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('Not found');
+});
+
+server.listen(PORT, () => {
+  logger.info('server.started', { port: PORT });
+});
+
+process.on('SIGTERM', () => {
+  logger.info('server.shutdown');
+  server.close(() => process.exit(0));
+});
+
+process.on('SIGINT', () => {
+  logger.info('server.shutdown');
+  server.close(() => process.exit(0));
+});

--- a/src/worker/github-app-auth.ts
+++ b/src/worker/github-app-auth.ts
@@ -1,0 +1,65 @@
+import { createSign } from 'crypto';
+import { logger } from '../utils/logger.js';
+
+interface InstallationTokenResponse {
+  token: string;
+  expires_at: string;
+}
+
+/**
+ * Creates a signed JWT for GitHub App authentication.
+ * JWT is valid for 10 minutes (GitHub maximum).
+ */
+function createAppJWT(appId: string, privateKey: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({
+    iss: appId,
+    iat: now - 60,   // 60s backdate to account for clock drift
+    exp: now + 600,  // 10 minute expiry
+  })).toString('base64url');
+
+  const sign = createSign('RSA-SHA256');
+  sign.update(`${header}.${payload}`);
+  const signature = sign.sign(privateKey, 'base64url');
+
+  return `${header}.${payload}.${signature}`;
+}
+
+/**
+ * Exchanges a GitHub App JWT for an installation access token.
+ * The installation token is valid for 1 hour and can be used
+ * as a bearer token with the GitHub API.
+ */
+export async function getInstallationToken(
+  appId: string,
+  privateKey: string,
+  installationId: number,
+): Promise<string> {
+  const jwt = createAppJWT(appId, privateKey);
+
+  const response = await fetch(
+    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${jwt}`,
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub App auth failed (${response.status}): ${body}`);
+  }
+
+  const data = await response.json() as InstallationTokenResponse;
+  logger.info('worker.installation_token_obtained', {
+    installationId,
+    expiresAt: data.expires_at,
+  });
+
+  return data.token;
+}

--- a/src/worker/main-worker.ts
+++ b/src/worker/main-worker.ts
@@ -1,0 +1,162 @@
+import { createClient } from '@supabase/supabase-js';
+import { logger } from '../utils/logger.js';
+import { processJob } from './process-job.js';
+import type { ProcessJobDeps } from './process-job.js';
+
+const POLL_INTERVAL_MS = 30_000;
+const MAX_ATTEMPTS = 3;
+
+const SUPABASE_URL = process.env['SUPABASE_URL'] ?? '';
+const SUPABASE_SERVICE_ROLE_KEY = process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '';
+const ANTHROPIC_API_KEY = process.env['ANTHROPIC_API_KEY'] ?? '';
+const GITHUB_APP_ID = process.env['GITHUB_APP_ID'] ?? '';
+const GITHUB_APP_PRIVATE_KEY = process.env['GITHUB_APP_PRIVATE_KEY'] ?? '';
+
+for (const [name, value] of [
+  ['SUPABASE_URL', SUPABASE_URL],
+  ['SUPABASE_SERVICE_ROLE_KEY', SUPABASE_SERVICE_ROLE_KEY],
+  ['ANTHROPIC_API_KEY', ANTHROPIC_API_KEY],
+  ['GITHUB_APP_ID', GITHUB_APP_ID],
+  ['GITHUB_APP_PRIVATE_KEY', GITHUB_APP_PRIVATE_KEY],
+] as [string, string][]) {
+  if (!value) {
+    logger.error('worker.missing_env', { var: name });
+    process.exit(1);
+  }
+}
+
+const db = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+const deps: ProcessJobDeps = {
+  db,
+  appId: GITHUB_APP_ID,
+  privateKey: GITHUB_APP_PRIVATE_KEY,
+  supabaseUrl: SUPABASE_URL,
+  supabaseServiceKey: SUPABASE_SERVICE_ROLE_KEY,
+  anthropicApiKey: ANTHROPIC_API_KEY,
+};
+
+/**
+ * Claims the oldest pending job by:
+ * 1. SELECT the candidate
+ * 2. UPDATE WHERE status='pending' (optimistic guard against race)
+ *
+ * With a single Cloud Run instance this race never occurs, but the guard
+ * is cheap and keeps the code correct if a second worker is ever added.
+ * Attempts are NOT incremented here — markFailed handles the increment.
+ */
+async function claimJob(): Promise<string | null> {
+  const { data: candidate, error: selectError } = await db
+    .from('job_queue')
+    .select('id')
+    .eq('status', 'pending')
+    .lt('attempts', MAX_ATTEMPTS)
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  if (selectError) {
+    logger.error('worker.claim.error', { error: selectError.message });
+    return null;
+  }
+  if (!candidate) return null;
+
+  const jobId = (candidate as { id: string }).id;
+
+  const { data: claimed, error: claimError } = await db
+    .from('job_queue')
+    .update({ status: 'processing' })
+    .eq('id', jobId)
+    .eq('status', 'pending')  // guard: only claim if still pending
+    .select('id')
+    .maybeSingle();
+
+  if (claimError) {
+    logger.error('worker.claim.update_error', { jobId, error: claimError.message });
+    return null;
+  }
+
+  return claimed ? (claimed as { id: string }).id : null;
+}
+
+async function markDone(jobId: string): Promise<void> {
+  const { error } = await db
+    .from('job_queue')
+    .update({ status: 'done', processed_at: new Date().toISOString() })
+    .eq('id', jobId);
+
+  if (error) logger.error('worker.mark_done.error', { jobId, error: error.message });
+}
+
+async function markFailed(jobId: string, errorMessage: string): Promise<void> {
+  // Fetch current attempts to increment and decide final status
+  const { data, error: fetchError } = await db
+    .from('job_queue')
+    .select('attempts')
+    .eq('id', jobId)
+    .single();
+
+  if (fetchError) {
+    logger.error('worker.mark_failed.fetch_error', { jobId, error: fetchError.message });
+    return;
+  }
+
+  const newAttempts = ((data as { attempts: number }).attempts) + 1;
+  const newStatus = newAttempts >= MAX_ATTEMPTS ? 'failed' : 'pending';
+
+  const { error } = await db
+    .from('job_queue')
+    .update({
+      status: newStatus,
+      attempts: newAttempts,
+      error: errorMessage,
+      ...(newStatus === 'failed' && { processed_at: new Date().toISOString() }),
+    })
+    .eq('id', jobId);
+
+  if (error) logger.error('worker.mark_failed.error', { jobId, error: error.message });
+  else logger.info('worker.job.marked_failed', { jobId, newAttempts, newStatus });
+}
+
+async function runOnce(): Promise<void> {
+  const jobId = await claimJob();
+  if (!jobId) return;
+
+  try {
+    await processJob(jobId, deps);
+    await markDone(jobId);
+  } catch (err) {
+    logger.error('worker.job.error', { jobId, error: String(err) });
+    await markFailed(jobId, String(err));
+  }
+}
+
+let running = true;
+
+async function main(): Promise<void> {
+  logger.info('worker.start', { pollIntervalMs: POLL_INTERVAL_MS, maxAttempts: MAX_ATTEMPTS });
+
+  while (running) {
+    await runOnce();
+    if (running) {
+      await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
+  }
+
+  logger.info('worker.stopped');
+}
+
+process.on('SIGTERM', () => {
+  logger.info('worker.shutdown');
+  running = false;
+});
+
+process.on('SIGINT', () => {
+  logger.info('worker.shutdown');
+  running = false;
+});
+
+main().catch((err) => {
+  logger.error('worker.fatal', { error: String(err) });
+  process.exit(1);
+});

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -1,0 +1,211 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { GitHubClient } from '../github/client.js';
+import { enrichCommit } from '../github/commit-enricher.js';
+import { isInteresting } from '../utils/commit-filter.js';
+import { runPipeline } from '../analysis/pipeline.js';
+import { MODULE_REGISTRY } from '../analysis/modules/index.js';
+import { AnthropicClient } from '../ai/client.js';
+import { generatePosts } from '../ai/post-generator.js';
+import { BufferClient } from '../buffer/client.js';
+import { publishToBuffer } from '../buffer/publisher.js';
+import { notifyNewDraft } from '../review/notifier.js';
+import { SupabaseStorage } from '../voice/supabase-storage.js';
+import { getInstallationToken } from './github-app-auth.js';
+import { logger } from '../utils/logger.js';
+import { ConfigSchema } from '../config/schema.js';
+import type { Config } from '../config/schema.js';
+
+interface TenantRow {
+  readonly id: string;
+  readonly github_installation_id: number;
+  readonly github_username: string;
+  readonly buffer_access_token: string | null;
+  readonly config: Record<string, unknown>;
+}
+
+interface JobRow {
+  readonly id: string;
+  readonly tenant_id: string;
+  readonly repo: string;
+  readonly before_sha: string;
+  readonly after_sha: string;
+  readonly ref: string;
+}
+
+export interface ProcessJobDeps {
+  readonly db: SupabaseClient;
+  readonly appId: string;
+  readonly privateKey: string;
+  readonly supabaseUrl: string;
+  readonly supabaseServiceKey: string;
+  readonly anthropicApiKey: string;
+}
+
+/**
+ * Builds a Config from a tenant row + its config JSONB.
+ * Uses 'UNCONFIGURED' as placeholder for buffer.organization_id when absent
+ * so Zod's min(1) constraint is satisfied — the caller checks
+ * buffer_access_token before attempting to publish.
+ */
+function buildConfig(tenant: TenantRow): Config {
+  const tc = tenant.config;
+  const result = ConfigSchema.safeParse({
+    buffer: { organization_id: 'UNCONFIGURED' },
+    platforms: {
+      linkedin: { enabled: true, buffer_profile_id: '' },
+      instagram: { enabled: false, buffer_profile_id: '' },
+    },
+    ...tc,
+    // author.github_username always comes from the tenants table, not JSONB
+    author: {
+      name: tenant.github_username,
+      ...((tc['author'] as Record<string, unknown> | undefined) ?? {}),
+      github_username: tenant.github_username,
+    },
+  });
+
+  if (!result.success) {
+    throw new Error(`Invalid config for tenant ${tenant.id}: ${result.error.message}`);
+  }
+
+  return result.data;
+}
+
+/**
+ * Processes a single job end-to-end:
+ * 1. Fetch job + tenant from DB
+ * 2. Get GitHub installation token
+ * 3. Compare commits in the push range
+ * 4. For each commit: filter → enrich → modules → Claude → Buffer
+ */
+export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<void> {
+  logger.info('worker.job.start', { jobId });
+
+  const { data: jobData, error: jobError } = await deps.db
+    .from('job_queue')
+    .select('id, tenant_id, repo, before_sha, after_sha, ref')
+    .eq('id', jobId)
+    .single();
+
+  if (jobError || !jobData) {
+    throw new Error(`Job ${jobId} not found: ${jobError?.message ?? 'no data'}`);
+  }
+  const job = jobData as JobRow;
+
+  const { data: tenantData, error: tenantError } = await deps.db
+    .from('tenants')
+    .select('id, github_installation_id, github_username, buffer_access_token, config')
+    .eq('id', job.tenant_id)
+    .single();
+
+  if (tenantError || !tenantData) {
+    throw new Error(`Tenant ${job.tenant_id} not found: ${tenantError?.message ?? 'no data'}`);
+  }
+  const tenant = tenantData as TenantRow;
+  const config = buildConfig(tenant);
+
+  logger.info('worker.job.tenant', {
+    jobId,
+    tenant: tenant.github_username,
+    repo: job.repo,
+    ref: job.ref,
+  });
+
+  // Installation token is valid for 1 hour — enough for one job
+  const installationToken = await getInstallationToken(
+    deps.appId,
+    deps.privateKey,
+    tenant.github_installation_id,
+  );
+
+  const github = new GitHubClient(installationToken);
+  const anthropic = new AnthropicClient(
+    deps.anthropicApiKey,
+    config.ai.model,
+    config.ai.max_tokens,
+  );
+  const storage = new SupabaseStorage(deps.supabaseUrl, deps.supabaseServiceKey);
+
+  const [owner, repo] = job.repo.split('/') as [string, string];
+
+  // Get the list of commits in this push range
+  const commits = await github.compareCommits(owner, repo, job.before_sha, job.after_sha);
+  logger.info('worker.job.commits', { jobId, count: commits.length });
+
+  for (const pushCommit of commits) {
+    logger.info('worker.commit.start', { sha: pushCommit.sha, repo: job.repo });
+
+    try {
+      const alreadyProcessed = await storage.hasDraft(pushCommit.sha, 'linkedin');
+      if (alreadyProcessed) {
+        logger.info('worker.commit.skip.duplicate', { sha: pushCommit.sha });
+        continue;
+      }
+
+      const commit = await enrichCommit(github, owner, repo, pushCommit.sha, tenant.github_username);
+
+      const filterResult = isInteresting(
+        {
+          sha: commit.sha,
+          message: commit.message,
+          authorLogin: commit.authorLogin,
+          totalAdditions: commit.totalAdditions,
+          totalDeletions: commit.totalDeletions,
+          repo: commit.repo,
+        },
+        {
+          excludeRepos: config.github.exclude_repos,
+          excludePatterns: config.github.exclude_patterns,
+          minChangedLines: config.posting.interesting_min_lines,
+        },
+      );
+
+      if (!filterResult.interesting) {
+        logger.info('worker.commit.skip.not_interesting', {
+          sha: commit.sha,
+          reason: filterResult.reason,
+        });
+        continue;
+      }
+
+      const findings = await runPipeline(
+        {
+          diffs: commit.diffs,
+          commitMessage: commit.message,
+          languages: commit.languages,
+          repo: commit.repo,
+          sha: commit.sha,
+        },
+        config.posting.analysis_top_n,
+        MODULE_REGISTRY,
+      );
+
+      if (findings.length === 0) {
+        logger.info('worker.commit.skip.no_findings', { sha: commit.sha });
+        continue;
+      }
+
+      const { bufferText, draftId } = await generatePosts(anthropic, commit, findings, storage, config);
+
+      // Only publish to Buffer if the tenant has configured their token
+      if (tenant.buffer_access_token) {
+        const bufferClient = new BufferClient(tenant.buffer_access_token);
+        const publishResult = await publishToBuffer(
+          bufferClient, storage, config, draftId, bufferText, commit.message,
+        );
+        if (publishResult) {
+          await notifyNewDraft(github, owner, repo, commit, [publishResult]);
+        }
+      } else {
+        logger.info('worker.commit.buffer_skipped', { sha: commit.sha, reason: 'no buffer token' });
+      }
+
+      logger.info('worker.commit.done', { sha: commit.sha });
+    } catch (err) {
+      // Per-commit errors are logged but don't abort the whole job
+      logger.error('worker.commit.error', { sha: pushCommit.sha, error: String(err) });
+    }
+  }
+
+  logger.info('worker.job.done', { jobId });
+}


### PR DESCRIPTION
## Summary

- **Webhook receiver** (Cloud Run): validates GitHub App HMAC-SHA256 signatures, routes `installation` and `push` events, upserts/deactivates tenants, enqueues jobs
- **Multi-tenant schema**: `tenants` + `job_queue` tables with RLS in Supabase
- **Worker**: polls `job_queue` every 30s, claims jobs atomically, runs the full pipeline (compareCommits → enrich → modules → Claude → Buffer) using per-tenant installation tokens
- **GitHub App auth**: RSA-SHA256 JWT → `POST /app/installations/{id}/access_tokens` → 1h bearer token
- **Dockerfile**: Node 20 Alpine for Cloud Run deployment

## Architecture

```
GitHub App webhook → Cloud Run (webhook/server.ts)
  → tenants upsert / job_queue insert

Cloud Run (worker/main-worker.ts) polls job_queue every 30s
  → getInstallationToken (JWT → GitHub API)
  → compareCommits → enrichCommit → runPipeline → generatePosts → publishToBuffer
```

## New files

| File | Purpose |
|------|---------|
| `src/webhook/server.ts` | HTTP server (no Express), `/health` + `/webhooks/github` |
| `src/webhook/github-handler.ts` | HMAC validation, event routing |
| `src/webhook/handlers/installation.ts` | Tenant upsert/deactivate on App events |
| `src/webhook/handlers/push.ts` | Job enqueue on push |
| `src/worker/github-app-auth.ts` | JWT signing + installation token exchange |
| `src/worker/process-job.ts` | Single job: token → compareCommits → full pipeline |
| `src/worker/main-worker.ts` | Polling loop, atomic claim, retry up to 3x |
| `Dockerfile` | Cloud Run image (Node 20 Alpine + tsx) |
| `database/schema.sql` | `tenants` + `job_queue` tables |

## Test plan

- [ ] Merge and deploy webhook to Cloud Run (`gcloud run deploy`)
- [ ] Trigger a push to any monitored repo → verify row in `job_queue`
- [ ] Run worker locally (`npm run worker`) → verify job processes end-to-end
- [ ] Simulate installation deleted → verify tenant `active=false`
- [ ] Simulate job failure → verify `attempts` increments, status becomes `failed` after 3x