### PR TITLE
feat: freshness multiplier to reduce post repetition

### DIFF
--- a/src/ai/post-generator.ts
+++ b/src/ai/post-generator.ts
@@ -43,6 +43,7 @@ export async function generatePosts(
   const { post, shortPost } = parseResponse(rawResponse);
 
   const topFinding = findings[0]?.finding;
+  const topModuleId = findings[0]?.moduleId;
   const findingsCount = findings.length;
 
   // One record per commit — ai_draft stores the full post for voice training
@@ -52,6 +53,7 @@ export async function generatePosts(
     platform: 'linkedin',
     ai_draft: post,
     top_finding: topFinding,
+    top_module_id: topModuleId,
     findings_count: findingsCount,
   });
 

--- a/src/analysis/pipeline.ts
+++ b/src/analysis/pipeline.ts
@@ -15,6 +15,7 @@ export async function runPipeline(
   ctx: AnalysisContext,
   topN = 3,
   modules: CodeAnalyzer[] = MODULE_REGISTRY,
+  recentModuleIds: string[] = [],
 ): Promise<Finding[]> {
   const applicableModules = modules.filter(mod => {
     if (!mod.applicableLanguages) return true;
@@ -52,17 +53,34 @@ export async function runPipeline(
     }
   }
 
+  // Freshness multiplier: penalise modules that fired recently.
+  // adjustedScore = interestScore / (fires_in_window + 1)
+  // A module that fired 3 times recently gets score ÷ 4, making room for others.
+  const fireCounts = new Map<string, number>();
+  for (const id of recentModuleIds) {
+    fireCounts.set(id, (fireCounts.get(id) ?? 0) + 1);
+  }
+
   const MIN_INTEREST_SCORE = 5;
   const sorted = findings
     .filter((f) => f.interestScore >= MIN_INTEREST_SCORE)
-    .sort((a, b) => b.interestScore - a.interestScore);
+    .map((f) => ({
+      finding: f,
+      adjustedScore: f.interestScore / ((fireCounts.get(f.moduleId) ?? 0) + 1),
+    }))
+    .sort((a, b) => b.adjustedScore - a.adjustedScore)
+    .map((x) => x.finding);
   const top = sorted.slice(0, topN);
 
   logger.info('analysis.pipeline.done', {
     sha: ctx.sha,
     findingsTotal: findings.length,
     findingsSelected: top.length,
-    scores: top.map(f => ({ module: f.moduleId, score: f.interestScore })),
+    scores: top.map(f => ({
+      module: f.moduleId,
+      score: f.interestScore,
+      adjusted: f.interestScore / ((fireCounts.get(f.moduleId) ?? 0) + 1),
+    })),
   });
 
   return top;

--- a/src/main-poll.ts
+++ b/src/main-poll.ts
@@ -104,11 +104,13 @@ async function main(): Promise<void> {
         continue;
       }
 
-      // Run analysis modules
+      // Run analysis modules (freshness multiplier uses last 30 days of module history)
+      const recentModuleIds = await storage.getRecentModuleIds(30);
       const findings = await runPipeline(
         { diffs: commit.diffs, commitMessage: commit.message, languages: commit.languages, repo: commit.repo, sha: commit.sha },
         config.posting.analysis_top_n,
         modules,
+        recentModuleIds,
       );
 
       if (findings.length === 0) {

--- a/src/voice/sqlite-storage.ts
+++ b/src/voice/sqlite-storage.ts
@@ -49,6 +49,7 @@ export class SqliteStorage implements IVoiceStorage {
       ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS linkedin_urn     TEXT;
       ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS reactions_count  INTEGER NOT NULL DEFAULT 0;
       ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS engagement_score REAL;
+      ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS top_module_id    TEXT;
 
       CREATE UNIQUE INDEX IF NOT EXISTS idx_sha_platform
         ON voice_posts(commit_sha, platform);
@@ -81,11 +82,20 @@ export class SqliteStorage implements IVoiceStorage {
   saveDraft(input: SaveDraftInput): Promise<string> {
     const id = randomUUID();
     this.db.prepare(`
-      INSERT INTO voice_posts (id, commit_sha, repo, platform, ai_draft, top_finding, findings_count, status)
-      VALUES (?, ?, ?, ?, ?, ?, ?, 'pending')
+      INSERT INTO voice_posts (id, commit_sha, repo, platform, ai_draft, top_finding, top_module_id, findings_count, status)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending')
     `).run(id, input.commit_sha, input.repo, input.platform, input.ai_draft,
-           input.top_finding ?? null, input.findings_count ?? 0);
+           input.top_finding ?? null, input.top_module_id ?? null, input.findings_count ?? 0);
     return Promise.resolve(id);
+  }
+
+  getRecentModuleIds(days: number): Promise<string[]> {
+    const rows = this.db.prepare(`
+      SELECT top_module_id FROM voice_posts
+      WHERE created_at >= datetime('now', '-' || ? || ' days')
+        AND top_module_id IS NOT NULL
+    `).all(days) as { top_module_id: string }[];
+    return Promise.resolve(rows.map((r) => r.top_module_id));
   }
 
   updatePublished(input: UpdatePublishedInput): Promise<void> {

--- a/src/voice/storage.ts
+++ b/src/voice/storage.ts
@@ -27,6 +27,7 @@ export interface SaveDraftInput {
   platform: Platform;
   ai_draft: string;
   top_finding?: string;
+  top_module_id?: string;
   findings_count?: number;
 }
 
@@ -85,6 +86,12 @@ export interface IVoiceStorage {
 
   /** Check if a commit SHA + platform already has a processed post. */
   hasDraft(commit_sha: string, platform: Platform): Promise<boolean>;
+
+  /**
+   * Returns the top_module_id values for posts created in the last `days` days.
+   * Used by the pipeline to apply the freshness multiplier to recently-fired modules.
+   */
+  getRecentModuleIds(days: number): Promise<string[]>;
 
   /** Get all posts with status='queued' for a given platform. */
   getQueuedPosts(platform: Platform): Promise<VoicePost[]>;

--- a/src/voice/supabase-storage.ts
+++ b/src/voice/supabase-storage.ts
@@ -27,6 +27,7 @@ export class SupabaseStorage implements IVoiceStorage {
         platform: input.platform,
         ai_draft: input.ai_draft,
         top_finding: input.top_finding ?? null,
+        top_module_id: input.top_module_id ?? null,
         findings_count: input.findings_count ?? 0,
         status: 'pending' satisfies PostStatus,
       })
@@ -125,6 +126,18 @@ export class SupabaseStorage implements IVoiceStorage {
 
     if (error) throw new Error(`getRecentPublished failed: ${error.message}`);
     return (data ?? []) as VoicePost[];
+  }
+
+  async getRecentModuleIds(days: number): Promise<string[]> {
+    const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+    const { data, error } = await this.db
+      .from('voice_posts')
+      .select('top_module_id')
+      .gte('created_at', since)
+      .not('top_module_id', 'is', null);
+
+    if (error) throw new Error(`getRecentModuleIds failed: ${error.message}`);
+    return (data ?? []).map((r) => (r as { top_module_id: string }).top_module_id);
   }
 
   async hasDraft(commit_sha: string, platform: Platform): Promise<boolean> {

--- a/src/worker/main-worker.ts
+++ b/src/worker/main-worker.ts
@@ -3,7 +3,6 @@ import { logger } from '../utils/logger.js';
 import { processJob } from './process-job.js';
 import type { ProcessJobDeps } from './process-job.js';
 
-const POLL_INTERVAL_MS = 30_000;
 const MAX_ATTEMPTS = 3;
 
 const SUPABASE_URL = process.env['SUPABASE_URL'] ?? '';
@@ -41,8 +40,6 @@ const deps: ProcessJobDeps = {
  * 1. SELECT the candidate
  * 2. UPDATE WHERE status='pending' (optimistic guard against race)
  *
- * With a single Cloud Run instance this race never occurs, but the guard
- * is cheap and keeps the code correct if a second worker is ever added.
  * Attempts are NOT incremented here — markFailed handles the increment.
  */
 async function claimJob(): Promise<string | null> {
@@ -67,7 +64,7 @@ async function claimJob(): Promise<string | null> {
     .from('job_queue')
     .update({ status: 'processing' })
     .eq('id', jobId)
-    .eq('status', 'pending')  // guard: only claim if still pending
+    .eq('status', 'pending')
     .select('id')
     .maybeSingle();
 
@@ -89,7 +86,6 @@ async function markDone(jobId: string): Promise<void> {
 }
 
 async function markFailed(jobId: string, errorMessage: string): Promise<void> {
-  // Fetch current attempts to increment and decide final status
   const { data, error: fetchError } = await db
     .from('job_queue')
     .select('attempts')
@@ -118,43 +114,34 @@ async function markFailed(jobId: string, errorMessage: string): Promise<void> {
   else logger.info('worker.job.marked_failed', { jobId, newAttempts, newStatus });
 }
 
-async function runOnce(): Promise<void> {
-  const jobId = await claimJob();
-  if (!jobId) return;
+/**
+ * Processes all pending jobs in one pass, then exits.
+ * Cloud Scheduler triggers this via Cloud Run Jobs every minute.
+ */
+async function processAllPending(): Promise<void> {
+  let processed = 0;
 
-  try {
-    await processJob(jobId, deps);
-    await markDone(jobId);
-  } catch (err) {
-    logger.error('worker.job.error', { jobId, error: String(err) });
-    await markFailed(jobId, String(err));
-  }
-}
+  while (true) {
+    const jobId = await claimJob();
+    if (!jobId) break;
 
-let running = true;
-
-async function main(): Promise<void> {
-  logger.info('worker.start', { pollIntervalMs: POLL_INTERVAL_MS, maxAttempts: MAX_ATTEMPTS });
-
-  while (running) {
-    await runOnce();
-    if (running) {
-      await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    try {
+      await processJob(jobId, deps);
+      await markDone(jobId);
+      processed++;
+    } catch (err) {
+      logger.error('worker.job.error', { jobId, error: String(err) });
+      await markFailed(jobId, String(err));
     }
   }
 
-  logger.info('worker.stopped');
+  logger.info('worker.run.complete', { processed });
 }
 
-process.on('SIGTERM', () => {
-  logger.info('worker.shutdown');
-  running = false;
-});
-
-process.on('SIGINT', () => {
-  logger.info('worker.shutdown');
-  running = false;
-});
+async function main(): Promise<void> {
+  logger.info('worker.start', { maxAttempts: MAX_ATTEMPTS });
+  await processAllPending();
+}
 
 main().catch((err) => {
   logger.error('worker.fatal', { error: String(err) });

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -168,6 +168,7 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
         continue;
       }
 
+      const recentModuleIds = await storage.getRecentModuleIds(30);
       const findings = await runPipeline(
         {
           diffs: commit.diffs,
@@ -178,6 +179,7 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
         },
         config.posting.analysis_top_n,
         MODULE_REGISTRY,
+        recentModuleIds,
       );
 
       if (findings.length === 0) {


### PR DESCRIPTION
## Summary

- **Freshness multiplier** in `pipeline.ts`: modules that fired recently are penalised so less-seen modules get a chance to surface
- **`top_module_id` column** in `voice_posts`: tracks which module produced the top finding per post — required for the multiplier history query
- **`getRecentModuleIds(days)`** added to `IVoiceStorage` (both SQLite and Supabase implementations)
- **Worker fix**: `main-worker.ts` corrected to run-once mode (process all pending jobs → exit), required for Cloud Run Jobs

## How the multiplier works

```
adjustedScore = interestScore / (fires_in_last_30d + 1)
```

A module (`performance`) that fired 3 times in the last 30 days gets its score divided by 4, giving space to modules that haven't appeared recently. Modules with 0 recent fires are unaffected (÷1).

## Supabase migration (already applied)

```sql
ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS top_module_id TEXT;
```

## Files changed

| File | Change |
|------|--------|
| `src/analysis/pipeline.ts` | Freshness multiplier in ranking |
| `src/voice/storage.ts` | `top_module_id` in `SaveDraftInput` + `getRecentModuleIds` interface |
| `src/voice/supabase-storage.ts` | Store `top_module_id` + implement `getRecentModuleIds` |
| `src/voice/sqlite-storage.ts` | Migration + store `top_module_id` + implement `getRecentModuleIds` |
| `src/ai/post-generator.ts` | Pass `findings[0].moduleId` as `top_module_id` when saving draft |
| `src/main-poll.ts` | Fetch `recentModuleIds(30)` and pass to `runPipeline` |
| `src/worker/process-job.ts` | Same |
| `src/worker/main-worker.ts` | Fix: run-once mode (was polling loop, incompatible with Cloud Run Jobs) |

## Test plan

- [ ] Merge and redeploy worker image (`gcloud builds submit` + `gcloud run jobs update`)
- [ ] Trigger multiple commits from the same repo → verify `top_module_id` is populated in `voice_posts`
- [ ] After several posts with the same module, verify a different module surfaces in the next run (check `analysis.pipeline.done` log: `adjusted` score should differ from `score`)