### PR TITLE
feat: inject module history into Claude prompt for post variety

### DIFF
--- a/src/ai/post-generator.ts
+++ b/src/ai/post-generator.ts
@@ -23,6 +23,7 @@ export async function generatePosts(
   findings: Finding[],
   storage: IVoiceStorage,
   config: Config,
+  recentModuleIds: string[] = [],
 ): Promise<GeneratedPosts> {
   if (findings.length === 0) {
     throw new Error('generatePosts called with 0 findings — caller should skip this call');
@@ -34,7 +35,7 @@ export async function generatePosts(
   const voiceExamples = selectVoiceExamples(voicePool, findings, config.posting.voice_examples_count);
 
   const systemPrompt = buildSystemPrompt(config);
-  const userPrompt = buildUserPrompt(commit, findings, voiceExamples, config);
+  const userPrompt = buildUserPrompt(commit, findings, voiceExamples, config, recentModuleIds);
 
   logger.info('ai.generate.start', { sha: commit.sha, repo: commit.repo, findings: findings.length });
 

--- a/src/ai/prompt-builder.ts
+++ b/src/ai/prompt-builder.ts
@@ -111,6 +111,7 @@ export function buildUserPrompt(
   findings: Finding[],
   voiceExamples: VoicePost[],
   config: Config,
+  recentModuleIds: string[] = [],
 ): string {
   const parts: string[] = [];
 
@@ -155,6 +156,22 @@ export function buildUserPrompt(
     parts.push('</finding>');
   }
   parts.push('</module_findings>\n');
+
+  // Module variety hint — tells Claude which topics have appeared recently
+  if (recentModuleIds.length > 0) {
+    const counts = new Map<string, number>();
+    for (const id of recentModuleIds) {
+      counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
+    const ranked = [...counts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([id, n]) => (n > 1 ? `${id} ×${n}` : id))
+      .join(', ');
+    parts.push(`<module_variety_hint>
+Recent posts covered these analysis modules (most frequent first): ${ranked}.
+If the top finding above is from a frequently repeated module, use a fresh angle — different metaphor, different structural pattern, or highlight a different aspect. The technical content differs, but repeated framing makes posts feel similar.
+</module_variety_hint>\n`);
+  }
 
   // Task at BOTTOM
   const websiteRef = config.author.website

--- a/src/main-poll.ts
+++ b/src/main-poll.ts
@@ -120,7 +120,7 @@ async function main(): Promise<void> {
 
       // Generate post (ONE Claude call — returns full post + Twitter short variant)
       const { bufferText, draftId } = await generatePosts(
-        anthropic, commit, findings, storage, config,
+        anthropic, commit, findings, storage, config, recentModuleIds,
       );
 
       // Publish ONE Buffer Idea with both variants in the text

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -187,7 +187,7 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
         continue;
       }
 
-      const { bufferText, draftId } = await generatePosts(anthropic, commit, findings, storage, config);
+      const { bufferText, draftId } = await generatePosts(anthropic, commit, findings, storage, config, recentModuleIds);
 
       // Only publish to Buffer if the tenant has configured their token
       if (tenant.buffer_access_token) {


### PR DESCRIPTION
## Summary

Completes Phase 0 variety fix. The freshness multiplier (PR #49) penalises repeated modules at the ranking level. This PR tells Claude *which modules appeared recently* so it can vary the framing even when the same module fires.

## What gets injected

When `recentModuleIds` is non-empty, a `<module_variety_hint>` section is inserted just before `<task>` in the user prompt:

```
<module_variety_hint>
Recent posts covered these analysis modules (most frequent first): performance ×3, observability ×1.
If the top finding above is from a frequently repeated module, use a fresh angle — different metaphor, different structural pattern, or highlight a different aspect.
</module_variety_hint>
```

## Files changed

| File | Change |
|------|--------|
| `src/ai/prompt-builder.ts` | Build `<module_variety_hint>` from `recentModuleIds[]` |
| `src/ai/post-generator.ts` | Accept and pass `recentModuleIds` to `buildUserPrompt` |
| `src/main-poll.ts` | Pass already-fetched `recentModuleIds` to `generatePosts` |
| `src/worker/process-job.ts` | Same |

## Test plan

- [ ] Trigger commit → check Buffer draft doesn't repeat the same structure as last post on the same module
- [ ] Verify `<module_variety_hint>` appears in prompt when there's history (add debug log or check token count)