### PR TITLE
feat: LinkedIn OAuth + onboarding UI for marketplace

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -70,7 +70,10 @@ CREATE TABLE IF NOT EXISTS tenants (
   github_username         TEXT NOT NULL UNIQUE,    -- installing user/org login
   plan                    TEXT NOT NULL DEFAULT 'free',
   active                  BOOLEAN NOT NULL DEFAULT TRUE,
-  buffer_access_token     TEXT,                    -- encrypted, set during onboarding
+  buffer_access_token     TEXT,                    -- set during onboarding (paste API key)
+  linkedin_access_token   TEXT,                    -- OAuth 2.0 access token
+  linkedin_member_id      TEXT,                    -- urn:li:person:{id}
+  linkedin_token_expires_at TIMESTAMPTZ,           -- token TTL (~2 months)
   config                  JSONB NOT NULL DEFAULT '{}',
   voice_bootstrap         TEXT                     -- raw posts pasted during onboarding
 );
@@ -115,6 +118,10 @@ ALTER TABLE job_queue        ENABLE ROW LEVEL SECURITY;
 ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS linkedin_urn     TEXT;
 ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS reactions_count  INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS engagement_score REAL;
+
+ALTER TABLE tenants ADD COLUMN IF NOT EXISTS linkedin_access_token     TEXT;
+ALTER TABLE tenants ADD COLUMN IF NOT EXISTS linkedin_member_id        TEXT;
+ALTER TABLE tenants ADD COLUMN IF NOT EXISTS linkedin_token_expires_at TIMESTAMPTZ;
 
 DROP INDEX IF EXISTS idx_voice_retrieval;
 CREATE INDEX IF NOT EXISTS idx_voice_retrieval

--- a/src/ai/post-generator.ts
+++ b/src/ai/post-generator.ts
@@ -8,7 +8,9 @@ import type { EnrichedCommit } from '../github/commit-enricher.js';
 import type { Config } from '../config/schema.js';
 
 export interface GeneratedPosts {
-  bufferText: string;
+  linkedinPost: string;   // clean LinkedIn text for direct posting
+  shortPost: string;      // short variant for Twitter/X
+  bufferText: string;     // combined text for Buffer Idea
   draftId: string;
 }
 
@@ -63,7 +65,7 @@ export async function generatePosts(
 
   logger.info('ai.generate.done', { sha: commit.sha, draftId });
 
-  return { bufferText, draftId };
+  return { linkedinPost: post, shortPost, bufferText, draftId };
 }
 
 function parseResponse(raw: string): { post: string; shortPost: string } {

--- a/src/linkedin/client.ts
+++ b/src/linkedin/client.ts
@@ -1,0 +1,83 @@
+import { withRetry, GITHUB_RETRY_POLICY } from '../utils/retry.js';
+import { logger } from '../utils/logger.js';
+
+const LINKEDIN_API = 'https://api.linkedin.com';
+const LINKEDIN_VERSION = '202501';
+
+export class LinkedInAuthExpiredError extends Error {
+  constructor() {
+    super('LinkedIn access token expired — user must re-authorize');
+    this.name = 'LinkedInAuthExpiredError';
+  }
+}
+
+export interface LinkedInPostResult {
+  readonly id: string;  // LinkedIn post URN
+}
+
+/**
+ * Posts text content directly to LinkedIn on behalf of an authenticated member.
+ * Uses the LinkedIn Posts API (v202501).
+ */
+export class LinkedInClient {
+  constructor(private readonly accessToken: string) {}
+
+  async post(memberUrn: string, text: string): Promise<LinkedInPostResult> {
+    return withRetry(async () => {
+      const response = await fetch(`${LINKEDIN_API}/rest/posts`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${this.accessToken}`,
+          'LinkedIn-Version': LINKEDIN_VERSION,
+          'X-Restli-Protocol-Version': '2.0.0',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          author: memberUrn,
+          lifecycleState: 'PUBLISHED',
+          visibility: 'PUBLIC',
+          commentary: text,
+          distribution: {
+            feedDistribution: 'MAIN_FEED',
+            targetEntities: [],
+            thirdPartyDistributionChannels: [],
+          },
+        }),
+      });
+
+      if (response.status === 401) throw new LinkedInAuthExpiredError();
+      if (response.status === 429) throw new Error('LinkedIn rate limited');
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`LinkedIn post failed (${response.status}): ${body}`);
+      }
+
+      // LinkedIn returns the post URN in the X-RestLi-Id header
+      const postUrn = response.headers.get('x-restli-id') ?? response.headers.get('X-RestLi-Id') ?? '';
+      logger.info('linkedin.post.created', { memberUrn, postUrn });
+      return { id: postUrn };
+    }, GITHUB_RETRY_POLICY, 'linkedin.post');
+  }
+
+  /**
+   * Fetches the authenticated member's profile to get their member ID.
+   * Required once after OAuth to store the URN for future posts.
+   */
+  async getMemberUrn(): Promise<string> {
+    const response = await fetch(`${LINKEDIN_API}/v2/userinfo`, {
+      headers: {
+        'Authorization': `Bearer ${this.accessToken}`,
+        'LinkedIn-Version': LINKEDIN_VERSION,
+      },
+    });
+
+    if (response.status === 401) throw new LinkedInAuthExpiredError();
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`LinkedIn userinfo failed (${response.status}): ${body}`);
+    }
+
+    const data = await response.json() as { sub: string };
+    return `urn:li:person:${data.sub}`;
+  }
+}

--- a/src/webhook/handlers/linkedin-oauth.ts
+++ b/src/webhook/handlers/linkedin-oauth.ts
@@ -1,0 +1,134 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+import { logger } from '../../utils/logger.js';
+import { LinkedInClient } from '../../linkedin/client.js';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+const LINKEDIN_AUTH_URL = 'https://www.linkedin.com/oauth/v2/authorization';
+const LINKEDIN_TOKEN_URL = 'https://www.linkedin.com/oauth/v2/accessToken';
+const SCOPES = 'openid profile w_member_social';
+
+function createState(installationId: number, secret: string): string {
+  const id = String(installationId);
+  const sig = createHmac('sha256', secret).update(id).digest('base64url');
+  return `${id}.${sig}`;
+}
+
+function parseState(state: string, secret: string): number | null {
+  const dot = state.lastIndexOf('.');
+  if (dot === -1) return null;
+  const id = state.slice(0, dot);
+  const sig = state.slice(dot + 1);
+  const expected = createHmac('sha256', secret).update(id).digest('base64url');
+  try {
+    const sigBuf = Buffer.from(sig, 'base64url');
+    const expBuf = Buffer.from(expected, 'base64url');
+    if (sigBuf.length !== expBuf.length) return null;
+    if (!timingSafeEqual(sigBuf, expBuf)) return null;
+  } catch {
+    return null;
+  }
+  const n = parseInt(id, 10);
+  return isNaN(n) ? null : n;
+}
+
+/**
+ * Builds the LinkedIn OAuth authorization URL and redirects the user.
+ */
+export function handleLinkedInRedirect(
+  installationId: number,
+  webhookSecret: string,
+  clientId: string,
+  appBaseUrl: string,
+): string {
+  const state = createState(installationId, webhookSecret);
+  const redirectUri = `${appBaseUrl}/auth/linkedin/callback`;
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    state,
+    scope: SCOPES,
+  });
+
+  return `${LINKEDIN_AUTH_URL}?${params.toString()}`;
+}
+
+interface TokenResponse {
+  access_token: string;
+  expires_in: number;
+  refresh_token?: string;
+}
+
+/**
+ * Handles the LinkedIn OAuth callback:
+ * 1. Validates state (CSRF guard)
+ * 2. Exchanges code for token
+ * 3. Fetches member URN
+ * 4. Stores token + member_id in tenant row
+ */
+export async function handleLinkedInCallback(
+  code: string,
+  state: string,
+  webhookSecret: string,
+  clientId: string,
+  clientSecret: string,
+  appBaseUrl: string,
+  db: SupabaseClient,
+): Promise<{ status: number; location: string }> {
+  const installationId = parseState(state, webhookSecret);
+  if (!installationId) {
+    logger.warn('linkedin.callback.invalid_state');
+    return { status: 302, location: '/onboard?error=invalid_state' };
+  }
+
+  // Exchange code for token
+  const tokenRes = await fetch(LINKEDIN_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: `${appBaseUrl}/auth/linkedin/callback`,
+      client_id: clientId,
+      client_secret: clientSecret,
+    }).toString(),
+  });
+
+  if (!tokenRes.ok) {
+    const body = await tokenRes.text();
+    logger.error('linkedin.callback.token_exchange_failed', { status: tokenRes.status, body });
+    return { status: 302, location: `/onboard?installation_id=${installationId}&error=linkedin_token_failed` };
+  }
+
+  const tokenData = await tokenRes.json() as TokenResponse;
+  const expiresAt = new Date(Date.now() + tokenData.expires_in * 1000).toISOString();
+
+  // Fetch member URN
+  let memberUrn: string;
+  try {
+    const client = new LinkedInClient(tokenData.access_token);
+    memberUrn = await client.getMemberUrn();
+  } catch (err) {
+    logger.error('linkedin.callback.member_fetch_failed', { error: String(err) });
+    return { status: 302, location: `/onboard?installation_id=${installationId}&error=linkedin_profile_failed` };
+  }
+
+  // Store in tenant
+  const { error } = await db
+    .from('tenants')
+    .update({
+      linkedin_access_token: tokenData.access_token,
+      linkedin_member_id: memberUrn,
+      linkedin_token_expires_at: expiresAt,
+    })
+    .eq('github_installation_id', installationId);
+
+  if (error) {
+    logger.error('linkedin.callback.save_failed', { installationId, error: error.message });
+    return { status: 302, location: `/onboard?installation_id=${installationId}&error=save_failed` };
+  }
+
+  logger.info('linkedin.callback.connected', { installationId, memberUrn });
+  return { status: 302, location: `/onboard?installation_id=${installationId}&saved=1` };
+}

--- a/src/webhook/handlers/onboard.ts
+++ b/src/webhook/handlers/onboard.ts
@@ -1,0 +1,188 @@
+import { logger } from '../../utils/logger.js';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+interface TenantRow {
+  readonly id: string;
+  readonly github_username: string;
+  readonly buffer_access_token: string | null;
+  readonly linkedin_member_id: string | null;
+  readonly config: Record<string, unknown>;
+}
+
+function maskToken(token: string | null): string {
+  if (!token) return '';
+  return token.slice(0, 6) + '••••••••';
+}
+
+function html(tenant: TenantRow, installationId: number, linkedinClientId: string, appBaseUrl: string, saved: boolean): string {
+  const cfg = tenant.config;
+  const author = (cfg['author'] as Record<string, unknown> | undefined) ?? {};
+  const buffer = (cfg['buffer'] as Record<string, unknown> | undefined) ?? {};
+
+  const name = (author['name'] as string | undefined) ?? tenant.github_username;
+  const website = (author['website'] as string | undefined) ?? '';
+  const bufferOrgId = (buffer['organization_id'] as string | undefined) ?? '';
+
+  const linkedinConnected = !!tenant.linkedin_member_id;
+  const linkedinSection = linkedinConnected
+    ? `<p class="connected">✓ LinkedIn connected</p>
+       <a href="/auth/linkedin?installation_id=${installationId}" class="link-small">Reconnect</a>`
+    : `<a href="/auth/linkedin?installation_id=${installationId}" class="btn-linkedin">Connect LinkedIn</a>
+       <p class="hint">Allows devcast to post directly to your LinkedIn feed.</p>`;
+
+  const banner = saved
+    ? `<div class="banner">Saved successfully.</div>`
+    : '';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>devcast — Setup</title>
+  <style>
+    *{box-sizing:border-box}
+    body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;max-width:540px;margin:60px auto;padding:0 20px;color:#111;line-height:1.5}
+    h1{font-size:1.4rem;margin-bottom:2px}
+    .sub{color:#666;margin-top:0;margin-bottom:28px}
+    .section{margin-bottom:28px}
+    .section-title{font-weight:600;font-size:.95rem;border-bottom:1px solid #eee;padding-bottom:6px;margin-bottom:14px}
+    label{display:block;font-size:.85rem;font-weight:500;margin-bottom:3px}
+    input{width:100%;padding:8px 10px;border:1px solid #ccc;border-radius:6px;font-size:.9rem;margin-bottom:14px}
+    .hint{font-size:.78rem;color:#888;margin-top:-10px;margin-bottom:14px}
+    .optional{color:#aaa;font-weight:400;font-size:.78rem;margin-left:3px}
+    button{background:#000;color:#fff;border:none;padding:9px 20px;border-radius:6px;font-size:.9rem;cursor:pointer}
+    button:hover{background:#333}
+    .btn-linkedin{display:inline-block;background:#0077B5;color:#fff;padding:9px 20px;border-radius:6px;font-size:.9rem;text-decoration:none}
+    .btn-linkedin:hover{background:#005f8e}
+    .connected{color:#16a34a;font-weight:500;margin:0}
+    .link-small{font-size:.8rem;color:#666}
+    .banner{background:#f0fdf4;border:1px solid #bbf7d0;color:#166534;padding:10px 14px;border-radius:6px;margin-bottom:20px;font-size:.875rem}
+  </style>
+</head>
+<body>
+  <h1>devcast setup</h1>
+  <p class="sub">GitHub account: <strong>${tenant.github_username}</strong></p>
+  ${banner}
+  <form method="POST" action="/onboard">
+    <input type="hidden" name="installation_id" value="${installationId}">
+
+    <div class="section">
+      <div class="section-title">About you</div>
+      <label>Name <span class="optional">(used in posts)</span></label>
+      <input type="text" name="name" value="${name}" placeholder="Your Name" required>
+      <label>Website <span class="optional">optional</span></label>
+      <input type="url" name="website" value="${website}" placeholder="https://yoursite.com">
+    </div>
+
+    <div class="section">
+      <div class="section-title">Buffer <span class="optional">optional</span></div>
+      <label>API key</label>
+      <input type="text" name="buffer_access_token" value="${maskToken(tenant.buffer_access_token)}" placeholder="Paste your Buffer API key">
+      <p class="hint">Get it at publish.buffer.com → Settings → API</p>
+      <label>Organization ID</label>
+      <input type="text" name="buffer_org_id" value="${bufferOrgId}" placeholder="org_...">
+      <p class="hint">Required to create Buffer Ideas. Leave blank if using LinkedIn direct only.</p>
+    </div>
+
+    <button type="submit">Save</button>
+  </form>
+
+  <div class="section" style="margin-top:32px">
+    <div class="section-title">LinkedIn</div>
+    ${linkedinSection}
+  </div>
+</body>
+</html>`;
+}
+
+export async function handleOnboardGet(
+  installationId: number,
+  db: SupabaseClient,
+  linkedinClientId: string,
+  appBaseUrl: string,
+  saved: boolean,
+): Promise<{ status: number; body: string; contentType: string }> {
+  const { data, error } = await db
+    .from('tenants')
+    .select('id, github_username, buffer_access_token, linkedin_member_id, config')
+    .eq('github_installation_id', installationId)
+    .single();
+
+  if (error || !data) {
+    logger.warn('onboard.tenant_not_found', { installationId });
+    return {
+      status: 404,
+      body: '<h1>Installation not found</h1><p>Make sure you installed the GitHub App first.</p>',
+      contentType: 'text/html',
+    };
+  }
+
+  return {
+    status: 200,
+    body: html(data as TenantRow, installationId, linkedinClientId, appBaseUrl, saved),
+    contentType: 'text/html',
+  };
+}
+
+export async function handleOnboardPost(
+  rawBody: string,
+  db: SupabaseClient,
+): Promise<{ status: number; location: string }> {
+  const params = new URLSearchParams(rawBody);
+  const installationId = parseInt(params.get('installation_id') ?? '', 10);
+  const name = params.get('name')?.trim() ?? '';
+  const website = params.get('website')?.trim() ?? '';
+  const bufferToken = params.get('buffer_access_token')?.trim() ?? '';
+  const bufferOrgId = params.get('buffer_org_id')?.trim() ?? '';
+
+  if (isNaN(installationId) || !name) {
+    return { status: 302, location: `/onboard?installation_id=${installationId}&error=missing_fields` };
+  }
+
+  // Fetch current tenant to merge config
+  const { data: tenant, error: fetchError } = await db
+    .from('tenants')
+    .select('id, config')
+    .eq('github_installation_id', installationId)
+    .single();
+
+  if (fetchError || !tenant) {
+    return { status: 302, location: `/onboard?installation_id=${installationId}&error=not_found` };
+  }
+
+  const existingConfig = (tenant as { config: Record<string, unknown> }).config;
+
+  const updatedConfig: Record<string, unknown> = {
+    ...existingConfig,
+    author: {
+      ...((existingConfig['author'] as Record<string, unknown> | undefined) ?? {}),
+      name,
+      ...(website && { website }),
+    },
+    buffer: {
+      ...((existingConfig['buffer'] as Record<string, unknown> | undefined) ?? {}),
+      ...(bufferOrgId && { organization_id: bufferOrgId }),
+    },
+  };
+
+  const updates: Record<string, unknown> = { config: updatedConfig };
+
+  // Only update buffer_access_token if a new one was provided (not the masked placeholder)
+  if (bufferToken && !bufferToken.includes('••')) {
+    updates['buffer_access_token'] = bufferToken;
+  }
+
+  const { error: updateError } = await db
+    .from('tenants')
+    .update(updates)
+    .eq('github_installation_id', installationId);
+
+  if (updateError) {
+    logger.error('onboard.save_failed', { installationId, error: updateError.message });
+    return { status: 302, location: `/onboard?installation_id=${installationId}&error=save_failed` };
+  }
+
+  logger.info('onboard.saved', { installationId, name });
+  return { status: 302, location: `/onboard?installation_id=${installationId}&saved=1` };
+}

--- a/src/webhook/server.ts
+++ b/src/webhook/server.ts
@@ -1,12 +1,17 @@
 import { createServer } from 'http';
 import { createClient } from '@supabase/supabase-js';
 import { handleGithubWebhook } from './github-handler.js';
+import { handleOnboardGet, handleOnboardPost } from './handlers/onboard.js';
+import { handleLinkedInRedirect, handleLinkedInCallback } from './handlers/linkedin-oauth.js';
 import { logger } from '../utils/logger.js';
 
 const PORT = parseInt(process.env['PORT'] ?? '3000', 10);
 const WEBHOOK_SECRET = process.env['GITHUB_WEBHOOK_SECRET'] ?? '';
 const SUPABASE_URL = process.env['SUPABASE_URL'] ?? '';
 const SUPABASE_SERVICE_ROLE_KEY = process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '';
+const LINKEDIN_CLIENT_ID = process.env['LINKEDIN_CLIENT_ID'] ?? '';
+const LINKEDIN_CLIENT_SECRET = process.env['LINKEDIN_CLIENT_SECRET'] ?? '';
+const APP_BASE_URL = process.env['APP_BASE_URL'] ?? '';
 
 if (!WEBHOOK_SECRET) {
   logger.error('server.missing_env', { var: 'GITHUB_WEBHOOK_SECRET' });
@@ -20,15 +25,101 @@ if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
 const db = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 const deps = { db };
 
+function parseUrl(raw: string): { path: string; query: URLSearchParams } {
+  const [path, qs = ''] = raw.split('?');
+  return { path: path ?? '/', query: new URLSearchParams(qs) };
+}
+
 const server = createServer((req, res) => {
+  const { path, query } = parseUrl(req.url ?? '/');
+
   // Health check — Cloud Run requires this to mark the instance healthy
-  if (req.method === 'GET' && req.url === '/health') {
+  if (req.method === 'GET' && path === '/health') {
     res.writeHead(200, { 'Content-Type': 'text/plain' });
     res.end('ok');
     return;
   }
 
-  if (req.method === 'POST' && req.url === '/webhooks/github') {
+  // Onboarding page
+  if (req.method === 'GET' && path === '/onboard') {
+    const installationId = parseInt(query.get('installation_id') ?? '', 10);
+    const saved = query.get('saved') === '1';
+    if (isNaN(installationId)) {
+      res.writeHead(400, { 'Content-Type': 'text/plain' });
+      res.end('Missing installation_id');
+      return;
+    }
+    handleOnboardGet(installationId, db, LINKEDIN_CLIENT_ID, APP_BASE_URL, saved)
+      .then(({ status, body, contentType }) => {
+        res.writeHead(status, { 'Content-Type': contentType });
+        res.end(body);
+      })
+      .catch((err: unknown) => {
+        logger.error('server.onboard_error', { error: String(err) });
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Internal error');
+      });
+    return;
+  }
+
+  // Onboarding form submission
+  if (req.method === 'POST' && path === '/onboard') {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const rawBody = Buffer.concat(chunks).toString('utf8');
+      handleOnboardPost(rawBody, db)
+        .then(({ status, location }) => {
+          res.writeHead(status, { Location: location });
+          res.end();
+        })
+        .catch((err: unknown) => {
+          logger.error('server.onboard_post_error', { error: String(err) });
+          res.writeHead(500, { 'Content-Type': 'text/plain' });
+          res.end('Internal error');
+        });
+    });
+    return;
+  }
+
+  // LinkedIn OAuth — redirect to authorization
+  if (req.method === 'GET' && path === '/auth/linkedin') {
+    const installationId = parseInt(query.get('installation_id') ?? '', 10);
+    if (isNaN(installationId) || !LINKEDIN_CLIENT_ID || !APP_BASE_URL) {
+      res.writeHead(400, { 'Content-Type': 'text/plain' });
+      res.end('LinkedIn OAuth not configured or missing installation_id');
+      return;
+    }
+    const redirectUrl = handleLinkedInRedirect(installationId, WEBHOOK_SECRET, LINKEDIN_CLIENT_ID, APP_BASE_URL);
+    res.writeHead(302, { Location: redirectUrl });
+    res.end();
+    return;
+  }
+
+  // LinkedIn OAuth — callback
+  if (req.method === 'GET' && path === '/auth/linkedin/callback') {
+    const code = query.get('code') ?? '';
+    const state = query.get('state') ?? '';
+    if (!code || !state || !LINKEDIN_CLIENT_ID || !LINKEDIN_CLIENT_SECRET || !APP_BASE_URL) {
+      res.writeHead(400, { 'Content-Type': 'text/plain' });
+      res.end('Invalid callback parameters');
+      return;
+    }
+    handleLinkedInCallback(code, state, WEBHOOK_SECRET, LINKEDIN_CLIENT_ID, LINKEDIN_CLIENT_SECRET, APP_BASE_URL, db)
+      .then(({ status, location }) => {
+        res.writeHead(status, { Location: location });
+        res.end();
+      })
+      .catch((err: unknown) => {
+        logger.error('server.linkedin_callback_error', { error: String(err) });
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Internal error');
+      });
+    return;
+  }
+
+  // GitHub App webhook
+  if (req.method === 'POST' && path === '/webhooks/github') {
     const event = req.headers['x-github-event'];
     const signature = req.headers['x-hub-signature-256'];
 

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { GitHubClient } from '../github/client.js';
+import { LinkedInClient, LinkedInAuthExpiredError } from '../linkedin/client.js';
 import { enrichCommit } from '../github/commit-enricher.js';
 import { isInteresting } from '../utils/commit-filter.js';
 import { runPipeline } from '../analysis/pipeline.js';
@@ -20,6 +21,8 @@ interface TenantRow {
   readonly github_installation_id: number;
   readonly github_username: string;
   readonly buffer_access_token: string | null;
+  readonly linkedin_access_token: string | null;
+  readonly linkedin_member_id: string | null;
   readonly config: Record<string, unknown>;
 }
 
@@ -94,7 +97,7 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
 
   const { data: tenantData, error: tenantError } = await deps.db
     .from('tenants')
-    .select('id, github_installation_id, github_username, buffer_access_token, config')
+    .select('id, github_installation_id, github_username, buffer_access_token, linkedin_access_token, linkedin_member_id, config')
     .eq('id', job.tenant_id)
     .single();
 
@@ -187,9 +190,26 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
         continue;
       }
 
-      const { bufferText, draftId } = await generatePosts(anthropic, commit, findings, storage, config, recentModuleIds);
+      const { linkedinPost, bufferText, draftId } = await generatePosts(anthropic, commit, findings, storage, config, recentModuleIds);
 
-      // Only publish to Buffer if the tenant has configured their token
+      // Post directly to LinkedIn if connected
+      if (tenant.linkedin_access_token && tenant.linkedin_member_id) {
+        try {
+          const linkedinClient = new LinkedInClient(tenant.linkedin_access_token);
+          await linkedinClient.post(tenant.linkedin_member_id, linkedinPost);
+          logger.info('worker.commit.linkedin_posted', { sha: commit.sha });
+        } catch (err) {
+          if (err instanceof LinkedInAuthExpiredError) {
+            logger.warn('worker.commit.linkedin_expired', { sha: commit.sha });
+          } else {
+            logger.error('worker.commit.linkedin_error', { sha: commit.sha, error: String(err) });
+          }
+        }
+      } else {
+        logger.info('worker.commit.linkedin_skipped', { sha: commit.sha, reason: 'no linkedin token' });
+      }
+
+      // Create Buffer Idea if configured (for Instagram or as backup)
       if (tenant.buffer_access_token) {
         const bufferClient = new BufferClient(tenant.buffer_access_token);
         const publishResult = await publishToBuffer(


### PR DESCRIPTION
## Summary

- **LinkedInClient** (`src/linkedin/client.ts`): `post()` via LinkedIn Posts API v202501, `getMemberUrn()` via userinfo endpoint, `LinkedInAuthExpiredError` for 401s
- **Onboarding UI** (`src/webhook/handlers/onboard.ts`): HTML form for name, website, Buffer API key (masked), Buffer org ID, LinkedIn connect button
- **LinkedIn OAuth** (`src/webhook/handlers/linkedin-oauth.ts`): authorization redirect + callback with HMAC-SHA256-signed CSRF state (signed with webhook secret)
- **Server routes** (`src/webhook/server.ts`): `GET/POST /onboard`, `GET /auth/linkedin`, `GET /auth/linkedin/callback`; LinkedIn routes fail gracefully (400) if env vars absent
- **Worker posting** (`src/worker/process-job.ts`): after `generatePosts`, posts directly to LinkedIn if token present; creates Buffer Idea if buffer token present — both can run in the same job
- **Schema** (`database/schema.sql`): `linkedin_access_token`, `linkedin_member_id`, `linkedin_token_expires_at` on `tenants`; migration block at bottom safe to re-run

## Deploy steps after merge

1. Run Supabase migration (migration block is already in schema.sql):
   ```sql
   ALTER TABLE tenants ADD COLUMN IF NOT EXISTS linkedin_access_token TEXT;
   ALTER TABLE tenants ADD COLUMN IF NOT EXISTS linkedin_member_id TEXT;
   ALTER TABLE tenants ADD COLUMN IF NOT EXISTS linkedin_token_expires_at TIMESTAMPTZ;
   ```

2. Add secrets to Secret Manager:
   ```
   LINKEDIN_CLIENT_ID
   LINKEDIN_CLIENT_SECRET
   APP_BASE_URL   (e.g. https://getdevcast-webhook-43rx6d5uua-uc.a.run.app)
   ```

3. Update Cloud Run webhook service with new env vars:
   ```
   gcloud run services update getdevcast-webhook \
     --update-secrets=LINKEDIN_CLIENT_ID=LINKEDIN_CLIENT_ID:latest,LINKEDIN_CLIENT_SECRET=LINKEDIN_CLIENT_SECRET:latest,APP_BASE_URL=APP_BASE_URL:latest
   ```

4. Configure GitHub App post-install redirect URL → `{APP_BASE_URL}/onboard`

5. In LinkedIn Developer Portal → Products tab → add "Share on LinkedIn" to get `w_member_social` scope

## Test plan

- [ ] Visit `/onboard?installation_id=<id>` — form renders with masked Buffer token if set
- [ ] Submit form — name/website/buffer token/org saved; redirect back with `saved=1`
- [ ] Click "Connect LinkedIn" → redirects to LinkedIn auth
- [ ] Complete LinkedIn auth → token + member URN stored in tenant row
- [ ] Trigger a push → worker logs `worker.commit.linkedin_posted` or `worker.commit.linkedin_skipped`
- [ ] Expired LinkedIn token → logs `worker.commit.linkedin_expired` (no crash)