### PR TITLE
feat: GitHub App OAuth callback for secure post-install redirect

### DIFF
--- a/src/webhook/handlers/github-oauth.ts
+++ b/src/webhook/handlers/github-oauth.ts
@@ -1,0 +1,52 @@
+import { logger } from '../../utils/logger.js';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+const GITHUB_TOKEN_URL = 'https://github.com/login/oauth/access_token';
+
+/**
+ * Handles the GitHub App OAuth callback after installation.
+ * GitHub redirects here with ?code=...&installation_id=...
+ *
+ * The code exchange is the security gate — only a user who completed
+ * GitHub's OAuth flow has a valid single-use code (expires in 10 min).
+ * After exchange succeeds, redirect to onboarding.
+ */
+export async function handleGitHubCallback(
+  code: string,
+  installationId: number,
+  clientId: string,
+  clientSecret: string,
+): Promise<{ status: number; location: string }> {
+  if (!code || isNaN(installationId)) {
+    logger.warn('github.callback.invalid_params', { installationId });
+    return { status: 302, location: '/onboard?error=invalid_params' };
+  }
+
+  const tokenRes = await fetch(GITHUB_TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    },
+    body: JSON.stringify({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code,
+    }),
+  });
+
+  if (!tokenRes.ok) {
+    logger.error('github.callback.token_exchange_failed', { status: tokenRes.status });
+    return { status: 302, location: `/onboard?installation_id=${installationId}&error=auth_failed` };
+  }
+
+  const data = await tokenRes.json() as { access_token?: string; error?: string };
+
+  if (!data.access_token || data.error) {
+    logger.error('github.callback.token_invalid', { error: data.error });
+    return { status: 302, location: `/onboard?installation_id=${installationId}&error=auth_failed` };
+  }
+
+  logger.info('github.callback.success', { installationId });
+  return { status: 302, location: `/onboard?installation_id=${installationId}` };
+}

--- a/src/webhook/server.ts
+++ b/src/webhook/server.ts
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 import { handleGithubWebhook } from './github-handler.js';
 import { handleOnboardGet, handleOnboardPost } from './handlers/onboard.js';
 import { handleLinkedInRedirect, handleLinkedInCallback } from './handlers/linkedin-oauth.js';
+import { handleGitHubCallback } from './handlers/github-oauth.js';
 import { logger } from '../utils/logger.js';
 
 const PORT = parseInt(process.env['PORT'] ?? '3000', 10);
@@ -12,6 +13,8 @@ const SUPABASE_SERVICE_ROLE_KEY = process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? ''
 const LINKEDIN_CLIENT_ID = process.env['LINKEDIN_CLIENT_ID'] ?? '';
 const LINKEDIN_CLIENT_SECRET = process.env['LINKEDIN_CLIENT_SECRET'] ?? '';
 const APP_BASE_URL = process.env['APP_BASE_URL'] ?? '';
+const GITHUB_APP_CLIENT_ID = process.env['GITHUB_APP_CLIENT_ID'] ?? '';
+const GITHUB_APP_CLIENT_SECRET = process.env['GITHUB_APP_CLIENT_SECRET'] ?? '';
 
 if (!WEBHOOK_SECRET) {
   logger.error('server.missing_env', { var: 'GITHUB_WEBHOOK_SECRET' });
@@ -79,6 +82,28 @@ const server = createServer((req, res) => {
           res.end('Internal error');
         });
     });
+    return;
+  }
+
+  // GitHub App OAuth — callback after installation
+  if (req.method === 'GET' && path === '/auth/github/callback') {
+    const code = query.get('code') ?? '';
+    const installationId = parseInt(query.get('installation_id') ?? '', 10);
+    if (!code || isNaN(installationId) || !GITHUB_APP_CLIENT_ID || !GITHUB_APP_CLIENT_SECRET) {
+      res.writeHead(400, { 'Content-Type': 'text/plain' });
+      res.end('Invalid callback parameters');
+      return;
+    }
+    handleGitHubCallback(code, installationId, GITHUB_APP_CLIENT_ID, GITHUB_APP_CLIENT_SECRET)
+      .then(({ status, location }) => {
+        res.writeHead(status, { Location: location });
+        res.end();
+      })
+      .catch((err: unknown) => {
+        logger.error('server.github_callback_error', { error: String(err) });
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Internal error');
+      });
     return;
   }
 


### PR DESCRIPTION
## Summary

- New `src/webhook/handlers/github-oauth.ts`: exchanges GitHub OAuth `code` for a user token (security gate), then redirects to `/onboard?installation_id={id}`
- `src/webhook/server.ts`: new route `GET /auth/github/callback` + env vars `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_CLIENT_SECRET`

## Why

Keeps "Request user authorization (OAuth) during installation" enabled on the GitHub App. The `code` exchange guarantees only a user who completed GitHub's OAuth flow can reach the onboarding page — not someone who guessed an `installation_id`.

## Deploy steps after merge

1. Update Cloud Run service with new secrets:
   ```
   gcloud run services update getdevcast-webhook \
     --update-secrets=GITHUB_APP_CLIENT_ID=GITHUB_APP_CLIENT_ID:latest,GITHUB_APP_CLIENT_SECRET=GITHUB_APP_CLIENT_SECRET:latest \
     --region us-central1 --project lilicurl
   ```

2. Update GitHub App Callback URL to `https://app.devcast.lilicurl.com/auth/github/callback`

3. Update `APP_BASE_URL` secret to `https://app.devcast.lilicurl.com` (once DNS propagates)

## Test plan

- [ ] Install GitHub App on a test account → redirects to `/auth/github/callback` → redirects to `/onboard?installation_id=...`
- [ ] Invalid/expired code → redirects to `/onboard?installation_id=...&error=auth_failed`
- [ ] Missing parameters → 400