### PR TITLE
feat: CI/CD auto-deploy on push to trunk

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to Cloud Run
+
+on:
+  push:
+    branches: [trunk]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Build image
+        run: |
+          IMAGE="gcr.io/lilicurl/devcast:${{ github.sha }}"
+          gcloud builds submit --tag "$IMAGE" --project lilicurl
+
+      - name: Deploy webhook service
+        run: |
+          IMAGE="gcr.io/lilicurl/devcast:${{ github.sha }}"
+          gcloud run services update getdevcast-webhook \
+            --image "$IMAGE" \
+            --region us-central1 \
+            --project lilicurl


### PR DESCRIPTION
## Summary

Auto-deploys `getdevcast-webhook` to Cloud Run on every push to `trunk`.

- **Auth**: Workload Identity Federation (no long-lived service account keys stored in GitHub)
- **Build**: `gcloud builds submit` tagged with commit SHA for traceability
- **Deploy**: `gcloud run services update` with the new image

## GCP resources created

- Workload Identity Pool: `github-pool`
- OIDC Provider: `github-provider` (scoped to `vialabs-net/social-engagement` only)
- Service Account: `github-deployer@lilicurl.iam.gserviceaccount.com`
- Roles granted: `run.admin`, `storage.admin`, `cloudbuild.builds.editor`, `iam.serviceAccountUser`

## GitHub Secrets required (add before merging)

- `WIF_PROVIDER`: `projects/749111652662/locations/global/workloadIdentityPools/github-pool/providers/github-provider`
- `WIF_SERVICE_ACCOUNT`: `github-deployer@lilicurl.iam.gserviceaccount.com`

## Test plan

- [ ] Add both secrets to GitHub → Settings → Secrets → Actions
- [ ] Merge this PR → workflow runs → deploy succeeds
- [ ] Verify new revision in Cloud Run console