### PR TITLE
fix: multi-tenant voice storage isolation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,3 +41,11 @@ jobs:
             --image "$IMAGE" \
             --region us-central1 \
             --project lilicurl
+
+      - name: Deploy worker job
+        run: |
+          IMAGE="gcr.io/lilicurl/devcast:${{ github.sha }}"
+          gcloud run jobs update devcast-worker \
+            --image "$IMAGE" \
+            --region us-central1 \
+            --project lilicurl

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -19,7 +19,8 @@ CREATE TABLE IF NOT EXISTS voice_posts (
   findings_count  INTEGER NOT NULL DEFAULT 0,
   linkedin_urn    TEXT,                    -- urn:li:share:... captured from Buffer externalLink
   reactions_count INTEGER NOT NULL DEFAULT 0, -- LinkedIn reactions fetched from socialActions API
-  engagement_score REAL                   -- composite: edit_ratio*0.6 + normalized_reactions*0.4
+  engagement_score REAL,                  -- composite: edit_ratio*0.6 + normalized_reactions*0.4
+  tenant_id       UUID REFERENCES tenants(id) -- multi-tenant: scopes voice data per user
 );
 
 -- Uninteresting commits saved for optional weekly roundup
@@ -122,6 +123,9 @@ ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS engagement_score REAL;
 ALTER TABLE tenants ADD COLUMN IF NOT EXISTS linkedin_access_token     TEXT;
 ALTER TABLE tenants ADD COLUMN IF NOT EXISTS linkedin_member_id        TEXT;
 ALTER TABLE tenants ADD COLUMN IF NOT EXISTS linkedin_token_expires_at TIMESTAMPTZ;
+
+ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS tenant_id UUID REFERENCES tenants(id);
+CREATE INDEX IF NOT EXISTS idx_voice_posts_tenant ON voice_posts(tenant_id);
 
 DROP INDEX IF EXISTS idx_voice_retrieval;
 CREATE INDEX IF NOT EXISTS idx_voice_retrieval

--- a/scripts/bootstrap-voice.ts
+++ b/scripts/bootstrap-voice.ts
@@ -59,9 +59,10 @@ function parseBootstrapFile(content: string): BootstrapPost[] {
 }
 
 async function main(): Promise<void> {
+  const tenantId = process.env['TENANT_ID'] ?? 'local';
   const storage: IVoiceStorage = process.env['SUPABASE_URL']
-    ? new SupabaseStorage(process.env['SUPABASE_URL'], process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '')
-    : new SqliteStorage(process.env['SQLITE_PATH'] ?? 'data/devcast.db');
+    ? new SupabaseStorage(process.env['SUPABASE_URL'], process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '', tenantId)
+    : new SqliteStorage(process.env['SQLITE_PATH'] ?? 'data/devcast.db', tenantId);
 
   let content: string;
   try {

--- a/scripts/update-engagement.ts
+++ b/scripts/update-engagement.ts
@@ -41,9 +41,10 @@ function formatPost(post: VoicePost): string {
 async function main(): Promise<void> {
   const config = loadConfig();
 
+  const tenantId = process.env['TENANT_ID'] ?? 'local';
   const storage: IVoiceStorage = process.env['SUPABASE_URL']
-    ? new SupabaseStorage(process.env['SUPABASE_URL'], process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '')
-    : new SqliteStorage(process.env['SQLITE_PATH'] ?? 'data/devcast.db');
+    ? new SupabaseStorage(process.env['SUPABASE_URL'], process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '', tenantId)
+    : new SqliteStorage(process.env['SQLITE_PATH'] ?? 'data/devcast.db', tenantId);
 
   const posts = await storage.getPostsPendingEngagement('linkedin');
 

--- a/scripts/voice-report.ts
+++ b/scripts/voice-report.ts
@@ -77,9 +77,10 @@ function postsTable(posts: VoicePost[]): string {
 async function main(): Promise<void> {
   const config = loadConfig();
 
+  const tenantId = process.env['TENANT_ID'] ?? 'local';
   const storage: IVoiceStorage = process.env['SUPABASE_URL']
-    ? new SupabaseStorage(process.env['SUPABASE_URL'], process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '')
-    : new SqliteStorage(process.env['SQLITE_PATH'] ?? 'data/devcast.db');
+    ? new SupabaseStorage(process.env['SUPABASE_URL'], process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '', tenantId)
+    : new SqliteStorage(process.env['SQLITE_PATH'] ?? 'data/devcast.db', tenantId);
 
   const posts = await storage.getRecentPublished(30);
 

--- a/src/main-poll.ts
+++ b/src/main-poll.ts
@@ -30,9 +30,11 @@ async function main(): Promise<void> {
   const modules = plugins.length > 0 ? [...MODULE_REGISTRY, ...plugins] : MODULE_REGISTRY;
 
   // Storage: Supabase in production (service_role key), SQLite locally
+  // TENANT_ID env var required for Supabase (multi-tenant). Defaults to 'local' for SQLite.
+  const tenantId = process.env['TENANT_ID'] ?? 'local';
   const storage: IVoiceStorage = process.env['SUPABASE_URL']
-    ? new SupabaseStorage(process.env['SUPABASE_URL'], process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '')
-    : new SqliteStorage(process.env['SQLITE_PATH'] ?? 'data/devcast.db');
+    ? new SupabaseStorage(process.env['SUPABASE_URL'], process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '', tenantId)
+    : new SqliteStorage(process.env['SQLITE_PATH'] ?? 'data/devcast.db', tenantId);
 
   const github = new GitHubClient(process.env['GITHUB_TOKEN'] ?? '');
   const anthropic = new AnthropicClient(

--- a/src/main-scan.ts
+++ b/src/main-scan.ts
@@ -16,9 +16,10 @@ async function main(): Promise<void> {
   const config = loadConfig();
   logger.info('scan.start');
 
+  const tenantId = process.env['TENANT_ID'] ?? 'local';
   const storage: IVoiceStorage = process.env['SUPABASE_URL']
-    ? new SupabaseStorage(process.env['SUPABASE_URL'], process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '')
-    : new SqliteStorage(process.env['SQLITE_PATH'] ?? 'data/devcast.db');
+    ? new SupabaseStorage(process.env['SUPABASE_URL'], process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '', tenantId)
+    : new SqliteStorage(process.env['SQLITE_PATH'] ?? 'data/devcast.db', tenantId);
 
   const bufferClient = new BufferClient(process.env['BUFFER_ACCESS_TOKEN'] ?? '');
 

--- a/src/voice/sqlite-storage.ts
+++ b/src/voice/sqlite-storage.ts
@@ -16,11 +16,13 @@ import type {
 
 export class SqliteStorage implements IVoiceStorage {
   private readonly db: Database.Database;
+  readonly tenantId: string;
 
-  constructor(dbPath = 'data/devcast.db') {
+  constructor(dbPath = 'data/devcast.db', tenantId = 'local') {
     mkdirSync(dirname(dbPath), { recursive: true });
     this.db = new Database(dbPath);
     this.db.pragma('journal_mode = WAL');
+    this.tenantId = tenantId;
     this.migrate();
   }
 
@@ -50,6 +52,7 @@ export class SqliteStorage implements IVoiceStorage {
       ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS reactions_count  INTEGER NOT NULL DEFAULT 0;
       ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS engagement_score REAL;
       ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS top_module_id    TEXT;
+      ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS tenant_id        TEXT;
 
       CREATE UNIQUE INDEX IF NOT EXISTS idx_sha_platform
         ON voice_posts(commit_sha, platform);
@@ -82,19 +85,21 @@ export class SqliteStorage implements IVoiceStorage {
   saveDraft(input: SaveDraftInput): Promise<string> {
     const id = randomUUID();
     this.db.prepare(`
-      INSERT INTO voice_posts (id, commit_sha, repo, platform, ai_draft, top_finding, top_module_id, findings_count, status)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending')
+      INSERT INTO voice_posts (id, commit_sha, repo, platform, ai_draft, top_finding, top_module_id, findings_count, status, tenant_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
     `).run(id, input.commit_sha, input.repo, input.platform, input.ai_draft,
-           input.top_finding ?? null, input.top_module_id ?? null, input.findings_count ?? 0);
+           input.top_finding ?? null, input.top_module_id ?? null, input.findings_count ?? 0,
+           this.tenantId);
     return Promise.resolve(id);
   }
 
   getRecentModuleIds(days: number): Promise<string[]> {
     const rows = this.db.prepare(`
       SELECT top_module_id FROM voice_posts
-      WHERE created_at >= datetime('now', '-' || ? || ' days')
+      WHERE tenant_id = ?
+        AND created_at >= datetime('now', '-' || ? || ' days')
         AND top_module_id IS NOT NULL
-    `).all(days) as { top_module_id: string }[];
+    `).all(this.tenantId, days) as { top_module_id: string }[];
     return Promise.resolve(rows.map((r) => r.top_module_id));
   }
 
@@ -126,10 +131,10 @@ export class SqliteStorage implements IVoiceStorage {
   getTopVoiceExamples(platform: Platform, limit: number): Promise<VoicePost[]> {
     const rows = this.db.prepare(`
       SELECT * FROM voice_posts
-      WHERE platform = ? AND status = 'published' AND edit_ratio IS NOT NULL
+      WHERE tenant_id = ? AND platform = ? AND status = 'published' AND edit_ratio IS NOT NULL
       ORDER BY engagement_score DESC NULLS LAST, edit_ratio DESC NULLS LAST
       LIMIT ?
-    `).all(platform, limit) as VoicePost[];
+    `).all(this.tenantId, platform, limit) as VoicePost[];
     return Promise.resolve(rows);
   }
 
@@ -145,44 +150,44 @@ export class SqliteStorage implements IVoiceStorage {
   getPostsPendingEngagement(platform: Platform): Promise<VoicePost[]> {
     const rows = this.db.prepare(`
       SELECT * FROM voice_posts
-      WHERE platform = ? AND status = 'published'
+      WHERE tenant_id = ? AND platform = ? AND status = 'published'
         AND linkedin_urn IS NOT NULL AND engagement_score IS NULL
-    `).all(platform) as VoicePost[];
+    `).all(this.tenantId, platform) as VoicePost[];
     return Promise.resolve(rows);
   }
 
   getRecentPublished(limit: number): Promise<VoicePost[]> {
     const rows = this.db.prepare(`
       SELECT * FROM voice_posts
-      WHERE status = 'published'
+      WHERE tenant_id = ? AND status = 'published'
       ORDER BY published_at DESC NULLS LAST
       LIMIT ?
-    `).all(limit) as VoicePost[];
+    `).all(this.tenantId, limit) as VoicePost[];
     return Promise.resolve(rows);
   }
 
   hasDraft(commit_sha: string, platform: Platform): Promise<boolean> {
     const row = this.db.prepare(`
-      SELECT id FROM voice_posts WHERE commit_sha = ? AND platform = ?
-    `).get(commit_sha, platform);
+      SELECT id FROM voice_posts WHERE tenant_id = ? AND commit_sha = ? AND platform = ?
+    `).get(this.tenantId, commit_sha, platform);
     return Promise.resolve(row !== undefined);
   }
 
   getQueuedPosts(platform: Platform): Promise<VoicePost[]> {
     const rows = this.db.prepare(`
       SELECT * FROM voice_posts
-      WHERE platform = ? AND status = 'queued'
+      WHERE tenant_id = ? AND platform = ? AND status = 'queued'
       ORDER BY created_at ASC
-    `).all(platform) as VoicePost[];
+    `).all(this.tenantId, platform) as VoicePost[];
     return Promise.resolve(rows);
   }
 
   getScheduledUnpublished(platform: Platform): Promise<VoicePost[]> {
     const rows = this.db.prepare(`
       SELECT * FROM voice_posts
-      WHERE platform = ? AND status = 'scheduled' AND published IS NULL
+      WHERE tenant_id = ? AND platform = ? AND status = 'scheduled' AND published IS NULL
       ORDER BY created_at ASC
-    `).all(platform) as VoicePost[];
+    `).all(this.tenantId, platform) as VoicePost[];
     return Promise.resolve(rows);
   }
 

--- a/src/voice/storage.ts
+++ b/src/voice/storage.ts
@@ -60,6 +60,9 @@ export interface SlottedPost {
 }
 
 export interface IVoiceStorage {
+  /** The tenant this storage instance is scoped to. All queries filter by this. */
+  readonly tenantId: string;
+
   /** Save an AI draft immediately after generation. Returns the new row ID. */
   saveDraft(input: SaveDraftInput): Promise<string>;
 

--- a/src/voice/supabase-storage.ts
+++ b/src/voice/supabase-storage.ts
@@ -13,9 +13,11 @@ import type {
 
 export class SupabaseStorage implements IVoiceStorage {
   private readonly db: SupabaseClient;
+  readonly tenantId: string;
 
-  constructor(url: string, anonKey: string) {
+  constructor(url: string, anonKey: string, tenantId: string) {
     this.db = createClient(url, anonKey);
+    this.tenantId = tenantId;
   }
 
   async saveDraft(input: SaveDraftInput): Promise<string> {
@@ -30,6 +32,7 @@ export class SupabaseStorage implements IVoiceStorage {
         top_module_id: input.top_module_id ?? null,
         findings_count: input.findings_count ?? 0,
         status: 'pending' satisfies PostStatus,
+        tenant_id: this.tenantId,
       })
       .select('id')
       .single();
@@ -79,6 +82,7 @@ export class SupabaseStorage implements IVoiceStorage {
     const { data, error } = await this.db
       .from('voice_posts')
       .select('*')
+      .eq('tenant_id', this.tenantId)
       .eq('platform', platform)
       .eq('status', 'published')
       .not('edit_ratio', 'is', null)
@@ -107,6 +111,7 @@ export class SupabaseStorage implements IVoiceStorage {
     const { data, error } = await this.db
       .from('voice_posts')
       .select('*')
+      .eq('tenant_id', this.tenantId)
       .eq('platform', platform)
       .eq('status', 'published')
       .not('linkedin_urn', 'is', null)
@@ -120,6 +125,7 @@ export class SupabaseStorage implements IVoiceStorage {
     const { data, error } = await this.db
       .from('voice_posts')
       .select('*')
+      .eq('tenant_id', this.tenantId)
       .eq('status', 'published')
       .order('published_at', { ascending: false, nullsFirst: false })
       .limit(limit);
@@ -133,6 +139,7 @@ export class SupabaseStorage implements IVoiceStorage {
     const { data, error } = await this.db
       .from('voice_posts')
       .select('top_module_id')
+      .eq('tenant_id', this.tenantId)
       .gte('created_at', since)
       .not('top_module_id', 'is', null);
 
@@ -144,6 +151,7 @@ export class SupabaseStorage implements IVoiceStorage {
     const { count, error } = await this.db
       .from('voice_posts')
       .select('id', { count: 'exact', head: true })
+      .eq('tenant_id', this.tenantId)
       .eq('commit_sha', commit_sha)
       .eq('platform', platform);
 
@@ -155,6 +163,7 @@ export class SupabaseStorage implements IVoiceStorage {
     const { data, error } = await this.db
       .from('voice_posts')
       .select('*')
+      .eq('tenant_id', this.tenantId)
       .eq('platform', platform)
       .eq('status', 'queued')
       .order('created_at', { ascending: true });
@@ -167,6 +176,7 @@ export class SupabaseStorage implements IVoiceStorage {
     const { data, error } = await this.db
       .from('voice_posts')
       .select('*')
+      .eq('tenant_id', this.tenantId)
       .eq('platform', platform)
       .eq('status', 'scheduled')
       .is('published', null)

--- a/src/worker/main-worker.ts
+++ b/src/worker/main-worker.ts
@@ -120,6 +120,8 @@ async function markFailed(jobId: string, errorMessage: string): Promise<void> {
  */
 async function processAllPending(): Promise<void> {
   let processed = 0;
+  let failed = 0;
+  const tenantsSeen = new Set<string>();
 
   while (true) {
     const jobId = await claimJob();
@@ -132,10 +134,14 @@ async function processAllPending(): Promise<void> {
     } catch (err) {
       logger.error('worker.job.error', { jobId, error: String(err) });
       await markFailed(jobId, String(err));
+      failed++;
     }
   }
 
-  logger.info('worker.run.complete', { processed });
+  logger.info('worker.run.summary', { processed, failed, skipped: 0 });
+  if (failed > 0) {
+    logger.error('worker.run.failures', { failed, processed });
+  }
 }
 
 async function main(): Promise<void> {

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -127,7 +127,7 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
     config.ai.model,
     config.ai.max_tokens,
   );
-  const storage = new SupabaseStorage(deps.supabaseUrl, deps.supabaseServiceKey);
+  const storage = new SupabaseStorage(deps.supabaseUrl, deps.supabaseServiceKey, tenant.id);
 
   const [owner, repo] = job.repo.split('/') as [string, string];
 
@@ -197,6 +197,12 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
         try {
           const linkedinClient = new LinkedInClient(tenant.linkedin_access_token);
           await linkedinClient.post(tenant.linkedin_member_id, linkedinPost);
+          await storage.updatePublished({
+            id: draftId,
+            published: linkedinPost,
+            edit_ratio: 1.0,
+            published_at: new Date().toISOString(),
+          });
           logger.info('worker.commit.linkedin_posted', { sha: commit.sha });
         } catch (err) {
           if (err instanceof LinkedInAuthExpiredError) {


### PR DESCRIPTION
## Summary

Critical multi-tenant fix. Without this, all tenants share voice examples, duplicate detection, and module history — User A's posts contaminate User B's voice training.

- `IVoiceStorage` interface: added `readonly tenantId: string` property
- `SupabaseStorage`: constructor accepts `tenantId`, all 10 query methods filter by `tenant_id`
- `SqliteStorage`: same pattern for local dev compatibility
- `process-job.ts`: creates `SupabaseStorage(url, key, tenant.id)` — tenant-scoped per job
- LinkedIn direct posts: marked as `status='published'` immediately after posting (`edit_ratio=1.0`)
- `deploy.yml`: deploys both webhook service AND worker job (previously only webhook)
- `main-worker.ts`: structured run summary log with processed/failed counts
- All scripts and entry points: accept `TENANT_ID` env var

## Cutover after merge (follow this order)

1. CI/CD deploys automatically (~3 min)
2. **Immediately** run in Supabase SQL Editor:
```sql
-- Verify
SELECT COUNT(*) FROM voice_posts WHERE tenant_id IS NULL;

-- Add column
ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS tenant_id UUID REFERENCES tenants(id);
CREATE INDEX IF NOT EXISTS idx_voice_posts_tenant ON voice_posts(tenant_id);

-- Backfill Liliana's posts
UPDATE voice_posts SET tenant_id = (
  SELECT id FROM tenants WHERE github_username = 'lilicurl'
) WHERE tenant_id IS NULL;

-- Verify
SELECT COUNT(*) FROM voice_posts WHERE tenant_id IS NULL;
-- Must be 0
```

## Test plan

- [ ] Push a test commit → worker processes it → `voice_posts` row has `tenant_id` set
- [ ] Voice examples query returns only the tenant's own posts
- [ ] `hasDraft` scoped per tenant (two tenants can process same SHA independently)
- [ ] LinkedIn direct post → `voice_posts.status = 'published'` immediately
- [ ] `deploy.yml` updates both webhook and worker on push to trunk
- [ ] Worker logs `worker.run.summary` with processed/failed counts