### PR TITLE
feat: complete Phase 1 — multi-tenant scanner, voice bootstrap, UI polish

### DIFF
--- a/.github/workflows/poll-and-generate.yml
+++ b/.github/workflows/poll-and-generate.yml
@@ -1,9 +1,9 @@
 name: Poll and Generate
 
 on:
-  schedule:
-    - cron: '0 */4 * * *'    # every 4 hours
-  workflow_dispatch:           # manual trigger for testing
+  # schedule disabled — replaced by multi-tenant webhook + worker pipeline
+  # - cron: '0 */4 * * *'
+  workflow_dispatch:           # manual trigger for local testing only
 
 permissions:
   contents: read

--- a/.github/workflows/scan-sent-posts.yml
+++ b/.github/workflows/scan-sent-posts.yml
@@ -1,8 +1,8 @@
 name: Scan Sent Posts
 
 on:
-  schedule:
-    - cron: '0 */2 * * *'    # every 2 hours
+  # schedule disabled — replaced by multi-tenant scanner (devcast-scanner Cloud Run Job)
+  # - cron: '0 */2 * * *'
   workflow_dispatch:
 
 permissions:

--- a/src/webhook/handlers/linkedin-oauth.ts
+++ b/src/webhook/handlers/linkedin-oauth.ts
@@ -130,5 +130,5 @@ export async function handleLinkedInCallback(
   }
 
   logger.info('linkedin.callback.connected', { installationId, memberUrn });
-  return { status: 302, location: `/onboard?installation_id=${installationId}&saved=1` };
+  return { status: 302, location: `/onboard?installation_id=${installationId}&saved=1&linkedin=connected` };
 }

--- a/src/webhook/handlers/onboard.ts
+++ b/src/webhook/handlers/onboard.ts
@@ -7,6 +7,7 @@ interface TenantRow {
   readonly buffer_access_token: string | null;
   readonly linkedin_member_id: string | null;
   readonly config: Record<string, unknown>;
+  readonly voice_bootstrap: string | null;
 }
 
 function maskToken(token: string | null): string {
@@ -22,6 +23,7 @@ function html(tenant: TenantRow, installationId: number, linkedinClientId: strin
   const name = (author['name'] as string | undefined) ?? tenant.github_username;
   const website = (author['website'] as string | undefined) ?? '';
   const bufferOrgId = (buffer['organization_id'] as string | undefined) ?? '';
+  const voiceBootstrap = tenant.voice_bootstrap ?? '';
 
   const linkedinConnected = !!tenant.linkedin_member_id;
   const linkedinSection = linkedinConnected
@@ -63,6 +65,9 @@ function html(tenant: TenantRow, installationId: number, linkedinClientId: strin
     input::placeholder{color:#3f3f46}
     .hint{font-size:.75rem;color:#52525b;margin-top:-12px;margin-bottom:16px}
     .hint-card{font-size:.75rem;color:#52525b;margin-top:10px}
+    textarea{width:100%;padding:8px 12px;background:#09090b;border:1px solid #27272a;border-radius:8px;font-size:.875rem;color:#f4f4f5;font-family:inherit;margin-bottom:16px;outline:none;transition:border-color .15s;resize:vertical}
+    textarea:focus{border-color:#52525b}
+    textarea::placeholder{color:#3f3f46}
     .btn-primary{background:#fff;color:#09090b;border:none;padding:9px 20px;border-radius:8px;font-size:.875rem;font-weight:500;cursor:pointer;font-family:inherit;transition:background .15s}
     .btn-primary:hover{background:#e4e4e7}
     .btn-linkedin{display:inline-flex;align-items:center;gap:8px;background:#0077B5;color:#fff;padding:9px 20px;border-radius:8px;font-size:.875rem;font-weight:500;text-decoration:none;transition:background .15s}
@@ -74,7 +79,7 @@ function html(tenant: TenantRow, installationId: number, linkedinClientId: strin
 </head>
 <body>
   <nav>
-    <span class="logo">devcast</span>
+    <img src="/favicon.png" alt="devcast" style="height:24px">
     <span class="account-badge"><span class="dot"></span>${tenant.github_username}</span>
   </nav>
   <main>
@@ -89,6 +94,12 @@ function html(tenant: TenantRow, installationId: number, linkedinClientId: strin
         <input type="text" name="name" value="${name}" placeholder="Your Name" required>
         <label>Website <span class="optional">optional</span></label>
         <input type="url" name="website" value="${website}" placeholder="https://yoursite.com">
+      </div>
+      <div class="card">
+        <div class="section-title">Your voice <span class="optional">recommended</span></div>
+        <label>Paste 2-3 posts you've written before</label>
+        <textarea name="voice_bootstrap" rows="6" placeholder="Paste any LinkedIn post, blog excerpt, or text that sounds like you. This teaches devcast your writing voice.">${voiceBootstrap}</textarea>
+        <p class="hint">devcast learns your tone, style, and personality from these examples. Better examples = posts that sound more like you.</p>
       </div>
       <div class="card">
         <div class="section-title">Buffer <span class="optional">optional</span></div>
@@ -119,7 +130,7 @@ export async function handleOnboardGet(
 ): Promise<{ status: number; body: string; contentType: string }> {
   const { data, error } = await db
     .from('tenants')
-    .select('id, github_username, buffer_access_token, linkedin_member_id, config')
+    .select('id, github_username, buffer_access_token, linkedin_member_id, config, voice_bootstrap')
     .eq('github_installation_id', installationId)
     .single();
 
@@ -149,6 +160,7 @@ export async function handleOnboardPost(
   const website = params.get('website')?.trim() ?? '';
   const bufferToken = params.get('buffer_access_token')?.trim() ?? '';
   const bufferOrgId = params.get('buffer_org_id')?.trim() ?? '';
+  const voiceBootstrap = params.get('voice_bootstrap')?.trim() ?? '';
 
   if (isNaN(installationId) || !name) {
     return { status: 302, location: `/onboard?installation_id=${installationId}&error=missing_fields` };
@@ -185,6 +197,11 @@ export async function handleOnboardPost(
   // Only update buffer_access_token if a new one was provided (not the masked placeholder)
   if (bufferToken && !bufferToken.includes('••')) {
     updates['buffer_access_token'] = bufferToken;
+  }
+
+  // Save voice bootstrap if provided
+  if (voiceBootstrap) {
+    updates['voice_bootstrap'] = voiceBootstrap;
   }
 
   const { error: updateError } = await db

--- a/src/worker/main-scan-tenants.ts
+++ b/src/worker/main-scan-tenants.ts
@@ -1,0 +1,103 @@
+/**
+ * main-scan-tenants.ts — multi-tenant sent-post scanner
+ *
+ * Replaces single-tenant main-scan.ts. Iterates over all active tenants
+ * with a Buffer access token and scans their published posts for voice training.
+ *
+ * Runs as Cloud Run Job triggered by Cloud Scheduler every 2 hours.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { logger } from '../utils/logger.js';
+import { BufferClient } from '../buffer/client.js';
+import { scanSentPosts } from '../buffer/sent-scanner.js';
+import { SupabaseStorage } from '../voice/supabase-storage.js';
+import { ConfigSchema } from '../config/schema.js';
+import type { Config } from '../config/schema.js';
+
+const SUPABASE_URL = process.env['SUPABASE_URL'] ?? '';
+const SUPABASE_SERVICE_ROLE_KEY = process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '';
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  logger.error('scanner.missing_env', { vars: 'SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY' });
+  process.exit(1);
+}
+
+const db = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+interface TenantRow {
+  readonly id: string;
+  readonly github_username: string;
+  readonly buffer_access_token: string;
+  readonly config: Record<string, unknown>;
+}
+
+function buildConfig(tenant: TenantRow): Config {
+  const tc = tenant.config;
+  const result = ConfigSchema.safeParse({
+    buffer: { organization_id: 'UNCONFIGURED' },
+    platforms: {
+      linkedin: { enabled: true, buffer_profile_id: '' },
+      instagram: { enabled: false, buffer_profile_id: '' },
+    },
+    ...tc,
+    author: {
+      name: tenant.github_username,
+      ...((tc['author'] as Record<string, unknown> | undefined) ?? {}),
+      github_username: tenant.github_username,
+    },
+  });
+
+  if (!result.success) {
+    throw new Error(`Invalid config for tenant ${tenant.id}: ${result.error.message}`);
+  }
+
+  return result.data;
+}
+
+async function main(): Promise<void> {
+  logger.info('scanner.start');
+
+  const { data: tenants, error } = await db
+    .from('tenants')
+    .select('id, github_username, buffer_access_token, config')
+    .eq('active', true)
+    .not('buffer_access_token', 'is', null);
+
+  if (error) {
+    logger.error('scanner.fetch_tenants_error', { error: error.message });
+    process.exit(1);
+  }
+
+  const rows = (tenants ?? []) as TenantRow[];
+  logger.info('scanner.tenants_found', { count: rows.length });
+
+  let scanned = 0;
+  let failed = 0;
+
+  for (const tenant of rows) {
+    try {
+      const config = buildConfig(tenant);
+      const storage = new SupabaseStorage(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, tenant.id);
+      const bufferClient = new BufferClient(tenant.buffer_access_token);
+
+      await scanSentPosts(bufferClient, storage, config);
+      scanned++;
+      logger.info('scanner.tenant.done', { tenantId: tenant.id, username: tenant.github_username });
+    } catch (err) {
+      failed++;
+      logger.error('scanner.tenant.error', {
+        tenantId: tenant.id,
+        username: tenant.github_username,
+        error: String(err),
+      });
+    }
+  }
+
+  logger.info('scanner.summary', { scanned, failed, total: rows.length });
+}
+
+main().catch((err) => {
+  logger.error('scanner.fatal', { error: String(err) });
+  process.exit(1);
+});

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -99,10 +99,11 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
     .from('tenants')
     .select('id, github_installation_id, github_username, buffer_access_token, linkedin_access_token, linkedin_member_id, config')
     .eq('id', job.tenant_id)
+    .eq('active', true)
     .single();
 
   if (tenantError || !tenantData) {
-    throw new Error(`Tenant ${job.tenant_id} not found: ${tenantError?.message ?? 'no data'}`);
+    throw new Error(`Tenant ${job.tenant_id} not found or inactive: ${tenantError?.message ?? 'no data'}`);
   }
   const tenant = tenantData as TenantRow;
   const config = buildConfig(tenant);


### PR DESCRIPTION
## Summary

Completes all remaining Phase 1 items (PRs B through E from phase1-spec.md).

### Multi-tenant scanner (replaces single-tenant CRONs)
- **`main-scan-tenants.ts`**: iterates all active tenants with Buffer tokens, scans each tenant's published posts for voice training. Uses tenant-scoped `SupabaseStorage`.
- **`poll-and-generate.yml`**: CRON disabled (kept as `workflow_dispatch` for local testing)
- **`scan-sent-posts.yml`**: CRON disabled (replaced by multi-tenant scanner)

### Tenant safety
- **`process-job.ts`**: adds `AND active = true` to tenant query — inactive tenants' jobs are skipped
- **`installation.ts`**: already handles `deleted`/`suspend`/`unsuspend` (no change needed)

### Onboarding improvements
- **Voice bootstrap**: textarea where users paste 2-3 posts to train their voice. Stored in `tenants.voice_bootstrap`.
- **Logo**: nav bar shows favicon image instead of text
- **LinkedIn badge**: callback redirects with `&linkedin=connected` for visual confirmation

## Deploy steps after merge

1. CI/CD deploys automatically (webhook + worker)
2. Create Cloud Run Job for scanner:
```bash
gcloud run jobs create devcast-scanner \
  --image gcr.io/lilicurl/devcast:latest \
  --region us-central1 --project lilicurl \
  --command "npx" --args "tsx,src/worker/main-scan-tenants.ts" \
  --set-secrets=SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_SERVICE_ROLE_KEY=SUPABASE_SERVICE_ROLE_KEY:latest
```
3. Create Cloud Scheduler trigger (every 2h):
```bash
gcloud scheduler jobs create http devcast-scanner-trigger \
  --schedule "0 */2 * * *" \
  --uri "https://us-central1-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/749111652662/jobs/devcast-scanner:run" \
  --http-method POST \
  --oauth-service-account-email 749111652662-compute@developer.gserviceaccount.com \
  --location us-central1 --project lilicurl
```

## Test plan
- [ ] Visit `/onboard?installation_id=121912608` — voice bootstrap textarea visible
- [ ] Submit form with voice text — stored in `tenants.voice_bootstrap`
- [ ] Logo appears in nav bar
- [ ] Connect LinkedIn → redirect includes `&linkedin=connected`
- [ ] Push commit with inactive tenant → worker logs `not found or inactive`
- [ ] Scanner: `npx tsx src/worker/main-scan-tenants.ts` runs without errors