### PR TITLE
fix: add devcast-scanner to CI/CD deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,3 +49,11 @@ jobs:
             --image "$IMAGE" \
             --region us-central1 \
             --project lilicurl
+
+      - name: Deploy scanner job
+        run: |
+          IMAGE="gcr.io/lilicurl/devcast:${{ github.sha }}"
+          gcloud run jobs update devcast-scanner \
+            --image "$IMAGE" \
+            --region us-central1 \
+            --project lilicurl


### PR DESCRIPTION
Adds `gcloud run jobs update devcast-scanner` to deploy.yml so the scanner gets updated automatically on every push to trunk.