### PR TITLE
fix: restore onboarding activation and config defaults

### DIFF
--- a/src/webhook/handlers/onboard.ts
+++ b/src/webhook/handlers/onboard.ts
@@ -8,6 +8,7 @@ import { mergeVoiceProfile } from '../../voice/profile-utils.js';
 interface TenantRow {
   readonly id: string;
   readonly github_username: string;
+  readonly active: boolean;
   readonly buffer_access_token: string | null;
   readonly encrypted_dek: string | null;
   readonly linkedin_member_id: string | null;
@@ -278,7 +279,7 @@ export async function handleOnboardGet(
 ): Promise<{ status: number; body: string; contentType: string }> {
   const { data, error } = await db
     .from('tenants')
-    .select('id, github_username, buffer_access_token, encrypted_dek, linkedin_member_id, config, voice_bootstrap')
+    .select('id, github_username, active, buffer_access_token, encrypted_dek, linkedin_member_id, config, voice_bootstrap')
     .eq('github_installation_id', installationId)
     .single();
 
@@ -292,11 +293,27 @@ export async function handleOnboardGet(
   }
 
   const tenant = data as TenantRow;
+  if (!tenant.active) {
+    const { error: activateError } = await db
+      .from('tenants')
+      .update({ active: true })
+      .eq('github_installation_id', installationId);
+
+    if (activateError) {
+      logger.error('onboard.tenant_reactivate_failed', { installationId, error: activateError.message });
+      return {
+        status: 500,
+        body: '<h1>Internal error</h1><p>Failed to reactivate installation.</p>',
+        contentType: 'text/html',
+      };
+    }
+  }
+
   const voiceProfile = await loadDefaultVoiceProfile(db, tenant.id);
 
   return {
     status: 200,
-    body: html(tenant, installationId, voiceProfile, saved),
+    body: html({ ...tenant, active: true }, installationId, voiceProfile, saved),
     contentType: 'text/html',
   };
 }
@@ -351,6 +368,7 @@ export async function handleOnboardPost(
   const updates: Record<string, unknown> = {
     config: updatedConfig,
     voice_bootstrap: voiceBootstrap,
+    active: true,
   };
 
   if (bufferToken && !bufferToken.includes('••')) {

--- a/src/worker/main-scan-tenants.ts
+++ b/src/worker/main-scan-tenants.ts
@@ -37,6 +37,10 @@ interface TenantRow {
 function buildConfig(tenant: TenantRow): Config {
   const tc = tenant.config;
   const result = ConfigSchema.safeParse({
+    github: { exclude_repos: [], exclude_patterns: [] },
+    scheduling: {},
+    posting: {},
+    ai: {},
     buffer: { organization_id: 'UNCONFIGURED' },
     platforms: {
       linkedin: { enabled: true, buffer_profile_id: '' },

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -61,6 +61,10 @@ export interface ProcessJobDeps {
 function buildConfig(tenant: TenantRow): Config {
   const tc = tenant.config;
   const result = ConfigSchema.safeParse({
+    github: { exclude_repos: [], exclude_patterns: [] },
+    scheduling: {},
+    posting: {},
+    ai: {},
     buffer: { organization_id: 'UNCONFIGURED' },
     platforms: {
       linkedin: { enabled: true, buffer_profile_id: '' },


### PR DESCRIPTION
## Summary

Fixes two onboarding regressions in the multi-tenant flow:

- tenants created through onboarding could end up with invalid config JSON because required top-level config objects were missing
- a tenant could remain inactive if the original GitHub installation webhook was missed before the webhook service was healthy

## Root cause

`ConfigSchema` requires the `github`, `scheduling`, `posting`, and `ai` objects, but onboarding only persists author and buffer settings. Even though inner fields have defaults, the parent objects do not, so `safeParse` failed for onboarding-created tenants.

Separately, tenant activation depended on the `installation.created` webhook. If that webhook was missed during bootstrap or an early deploy problem, the user could still reach onboarding, but the tenant stayed inactive.

## What changed

- adds missing top-level defaults to `buildConfig()` in:
  - `src/worker/process-job.ts`
  - `src/worker/main-scan-tenants.ts`
- reactivates the tenant when `/onboard` is loaded and the row exists but `active = false`
- keeps `active: true` in onboarding POST updates so the normal save flow also repairs the row

## Impact

- onboarding-created tenants now parse successfully through `ConfigSchema`
- visiting `/onboard?installation_id=...` is enough to recover an inactive tenant row without requiring a second webhook
- the fix does not change the onboarding form shape or require users to configure hidden sections manually

## Validation

- `npm run typecheck`
