### PR TITLE
feat: per-developer Buffer routing via developer_profiles

### DIFF
--- a/src/buffer/publisher.ts
+++ b/src/buffer/publisher.ts
@@ -21,9 +21,9 @@ export async function publishToBuffer(
   draftId: string,
   text: string,
   platform: Platform,
+  orgId: string,
   commitMessage?: string,
 ): Promise<PublishResult | null> {
-  const orgId = config.buffer.organization_id;
   const title = commitMessage ? commitMessage.slice(0, 80) : draftId.slice(0, 8);
 
   const { id: bufferIdeaId } = await bufferClient.createIdea(orgId, title, text);

--- a/src/buffer/sent-scanner.ts
+++ b/src/buffer/sent-scanner.ts
@@ -51,17 +51,22 @@ export async function scanSentPosts(
   }
 }
 
-async function scanPlatform(
+export async function scanPlatform(
   bufferClient: BufferClient,
   storage: IVoiceStorage,
   platform: Platform,
   orgId: string,
   channelId: string,
+  authorLogin?: string,
 ): Promise<void> {
-  const [sentPosts, unmatched] = await Promise.all([
+  const [sentPosts, allUnmatched] = await Promise.all([
     bufferClient.getSentPosts(orgId, channelId),
     storage.getScheduledUnpublished(platform),
   ]);
+  // When scanning a member's personal Buffer, only match their own drafts.
+  const unmatched = authorLogin
+    ? allUnmatched.filter((d) => d.author_login === authorLogin)
+    : allUnmatched;
 
   if (sentPosts.length === 0 || unmatched.length === 0) {
     logger.info('sent_scanner.nothing_to_match', { platform, sentCount: sentPosts.length, draftCount: unmatched.length });

--- a/src/main-poll.ts
+++ b/src/main-poll.ts
@@ -309,6 +309,7 @@ async function main(): Promise<void> {
           draftId,
           bufferText,
           'linkedin',
+          config.buffer.organization_id,
           candidate.commit.message,
         );
 

--- a/src/webhook/handlers/member-onboard.ts
+++ b/src/webhook/handlers/member-onboard.ts
@@ -1,6 +1,7 @@
 import { createHmac, timingSafeEqual } from 'crypto';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { sealTenantSecrets } from '../../security/tenant-secrets.js';
+import { BufferClient } from '../../buffer/client.js';
 import { logger } from '../../utils/logger.js';
 
 // ---------------------------------------------------------------------------
@@ -112,7 +113,7 @@ function htmlForm(
   login: string,
   memberToken: string,
   orgName: string,
-  existing: { bufferConfigured: boolean; linkedinConnected: boolean; bootstrapPosts: string[] },
+  existing: { bufferConfigured: boolean; bufferOrgId: string; linkedinConnected: boolean; bootstrapPosts: string[] },
   saved: boolean,
   linkedinClientId: string,
   appBaseUrl: string,
@@ -182,6 +183,9 @@ function htmlForm(
         <label>API key</label>
         <input type="text" name="buffer_access_token" value="${maskToken(existing.bufferConfigured ? 'set' : null)}" placeholder="Paste your personal Buffer API key">
         <p class="hint">Get it at publish.buffer.com → Settings → API. Leave blank to use the organization token.</p>
+        <label>Organization ID <span style="color:#52525b;font-weight:400">optional</span></label>
+        <input type="text" name="buffer_org_id" value="${escapeHtml(existing.bufferOrgId)}" placeholder="org_...">
+        <p class="hint">Required if using your personal Buffer token. Found in your Buffer URL or Settings.</p>
       </div>
 
       <div class="card">
@@ -222,6 +226,8 @@ interface TenantRow {
 
 interface MemberRow {
   readonly buffer_access_token: string | null;
+  readonly buffer_org_id: string | null;
+  readonly buffer_linkedin_channel_id: string | null;
   readonly linkedin_member_id: string | null;
   readonly encrypted_dek: string | null;
   readonly voice_bootstrap: string | null;
@@ -277,7 +283,7 @@ export async function handleMemberOnboardGet(
   // Load existing member row
   const { data: memberData } = await db
     .from('tenant_members')
-    .select('buffer_access_token, linkedin_member_id, encrypted_dek, voice_bootstrap')
+    .select('buffer_access_token, buffer_org_id, buffer_linkedin_channel_id, linkedin_member_id, encrypted_dek, voice_bootstrap')
     .eq('tenant_id', tenant.id)
     .eq('github_author_login', parsed.login)
     .maybeSingle();
@@ -299,6 +305,7 @@ export async function handleMemberOnboardGet(
       tenant.github_username,
       {
         bufferConfigured: !!member?.buffer_access_token,
+        bufferOrgId: member?.buffer_org_id ?? '',
         linkedinConnected: !!member?.linkedin_member_id,
         bootstrapPosts,
       },
@@ -355,9 +362,11 @@ export async function handleMemberOnboardPost(
 
   const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
 
-  // Buffer token — skip if placeholder or empty
   const bufferToken = params.get('buffer_access_token')?.trim() ?? '';
-  if (bufferToken && !bufferToken.includes('••')) {
+  const bufferOrgId = params.get('buffer_org_id')?.trim() ?? '';
+  const isNewToken = !!(bufferToken && !bufferToken.includes('••'));
+
+  if (isNewToken) {
     try {
       const sealed = await sealTenantSecrets({ bufferAccessToken: bufferToken }, existingDek);
       updates['buffer_access_token'] = sealed.bufferAccessToken ?? null;
@@ -365,6 +374,24 @@ export async function handleMemberOnboardPost(
     } catch (err) {
       logger.error('member_onboard.buffer_encrypt_failed', { login, error: String(err) });
       return { status: 302, location: `/member/onboard?installation_id=${installationId}&member_token=${encodeURIComponent(memberToken)}&error=save_failed` };
+    }
+  }
+
+  if (bufferOrgId) {
+    updates['buffer_org_id'] = bufferOrgId;
+
+    // Auto-discover LinkedIn channel ID when a new token is provided with an org ID.
+    if (isNewToken) {
+      try {
+        const bufferClient = new BufferClient(bufferToken);
+        const channelId = await bufferClient.getLinkedInChannelId(bufferOrgId);
+        if (channelId) {
+          updates['buffer_linkedin_channel_id'] = channelId;
+          logger.info('member_onboard.linkedin_channel_discovered', { login, channelId });
+        }
+      } catch (err) {
+        logger.warn('member_onboard.linkedin_channel_discovery_failed', { login, error: String(err) });
+      }
     }
   }
 

--- a/src/webhook/handlers/onboard.ts
+++ b/src/webhook/handlers/onboard.ts
@@ -347,7 +347,7 @@ export async function handleOnboardPost(
 
   const { data: tenantData, error: fetchError } = await db
     .from('tenants')
-    .select('id, config, encrypted_dek, buffer_access_token')
+    .select('id, github_username, config, encrypted_dek, buffer_access_token')
     .eq('github_installation_id', installationId)
     .single();
 
@@ -355,7 +355,7 @@ export async function handleOnboardPost(
     return { status: 302, location: `/onboard?installation_id=${installationId}&error=not_found` };
   }
 
-  const tenant = tenantData as { id: string; config: Record<string, unknown>; encrypted_dek: string | null; buffer_access_token: string | null };
+  const tenant = tenantData as { id: string; github_username: string; config: Record<string, unknown>; encrypted_dek: string | null; buffer_access_token: string | null };
   const existingConfig = tenant.config;
 
   const updatedConfig: Record<string, unknown> = {
@@ -388,6 +388,7 @@ export async function handleOnboardPost(
 
   // Auto-discover LinkedIn channel ID when we have any usable token + an org ID.
   // Runs on new token OR on org ID change using the existing stored token.
+  let discoveredLinkedInChannelId: string | null = null;
   if (effectiveOrgId) {
     let rawTokenForDiscovery: string | null = null;
     if (isNewToken) {
@@ -398,15 +399,15 @@ export async function handleOnboardPost(
     if (rawTokenForDiscovery) {
       try {
         const bufferClient = new BufferClient(rawTokenForDiscovery);
-        const linkedInChannelId = await bufferClient.getLinkedInChannelId(effectiveOrgId);
-        if (linkedInChannelId) {
+        discoveredLinkedInChannelId = await bufferClient.getLinkedInChannelId(effectiveOrgId);
+        if (discoveredLinkedInChannelId) {
           const existingPlatforms = (existingConfig['platforms'] as Record<string, unknown> | undefined) ?? {};
           const existingLinkedin = (existingPlatforms['linkedin'] as Record<string, unknown> | undefined) ?? {};
           updatedConfig['platforms'] = {
             ...existingPlatforms,
-            linkedin: { ...existingLinkedin, buffer_profile_id: linkedInChannelId },
+            linkedin: { ...existingLinkedin, buffer_profile_id: discoveredLinkedInChannelId },
           };
-          logger.info('onboard.linkedin_channel_discovered', { installationId, linkedInChannelId });
+          logger.info('onboard.linkedin_channel_discovered', { installationId, linkedInChannelId: discoveredLinkedInChannelId });
         }
       } catch (err) {
         logger.warn('onboard.linkedin_channel_discovery_failed', { installationId, error: String(err) });
@@ -436,6 +437,44 @@ export async function handleOnboardPost(
   if (updateError) {
     logger.error('onboard.save_failed', { installationId, error: updateError.message });
     return { status: 302, location: `/onboard?installation_id=${installationId}&error=save_failed` };
+  }
+
+  // Upsert developer_profiles so this developer's Buffer config is available
+  // cross-tenant. Non-fatal: a failure here does not roll back the tenant save.
+  try {
+    const { data: existingProfile } = await db
+      .from('developer_profiles')
+      .select('encrypted_dek')
+      .eq('github_login', tenant.github_username)
+      .maybeSingle();
+
+    const existingProfileDek = (existingProfile as { encrypted_dek: string | null } | null)?.encrypted_dek ?? null;
+    const profileUpdates: Record<string, unknown> = {
+      github_login: tenant.github_username,
+      voice_bootstrap: voiceBootstrap,
+      updated_at: new Date().toISOString(),
+    };
+
+    if (effectiveOrgId) profileUpdates['buffer_org_id'] = effectiveOrgId;
+    if (discoveredLinkedInChannelId) profileUpdates['buffer_linkedin_channel_id'] = discoveredLinkedInChannelId;
+
+    if (isNewToken) {
+      const sealed = await sealTenantSecrets({ bufferAccessToken: bufferToken }, existingProfileDek);
+      profileUpdates['buffer_access_token'] = sealed.bufferAccessToken ?? null;
+      profileUpdates['encrypted_dek'] = sealed.encryptedDek;
+    }
+
+    const { error: profileError } = await db
+      .from('developer_profiles')
+      .upsert(profileUpdates, { onConflict: 'github_login' });
+
+    if (profileError) {
+      logger.warn('onboard.developer_profile_upsert_failed', { installationId, login: tenant.github_username, error: profileError.message });
+    } else {
+      logger.info('onboard.developer_profile_saved', { installationId, login: tenant.github_username });
+    }
+  } catch (err) {
+    logger.warn('onboard.developer_profile_upsert_error', { installationId, error: String(err) });
   }
 
   const { data: voiceRow, error: voiceFetchError } = await db

--- a/src/worker/main-scan-tenants.ts
+++ b/src/worker/main-scan-tenants.ts
@@ -10,7 +10,7 @@
 import { createClient } from '@supabase/supabase-js';
 import { logger } from '../utils/logger.js';
 import { BufferClient } from '../buffer/client.js';
-import { scanSentPosts } from '../buffer/sent-scanner.js';
+import { scanSentPosts, scanPlatform } from '../buffer/sent-scanner.js';
 import { SupabaseStorage } from '../voice/supabase-storage.js';
 import { ConfigSchema } from '../config/schema.js';
 import type { Config } from '../config/schema.js';
@@ -32,6 +32,14 @@ interface TenantRow {
   readonly buffer_access_token: string | null;
   readonly encrypted_dek: string | null;
   readonly config: Record<string, unknown>;
+}
+
+interface MemberScanRow {
+  readonly github_author_login: string;
+  readonly buffer_access_token: string | null;
+  readonly buffer_org_id: string | null;
+  readonly buffer_linkedin_channel_id: string | null;
+  readonly encrypted_dek: string | null;
 }
 
 function buildConfig(tenant: TenantRow): Config {
@@ -93,6 +101,43 @@ async function main(): Promise<void> {
       const bufferClient = new BufferClient(secrets.bufferAccessToken);
 
       await scanSentPosts(bufferClient, storage, config);
+
+      // Scan each member's personal Buffer when they have their own org ID configured.
+      const { data: memberRows } = await db
+        .from('tenant_members')
+        .select('github_author_login, buffer_access_token, buffer_org_id, buffer_linkedin_channel_id, encrypted_dek')
+        .eq('tenant_id', tenant.id)
+        .not('buffer_org_id', 'is', null)
+        .not('buffer_linkedin_channel_id', 'is', null);
+
+      for (const raw of (memberRows ?? []) as MemberScanRow[]) {
+        if (!raw.buffer_access_token) continue;
+        try {
+          const memberSecrets = await resolveTenantSecrets({
+            encrypted_dek: raw.encrypted_dek,
+            buffer_access_token: raw.buffer_access_token,
+          });
+          if (!memberSecrets.bufferAccessToken) continue;
+
+          const memberClient = new BufferClient(memberSecrets.bufferAccessToken);
+          await scanPlatform(
+            memberClient,
+            storage,
+            'linkedin',
+            raw.buffer_org_id!,
+            raw.buffer_linkedin_channel_id!,
+            raw.github_author_login,
+          );
+          logger.info('scanner.member.done', { tenantId: tenant.id, authorLogin: raw.github_author_login });
+        } catch (err) {
+          logger.error('scanner.member.error', {
+            tenantId: tenant.id,
+            authorLogin: raw.github_author_login,
+            error: String(err),
+          });
+        }
+      }
+
       scanned++;
       logger.info('scanner.tenant.done', { tenantId: tenant.id, username: tenant.github_username });
     } catch (err) {

--- a/src/worker/main-scan-tenants.ts
+++ b/src/worker/main-scan-tenants.ts
@@ -34,8 +34,7 @@ interface TenantRow {
   readonly config: Record<string, unknown>;
 }
 
-interface MemberScanRow {
-  readonly github_author_login: string;
+interface DevProfileRow {
   readonly buffer_access_token: string | null;
   readonly buffer_org_id: string | null;
   readonly buffer_linkedin_channel_id: string | null;
@@ -75,8 +74,7 @@ async function main(): Promise<void> {
   const { data: tenants, error } = await db
     .from('tenants')
     .select('id, github_username, buffer_access_token, encrypted_dek, config')
-    .eq('active', true)
-    .not('buffer_access_token', 'is', null);
+    .eq('active', true);
 
   if (error) {
     logger.error('scanner.fetch_tenants_error', { error: error.message });
@@ -94,47 +92,47 @@ async function main(): Promise<void> {
       const config = buildConfig(tenant);
       const secrets = await resolveTenantSecrets(tenant);
       const storage = new SupabaseStorage(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, tenant.id);
-      if (!secrets.bufferAccessToken) {
-        logger.warn('scanner.tenant.skip_missing_buffer_token', { tenantId: tenant.id, username: tenant.github_username });
-        continue;
+
+      // Org-level scan — only runs when the tenant has its own Buffer configured.
+      if (secrets.bufferAccessToken) {
+        const bufferClient = new BufferClient(secrets.bufferAccessToken);
+        await scanSentPosts(bufferClient, storage, config);
       }
-      const bufferClient = new BufferClient(secrets.bufferAccessToken);
 
-      await scanSentPosts(bufferClient, storage, config);
-
-      // Scan each member's personal Buffer when they have their own org ID configured.
-      const { data: memberRows } = await db
-        .from('tenant_members')
-        .select('github_author_login, buffer_access_token, buffer_org_id, buffer_linkedin_channel_id, encrypted_dek')
-        .eq('tenant_id', tenant.id)
-        .not('buffer_org_id', 'is', null)
-        .not('buffer_linkedin_channel_id', 'is', null);
-
-      for (const raw of (memberRows ?? []) as MemberScanRow[]) {
-        if (!raw.buffer_access_token) continue;
+      // Scan each active author's personal Buffer via developer_profiles.
+      // This is the primary path: one-time configuration, works cross-tenant.
+      const activeAuthors = await storage.listActiveAuthors(30);
+      for (const authorLogin of activeAuthors) {
         try {
-          const memberSecrets = await resolveTenantSecrets({
-            encrypted_dek: raw.encrypted_dek,
-            buffer_access_token: raw.buffer_access_token,
-          });
-          if (!memberSecrets.bufferAccessToken) continue;
+          const { data: devProfile } = await db
+            .from('developer_profiles')
+            .select('buffer_access_token, buffer_org_id, buffer_linkedin_channel_id, encrypted_dek')
+            .eq('github_login', authorLogin)
+            .not('buffer_org_id', 'is', null)
+            .not('buffer_linkedin_channel_id', 'is', null)
+            .maybeSingle();
 
-          const memberClient = new BufferClient(memberSecrets.bufferAccessToken);
+          if (!devProfile?.buffer_access_token) continue;
+
+          const row = devProfile as DevProfileRow;
+          const devSecrets = await resolveTenantSecrets({
+            encrypted_dek: row.encrypted_dek,
+            buffer_access_token: row.buffer_access_token,
+          });
+          if (!devSecrets.bufferAccessToken) continue;
+
+          const devClient = new BufferClient(devSecrets.bufferAccessToken);
           await scanPlatform(
-            memberClient,
+            devClient,
             storage,
             'linkedin',
-            raw.buffer_org_id!,
-            raw.buffer_linkedin_channel_id!,
-            raw.github_author_login,
+            row.buffer_org_id!,
+            row.buffer_linkedin_channel_id!,
+            authorLogin,
           );
-          logger.info('scanner.member.done', { tenantId: tenant.id, authorLogin: raw.github_author_login });
+          logger.info('scanner.author.done', { tenantId: tenant.id, authorLogin });
         } catch (err) {
-          logger.error('scanner.member.error', {
-            tenantId: tenant.id,
-            authorLogin: raw.github_author_login,
-            error: String(err),
-          });
+          logger.error('scanner.author.error', { tenantId: tenant.id, authorLogin, error: String(err) });
         }
       }
 

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -651,7 +651,7 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
         // Create Buffer Idea — prefer member credentials, fall back to tenant
         const effectiveBufferToken = authorState.memberBufferToken ?? secrets.bufferAccessToken;
         const effectiveBufferOrgId = authorState.memberBufferOrgId ?? config.buffer.organization_id;
-        if (effectiveBufferToken) {
+        if (effectiveBufferToken && effectiveBufferOrgId && effectiveBufferOrgId !== 'UNCONFIGURED') {
           const bufferClient = new BufferClient(effectiveBufferToken);
           const publishResult = await publishToBuffer(
             bufferClient, storage, config, draftId, bufferText, 'linkedin', effectiveBufferOrgId, candidate.commit.message,

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -76,6 +76,7 @@ interface AuthorGenerationState {
   readonly memberLinkedinToken: string | null;
   readonly memberLinkedinMemberId: string | null;
   readonly memberBufferToken: string | null;
+  readonly memberBufferOrgId: string | null;
   // Per-member bootstrap posts — empty means fall back to voiceProfile.bootstrap_posts
   readonly memberBootstrapPosts: BootstrapPost[];
 }
@@ -207,13 +208,14 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
     let memberLinkedinToken: string | null = null;
     let memberLinkedinMemberId: string | null = null;
     let memberBufferToken: string | null = null;
+    let memberBufferOrgId: string | null = null;
     let memberBootstrapPosts: BootstrapPost[] = [];
 
     if (authorLogin) {
       try {
         const { data: memberRow, error: memberError } = await deps.db
           .from('tenant_members')
-          .select('linkedin_access_token, linkedin_member_id, buffer_access_token, encrypted_dek, voice_bootstrap')
+          .select('linkedin_access_token, linkedin_member_id, buffer_access_token, buffer_org_id, encrypted_dek, voice_bootstrap')
           .eq('tenant_id', tenant.id)
           .eq('github_author_login', authorLogin)
           .maybeSingle();
@@ -223,6 +225,7 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
             linkedin_access_token: string | null;
             linkedin_member_id: string | null;
             buffer_access_token: string | null;
+            buffer_org_id: string | null;
             encrypted_dek: string | null;
             voice_bootstrap: string | null;
           };
@@ -234,6 +237,7 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
           memberLinkedinToken = memberSecrets.linkedinAccessToken;
           memberBufferToken = memberSecrets.bufferAccessToken;
           memberLinkedinMemberId = row.linkedin_member_id;
+          memberBufferOrgId = row.buffer_org_id;
 
           try {
             const raw = JSON.parse(row.voice_bootstrap ?? '[]') as string[];
@@ -264,6 +268,7 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
       memberLinkedinToken,
       memberLinkedinMemberId,
       memberBufferToken,
+      memberBufferOrgId,
       memberBootstrapPosts,
     };
     authorStates.set(authorKey, state);
@@ -599,10 +604,11 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
 
         // Create Buffer Idea — prefer member credentials, fall back to tenant
         const effectiveBufferToken = authorState.memberBufferToken ?? secrets.bufferAccessToken;
+        const effectiveBufferOrgId = authorState.memberBufferOrgId ?? config.buffer.organization_id;
         if (effectiveBufferToken) {
           const bufferClient = new BufferClient(effectiveBufferToken);
           const publishResult = await publishToBuffer(
-            bufferClient, storage, config, draftId, bufferText, 'linkedin', candidate.commit.message,
+            bufferClient, storage, config, draftId, bufferText, 'linkedin', effectiveBufferOrgId, candidate.commit.message,
           );
           if (publishResult) {
             const notificationRepo = config.github.notification_repo ?? repo;

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -204,7 +204,8 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
       ? (await storage.getDraftsSince(authorLogin, dayStartIso)).map(toTodayDraftState)
       : [];
 
-    // Load per-member credentials — one query per author per job, cached below
+    // Load per-author credentials.
+    // Lookup order: developer_profiles (global) → tenant_members (org override).
     let memberLinkedinToken: string | null = null;
     let memberLinkedinMemberId: string | null = null;
     let memberBufferToken: string | null = null;
@@ -212,6 +213,48 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
     let memberBootstrapPosts: BootstrapPost[] = [];
 
     if (authorLogin) {
+      // 1. Global developer profile — configured once, applies cross-tenant.
+      try {
+        const { data: devProfile } = await deps.db
+          .from('developer_profiles')
+          .select('buffer_access_token, buffer_org_id, buffer_linkedin_channel_id, linkedin_access_token, linkedin_member_id, encrypted_dek, voice_bootstrap')
+          .eq('github_login', authorLogin)
+          .maybeSingle();
+
+        if (devProfile) {
+          const row = devProfile as {
+            buffer_access_token: string | null;
+            buffer_org_id: string | null;
+            buffer_linkedin_channel_id: string | null;
+            linkedin_access_token: string | null;
+            linkedin_member_id: string | null;
+            encrypted_dek: string | null;
+            voice_bootstrap: string | null;
+          };
+          const devSecrets = await resolveTenantSecrets({
+            encrypted_dek: row.encrypted_dek,
+            buffer_access_token: row.buffer_access_token,
+            linkedin_access_token: row.linkedin_access_token,
+          });
+          memberBufferToken = devSecrets.bufferAccessToken;
+          memberBufferOrgId = row.buffer_org_id;
+          memberLinkedinToken = devSecrets.linkedinAccessToken;
+          memberLinkedinMemberId = row.linkedin_member_id;
+
+          try {
+            const raw = JSON.parse(row.voice_bootstrap ?? '[]') as string[];
+            memberBootstrapPosts = raw
+              .filter((t) => typeof t === 'string' && t.trim().length > 0)
+              .map((text) => ({ text, pasted_at: new Date().toISOString() }));
+          } catch {
+            // Non-fatal
+          }
+        }
+      } catch (err) {
+        logger.warn('worker.author.dev_profile_failed', { authorLogin, error: String(err) });
+      }
+
+      // 2. Org-level override in tenant_members — explicit per-org config wins over global.
       try {
         const { data: memberRow, error: memberError } = await deps.db
           .from('tenant_members')
@@ -234,23 +277,26 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
             buffer_access_token: row.buffer_access_token,
             linkedin_access_token: row.linkedin_access_token,
           });
-          memberLinkedinToken = memberSecrets.linkedinAccessToken;
-          memberBufferToken = memberSecrets.bufferAccessToken;
-          memberLinkedinMemberId = row.linkedin_member_id;
-          memberBufferOrgId = row.buffer_org_id;
+          // Override only fields explicitly set in tenant_members
+          if (memberSecrets.bufferAccessToken) memberBufferToken = memberSecrets.bufferAccessToken;
+          if (row.buffer_org_id) memberBufferOrgId = row.buffer_org_id;
+          if (memberSecrets.linkedinAccessToken) memberLinkedinToken = memberSecrets.linkedinAccessToken;
+          if (row.linkedin_member_id) memberLinkedinMemberId = row.linkedin_member_id;
 
-          try {
-            const raw = JSON.parse(row.voice_bootstrap ?? '[]') as string[];
-            memberBootstrapPosts = raw
-              .filter((t) => typeof t === 'string' && t.trim().length > 0)
-              .map((text) => ({ text, pasted_at: new Date().toISOString() }));
-          } catch {
-            // Non-fatal: leave memberBootstrapPosts empty, fall back to org defaults
+          if (row.voice_bootstrap) {
+            try {
+              const raw = JSON.parse(row.voice_bootstrap) as string[];
+              const parsed = raw
+                .filter((t) => typeof t === 'string' && t.trim().length > 0)
+                .map((text) => ({ text, pasted_at: new Date().toISOString() }));
+              if (parsed.length > 0) memberBootstrapPosts = parsed;
+            } catch {
+              // Non-fatal
+            }
           }
         }
       } catch (err) {
         logger.warn('worker.author.member_secrets_failed', { authorLogin, error: String(err) });
-        // Non-fatal: worker falls back to tenant-level credentials
       }
     }
 


### PR DESCRIPTION
## Problem

Org installs (e.g. microboxlabs) had no Buffer token configured at the tenant level, so posts were generated but never sent to Buffer. Requiring each developer to configure Buffer credentials per org installation was bad UX.

## Solution

Introduce a `developer_profiles` table — configure Buffer once on personal install, works automatically across all org installs (same pattern as GitHub OAuth).

## Lookup order for Buffer credentials (process-job.ts)

1. `developer_profiles` (global, per developer) — primary path
2. `tenant_members` (org-level override) — only if explicitly set
3. `tenants.buffer_access_token` — fallback for old single-tenant configs

## Changes

### `src/buffer/publisher.ts`
- `publishToBuffer` now accepts explicit `orgId` parameter instead of reading from config — enables per-developer org routing

### `src/buffer/sent-scanner.ts`
- Export `scanPlatform` with optional `authorLogin` filter — when set, only matches that author's drafts (prevents cross-author contamination)

### `src/webhook/handlers/onboard.ts`
- After saving tenant config, upsert to `developer_profiles` with Buffer token, org ID, and LinkedIn channel ID — creates the global profile automatically on personal install

### `src/webhook/handlers/member-onboard.ts`
- Add `buffer_org_id` field to the member onboard form
- Auto-discover LinkedIn channel ID when org ID is provided (reuses existing discovery logic)

### `src/worker/process-job.ts`
- Two-step credential lookup: `developer_profiles` first, `tenant_members` override second
- Guard: skip Buffer publish when `effectiveBufferOrgId` is `'UNCONFIGURED'`

### `src/worker/main-scan-tenants.ts`
- Org-level scan is now conditional on tenant having a Buffer token
- Per-author scan: iterates `listActiveAuthors` → looks up `developer_profiles` → calls `scanPlatform` with `authorLogin` filter

### `src/main-poll.ts`
- Fix broken `publishToBuffer` call — `orgId` was missing after publisher signature change, causing commit message to be passed as org ID

## Migration required

The `developer_profiles` table must exist before deploying. SQL already applied to production:

```sql
CREATE TABLE developer_profiles (
  github_login TEXT PRIMARY KEY,
  buffer_access_token TEXT,
  buffer_org_id TEXT,
  buffer_linkedin_channel_id TEXT,
  encrypted_dek TEXT,
  voice_bootstrap JSONB,
  updated_at TIMESTAMPTZ DEFAULT NOW()
);
```

## Post-deploy steps

1. korutx redoes onboard at `/onboard?installation_id=122945568` — creates his `developer_profiles` entry
2. Run backfill script to send his existing pending posts to Buffer