### PR TITLE
feat: Fase A delta-awareness — 22 modules + diff-parser helpers + commit.body

### DIFF
--- a/src/ai/prompt-builder.ts
+++ b/src/ai/prompt-builder.ts
@@ -163,6 +163,9 @@ export function buildUserPrompt(
   parts.push('<commit>');
   parts.push(`Repository: ${commit.repo}`);
   parts.push(`Message: ${commit.message}`);
+  if (commit.body.trim()) {
+    parts.push(`Body:\n${commit.body.trim().split('\n').slice(0, 5).join('\n')}`);
+  }
   parts.push(`Languages: ${commit.languages.join(', ') || 'mixed'}`);
   if (commit.authorLogin) parts.push(`Author: ${commit.authorLogin}`);
   parts.push('</commit>');

--- a/src/analysis/diff-parser.ts
+++ b/src/analysis/diff-parser.ts
@@ -32,6 +32,41 @@ export function parseCommitFiles(rawFiles: RawFile[]): FileDiff[] {
     });
 }
 
+export function extractAddedLines(patch: string): string {
+  return patch
+    .split('\n')
+    .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+    .map((l) => l.slice(1))
+    .join('\n');
+}
+
+export function extractRemovedLines(patch: string): string {
+  return patch
+    .split('\n')
+    .filter((l) => l.startsWith('-') && !l.startsWith('---'))
+    .map((l) => l.slice(1))
+    .join('\n');
+}
+
+export function extractFirstHunkSnippet(patch: string, maxLines = 6): string {
+  const lines = patch.split('\n');
+  let inHunk = false;
+  const result: string[] = [];
+
+  for (const line of lines) {
+    if (line.startsWith('@@')) {
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk) continue;
+    if (line.startsWith('\\')) continue;
+    result.push(line);
+    if (result.length >= maxLines) break;
+  }
+
+  return result.join('\n');
+}
+
 function normalizeStatus(raw: string): FileDiff['status'] {
   switch (raw) {
     case 'added':    return 'added';

--- a/src/analysis/modules/ai-assisted.ts
+++ b/src/analysis/modules/ai-assisted.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 // AI SDK imports in added lines
 const AI_SDK_PATTERNS = [
@@ -37,7 +38,9 @@ export class AiAssistedModule implements CodeAnalyzer {
         .map(l => l.slice(1))
     ).join('\n');
 
-    const hasAiSdk = AI_SDK_PATTERNS.some(p => p.test(addedText));
+    const removedText = ctx.diffs.map(d => extractRemovedLines(d.patch)).join('\n');
+
+    const hasAiSdk = AI_SDK_PATTERNS.some(p => p.test(addedText)) && !AI_SDK_PATTERNS.some(p => p.test(removedText));
 
     const aiFiles = ctx.diffs.filter(d =>
       AI_FILE_PATTERNS.some(p => p.test(d.filename))
@@ -56,6 +59,7 @@ export class AiAssistedModule implements CodeAnalyzer {
                     : sdkMatch?.source.includes('langchain') ? 'LangChain'
                     : 'an AI SDK';
 
+      const sdkDiff = ctx.diffs.find(d => AI_SDK_PATTERNS.some(p => p.test(d.patch)));
       return {
         moduleId: this.id,
         aspect: 'AI SDK integration',
@@ -64,6 +68,10 @@ export class AiAssistedModule implements CodeAnalyzer {
         plainLanguage: `The commit adds ${sdkName} as a capability layer in the application. Focus on the engineering decision: where the model sits in the flow, what constraints or retries were added, what cost boundary was introduced, and what the code now enables or prevents.`,
         interestScore: 8,
         contextHint: `${ctx.diffs[0]?.filename ?? 'unknown'} in ${ctx.repo}`,
+        evidence: {
+          before: sdkDiff ? extractRemovedLines(sdkDiff.patch).slice(0, 300) || undefined : undefined,
+          after: sdkDiff ? extractFirstHunkSnippet(sdkDiff.patch) || undefined : undefined,
+        },
       };
     }
 
@@ -77,6 +85,10 @@ export class AiAssistedModule implements CodeAnalyzer {
         plainLanguage: 'Prompts and control surfaces are part of the product. Write about the behavior that changed: what became configurable, what guardrail was added, what failure mode was reduced, or what output became more reliable. The model is context, not the protagonist.',
         interestScore: 7,
         contextHint: `${aiFiles[0]?.filename ?? 'unknown'} in ${ctx.repo}`,
+        evidence: {
+          before: aiFiles[0] ? extractRemovedLines(aiFiles[0].patch).slice(0, 300) || undefined : undefined,
+          after: aiFiles[0] ? extractFirstHunkSnippet(aiFiles[0].patch) || undefined : undefined,
+        },
       };
     }
 

--- a/src/analysis/modules/api-design.ts
+++ b/src/analysis/modules/api-design.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 interface ApiPattern {
   readonly name: string;
@@ -90,8 +91,11 @@ export class ApiDesignModule implements CodeAnalyzer {
 
       if (addedLines.length === 0) continue;
 
+      const removedText = extractRemovedLines(diff.patch);
+      const removedLines = removedText.split('\n').filter(Boolean);
+
       for (const pattern of PATTERNS) {
-        if (pattern.detect(addedLines)) {
+        if (pattern.detect(addedLines) && !pattern.detect(removedLines)) {
           return {
             moduleId: this.id,
             aspect: pattern.name,
@@ -100,6 +104,10 @@ export class ApiDesignModule implements CodeAnalyzer {
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
             contextHint: `${diff.filename} in ${ctx.repo}`,
+            evidence: {
+              before: removedText.slice(0, 300) || undefined,
+              after: extractFirstHunkSnippet(diff.patch) || undefined,
+            },
           };
         }
       }

--- a/src/analysis/modules/architecture-patterns.ts
+++ b/src/analysis/modules/architecture-patterns.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 interface ArchPattern {
   readonly name: string;
@@ -114,18 +115,28 @@ export class ArchitecturePatternsModule implements CodeAnalyzer {
 
       if (addedLines.length === 0) continue;
 
+      const removedText = extractRemovedLines(diff.patch);
+      const removedLines = removedText.split('\n').filter(Boolean);
+
       for (const pattern of PATTERNS) {
-        if (pattern.detect(addedLines, diff.filename, allFilenames)) {
-          return {
-            moduleId: this.id,
-            aspect: pattern.name,
-            finding: `Detected ${pattern.name} in ${diff.filename}`,
-            technicalDetail: pattern.technicalDetail,
-            plainLanguage: pattern.explanation,
-            interestScore: pattern.score,
-            contextHint: `${diff.filename} in ${ctx.repo}`,
-          };
-        }
+        if (!pattern.detect(addedLines, diff.filename, allFilenames)) continue;
+        // Filename-only patterns (detect ignores lines) always fire — skip delta guard.
+        // Line-content patterns: skip if the same pattern fires on removed lines too.
+        const firesWithoutLines = pattern.detect([], diff.filename, allFilenames);
+        if (!firesWithoutLines && pattern.detect(removedLines, diff.filename, allFilenames)) continue;
+        return {
+          moduleId: this.id,
+          aspect: pattern.name,
+          finding: `Detected ${pattern.name} in ${diff.filename}`,
+          technicalDetail: pattern.technicalDetail,
+          plainLanguage: pattern.explanation,
+          interestScore: pattern.score,
+          contextHint: `${diff.filename} in ${ctx.repo}`,
+          evidence: {
+            before: firesWithoutLines ? undefined : removedText.slice(0, 300) || undefined,
+            after: extractFirstHunkSnippet(diff.patch) || undefined,
+          },
+        };
       }
     }
 

--- a/src/analysis/modules/complexity.ts
+++ b/src/analysis/modules/complexity.ts
@@ -1,4 +1,6 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+// extractAddedLines/extractRemovedLines not imported: complexity already computes
+// a per-file delta (addedDecisions vs removedDecisions) and fires only on net change >= 3.
 
 // Decision-point keywords that contribute to cyclomatic complexity
 const DECISION_PATTERN = /\b(if|else\s+if|switch|case|for|while|do|catch|finally)\b|&&|\|\||\?[^:]/g;

--- a/src/analysis/modules/concurrency.ts
+++ b/src/analysis/modules/concurrency.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 interface ConcurrencyPattern {
   readonly name: string;
@@ -80,8 +81,11 @@ export class ConcurrencyModule implements CodeAnalyzer {
 
       if (addedLines.length === 0) continue;
 
+      const removedText = extractRemovedLines(diff.patch);
+      const removedLines = removedText.split('\n').filter(Boolean);
+
       for (const pattern of PATTERNS) {
-        if (pattern.detect(addedLines)) {
+        if (pattern.detect(addedLines) && !pattern.detect(removedLines)) {
           return {
             moduleId: this.id,
             aspect: pattern.name,
@@ -90,6 +94,10 @@ export class ConcurrencyModule implements CodeAnalyzer {
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
             contextHint: `${diff.filename} in ${ctx.repo}`,
+            evidence: {
+              before: removedText.slice(0, 300) || undefined,
+              after: extractFirstHunkSnippet(diff.patch) || undefined,
+            },
           };
         }
       }

--- a/src/analysis/modules/design-patterns.ts
+++ b/src/analysis/modules/design-patterns.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractAddedLines, extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 interface PatternSignature {
   name: string;
@@ -86,15 +87,16 @@ export class DesignPatternsModule implements CodeAnalyzer {
   readonly category = 'design_patterns' as const;
 
   async analyze(ctx: AnalysisContext): Promise<Finding | null> {
-    const addedLines = extractAddedLines(ctx.diffs);
-    if (addedLines.length === 0) return null;
+    const addedText = ctx.diffs.map(d => extractAddedLines(d.patch)).join('\n');
+    if (!addedText) return null;
 
-    const addedText = addedLines.join('\n');
+    const removedText = ctx.diffs.map(d => extractRemovedLines(d.patch)).join('\n');
     const primaryFile = ctx.diffs[0]?.filename ?? 'unknown';
 
     for (const pattern of PATTERNS) {
-      const matches = pattern.addedPatterns.filter(p => p.test(addedText));
-      if (matches.length >= pattern.minMatches) {
+      const addedMatches = pattern.addedPatterns.filter(p => p.test(addedText));
+      const removedMatches = pattern.addedPatterns.filter(p => p.test(removedText));
+      if (addedMatches.length >= pattern.minMatches && removedMatches.length < pattern.minMatches) {
         return {
           moduleId: this.id,
           aspect: `${pattern.name} pattern`,
@@ -103,22 +105,14 @@ export class DesignPatternsModule implements CodeAnalyzer {
           plainLanguage: pattern.explanation,
           interestScore: pattern.interestScore,
           contextHint: `${primaryFile} in ${ctx.repo}`,
+          evidence: {
+            before: removedText.slice(0, 300) || undefined,
+            after: extractFirstHunkSnippet(ctx.diffs[0]?.patch ?? '') || undefined,
+          },
         };
       }
     }
 
     return null;
   }
-}
-
-function extractAddedLines(diffs: { patch: string }[]): string[] {
-  const lines: string[] = [];
-  for (const diff of diffs) {
-    for (const line of diff.patch.split('\n')) {
-      if (line.startsWith('+') && !line.startsWith('+++')) {
-        lines.push(line.slice(1));
-      }
-    }
-  }
-  return lines;
 }

--- a/src/analysis/modules/devops.ts
+++ b/src/analysis/modules/devops.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 interface DevopsPattern {
   readonly name: string;
@@ -130,8 +131,11 @@ export class DevopsModule implements CodeAnalyzer {
 
       if (addedLines.length === 0) continue;
 
+      const removedText = extractRemovedLines(diff.patch);
+      const removedLines = removedText.split('\n').filter(Boolean);
+
       for (const pattern of PATTERNS) {
-        if (pattern.detect(addedLines, diff.filename)) {
+        if (pattern.detect(addedLines, diff.filename) && !pattern.detect(removedLines, diff.filename)) {
           return {
             moduleId: this.id,
             aspect: pattern.name,
@@ -140,6 +144,10 @@ export class DevopsModule implements CodeAnalyzer {
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
             contextHint: `${diff.filename} in ${ctx.repo}`,
+            evidence: {
+              before: removedText.slice(0, 300) || undefined,
+              after: extractFirstHunkSnippet(diff.patch) || undefined,
+            },
           };
         }
       }

--- a/src/analysis/modules/dx.ts
+++ b/src/analysis/modules/dx.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 interface DxPattern {
   readonly name: string;
@@ -111,8 +112,11 @@ export class DxModule implements CodeAnalyzer {
 
       if (addedLines.length === 0) continue;
 
+      const removedText = extractRemovedLines(diff.patch);
+      const removedLines = removedText.split('\n').filter(Boolean);
+
       for (const pattern of PATTERNS) {
-        if (pattern.detect(addedLines, diff.filename)) {
+        if (pattern.detect(addedLines, diff.filename) && !pattern.detect(removedLines, diff.filename)) {
           return {
             moduleId: this.id,
             aspect: pattern.name,
@@ -121,6 +125,10 @@ export class DxModule implements CodeAnalyzer {
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
             contextHint: `${diff.filename} in ${ctx.repo}`,
+            evidence: {
+              before: removedText.slice(0, 300) || undefined,
+              after: extractFirstHunkSnippet(diff.patch) || undefined,
+            },
           };
         }
       }

--- a/src/analysis/modules/elixir-patterns.ts
+++ b/src/analysis/modules/elixir-patterns.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 interface ElixirPattern {
   readonly name: string;
@@ -118,8 +119,11 @@ export class ElixirPatternsModule implements CodeAnalyzer {
 
       if (addedLines.length === 0) continue;
 
+      const removedText = extractRemovedLines(diff.patch);
+      const removedLines = removedText.split('\n').filter(Boolean);
+
       for (const pattern of PATTERNS) {
-        if (pattern.detect(addedLines)) {
+        if (pattern.detect(addedLines) && !pattern.detect(removedLines)) {
           return {
             moduleId: this.id,
             aspect: pattern.name,
@@ -128,6 +132,10 @@ export class ElixirPatternsModule implements CodeAnalyzer {
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
             contextHint: `${diff.filename} in ${ctx.repo}`,
+            evidence: {
+              before: removedText.slice(0, 300) || undefined,
+              after: extractFirstHunkSnippet(diff.patch) || undefined,
+            },
           };
         }
       }

--- a/src/analysis/modules/error-resilience.ts
+++ b/src/analysis/modules/error-resilience.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 interface ResiliencePattern {
   readonly name: string;
@@ -87,8 +88,11 @@ export class ErrorResilienceModule implements CodeAnalyzer {
 
       if (addedLines.length === 0) continue;
 
+      const removedText = extractRemovedLines(diff.patch);
+      const removedLines = removedText.split('\n').filter(Boolean);
+
       for (const pattern of PATTERNS) {
-        if (pattern.detect(addedLines)) {
+        if (pattern.detect(addedLines) && !pattern.detect(removedLines)) {
           return {
             moduleId: this.id,
             aspect: pattern.name,
@@ -97,6 +101,10 @@ export class ErrorResilienceModule implements CodeAnalyzer {
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
             contextHint: `${diff.filename} in ${ctx.repo}`,
+            evidence: {
+              before: removedText.slice(0, 300) || undefined,
+              after: extractFirstHunkSnippet(diff.patch) || undefined,
+            },
           };
         }
       }

--- a/src/analysis/modules/evolutionary.ts
+++ b/src/analysis/modules/evolutionary.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding, FileDiff } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 const MIGRATION_REGEX = /(?:migrat|\.sql$)/i;
 const MIN_EXTRACTION_LINES = 30;
@@ -78,6 +79,8 @@ function detectMigration(ctx: AnalysisContext): Finding | null {
   };
 }
 
+const DEPRECATION_REGEX = /\b@[Dd]eprecated\b|\/\/\s*DEPRECATED|\/\*\*?\s*@deprecated/;
+
 function detectDeprecation(ctx: AnalysisContext): Finding | null {
   for (const diff of ctx.diffs) {
     if (!diff.patch || diff.status === 'removed') continue;
@@ -86,18 +89,25 @@ function detectDeprecation(ctx: AnalysisContext): Finding | null {
       .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
       .map((l) => l.slice(1));
 
-    if (addedLines.some((l) => /\b@[Dd]eprecated\b|\/\/\s*DEPRECATED|\/\*\*?\s*@deprecated/.test(l))) {
-      return {
-        moduleId: 'evolutionary',
-        aspect: 'deprecation marker',
-        finding: `deprecation marker in ${diff.filename}`,
-        technicalDetail: 'Deprecation — marking code as obsolete with a clear signal to stop using it before it is removed.',
-        plainLanguage: 'Deprecation warnings give consumers time to migrate. Instead of a breaking removal, you mark it deprecated, document the replacement, and remove it in the next major version.',
-        interestScore: 7,
-        contextHint: `${diff.filename} in ${ctx.repo}`,
-        retrievalTerms: getRetrievalTerms('deprecation', diff.filename, ctx.commitMessage),
-      };
-    }
+    if (!addedLines.some((l) => DEPRECATION_REGEX.test(l))) continue;
+
+    const removedText = extractRemovedLines(diff.patch);
+    if (removedText.split('\n').some((l) => DEPRECATION_REGEX.test(l))) continue;
+
+    return {
+      moduleId: 'evolutionary',
+      aspect: 'deprecation marker',
+      finding: `deprecation marker in ${diff.filename}`,
+      technicalDetail: 'Deprecation — marking code as obsolete with a clear signal to stop using it before it is removed.',
+      plainLanguage: 'Deprecation warnings give consumers time to migrate. Instead of a breaking removal, you mark it deprecated, document the replacement, and remove it in the next major version.',
+      interestScore: 7,
+      contextHint: `${diff.filename} in ${ctx.repo}`,
+      retrievalTerms: getRetrievalTerms('deprecation', diff.filename, ctx.commitMessage),
+      evidence: {
+        before: removedText.slice(0, 300) || undefined,
+        after: extractFirstHunkSnippet(diff.patch) || undefined,
+      },
+    };
   }
   return null;
 }

--- a/src/analysis/modules/go-patterns.ts
+++ b/src/analysis/modules/go-patterns.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 interface GoPattern {
   readonly name: string;
@@ -126,8 +127,11 @@ export class GoPatternsModule implements CodeAnalyzer {
 
       if (addedLines.length === 0) continue;
 
+      const removedText = extractRemovedLines(diff.patch);
+      const removedLines = removedText.split('\n').filter(Boolean);
+
       for (const pattern of PATTERNS) {
-        if (pattern.detect(addedLines)) {
+        if (pattern.detect(addedLines) && !pattern.detect(removedLines)) {
           return {
             moduleId: this.id,
             aspect: pattern.name,
@@ -136,6 +140,10 @@ export class GoPatternsModule implements CodeAnalyzer {
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
             contextHint: `${diff.filename} in ${ctx.repo}`,
+            evidence: {
+              before: removedText.slice(0, 300) || undefined,
+              after: extractFirstHunkSnippet(diff.patch) || undefined,
+            },
           };
         }
       }

--- a/src/analysis/modules/integration.ts
+++ b/src/analysis/modules/integration.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 interface ServiceSignature {
   name: string;
@@ -110,10 +111,11 @@ export class IntegrationModule implements CodeAnalyzer {
     if (addedLines.length === 0) return null;
 
     const addedText = addedLines.join('\n');
+    const removedText = ctx.diffs.map(d => extractRemovedLines(d.patch)).join('\n');
 
     for (const service of KNOWN_SERVICES) {
       if (service.category === AI_CATEGORY) continue;
-      if (service.patterns.some(p => p.test(addedText))) {
+      if (service.patterns.some(p => p.test(addedText)) && !service.patterns.some(p => p.test(removedText))) {
         const matchingDiff = ctx.diffs.find((diff) => service.patterns.some((pattern) => pattern.test(diff.patch)));
         return {
           moduleId: this.id,
@@ -124,6 +126,10 @@ export class IntegrationModule implements CodeAnalyzer {
           interestScore: service.score,
           contextHint: `${matchingDiff?.filename ?? ctx.diffs[0]?.filename ?? 'unknown'} in ${ctx.repo}`,
           retrievalTerms: service.retrievalTerms,
+          evidence: {
+            before: matchingDiff ? extractRemovedLines(matchingDiff.patch).slice(0, 300) || undefined : undefined,
+            after: matchingDiff ? extractFirstHunkSnippet(matchingDiff.patch) || undefined : undefined,
+          },
         };
       }
     }

--- a/src/analysis/modules/java-patterns.ts
+++ b/src/analysis/modules/java-patterns.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 interface JavaPattern {
   readonly name: string;
@@ -130,8 +131,11 @@ export class JavaPatternsModule implements CodeAnalyzer {
 
       if (addedLines.length === 0) continue;
 
+      const removedText = extractRemovedLines(diff.patch);
+      const removedLines = removedText.split('\n').filter(Boolean);
+
       for (const pattern of PATTERNS) {
-        if (pattern.detect(addedLines, diff.patch)) {
+        if (pattern.detect(addedLines, diff.patch) && !pattern.detect(removedLines, diff.patch)) {
           return {
             moduleId: this.id,
             aspect: pattern.name,
@@ -140,6 +144,10 @@ export class JavaPatternsModule implements CodeAnalyzer {
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
             contextHint: `${diff.filename} in ${ctx.repo}`,
+            evidence: {
+              before: removedText.slice(0, 300) || undefined,
+              after: extractFirstHunkSnippet(diff.patch) || undefined,
+            },
           };
         }
       }

--- a/src/analysis/modules/js-advanced.ts
+++ b/src/analysis/modules/js-advanced.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 interface JsAdvancedPattern {
   readonly name: string;
@@ -60,8 +61,11 @@ export class JsAdvancedModule implements CodeAnalyzer {
 
       if (addedLines.length === 0) continue;
 
+      const removedText = extractRemovedLines(diff.patch);
+      const removedLines = removedText.split('\n').filter(Boolean);
+
       for (const pattern of PATTERNS) {
-        if (pattern.detect(addedLines)) {
+        if (pattern.detect(addedLines) && !pattern.detect(removedLines)) {
           return {
             moduleId: this.id,
             aspect: pattern.name,
@@ -70,6 +74,10 @@ export class JsAdvancedModule implements CodeAnalyzer {
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
             contextHint: `${diff.filename} in ${ctx.repo}`,
+            evidence: {
+              before: removedText.slice(0, 300) || undefined,
+              after: extractFirstHunkSnippet(diff.patch) || undefined,
+            },
           };
         }
       }

--- a/src/analysis/modules/observability.ts
+++ b/src/analysis/modules/observability.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 interface ObservabilityPattern {
   readonly name: string;
@@ -77,8 +78,11 @@ export class ObservabilityModule implements CodeAnalyzer {
 
       if (addedLines.length === 0) continue;
 
+      const removedText = extractRemovedLines(diff.patch);
+      const removedLines = removedText.split('\n').filter(Boolean);
+
       for (const pattern of PATTERNS) {
-        if (pattern.detect(addedLines)) {
+        if (pattern.detect(addedLines) && !pattern.detect(removedLines)) {
           return {
             moduleId: this.id,
             aspect: pattern.name,
@@ -87,6 +91,10 @@ export class ObservabilityModule implements CodeAnalyzer {
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
             contextHint: `${diff.filename} in ${ctx.repo}`,
+            evidence: {
+              before: removedText.slice(0, 300) || undefined,
+              after: extractFirstHunkSnippet(diff.patch) || undefined,
+            },
           };
         }
       }

--- a/src/analysis/modules/performance.ts
+++ b/src/analysis/modules/performance.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 interface PerformancePattern {
   readonly name: string;
@@ -121,9 +122,12 @@ export class PerformanceModule implements CodeAnalyzer {
 
       if (addedLines.length === 0) continue;
 
+      const removedText = extractRemovedLines(diff.patch);
+      const removedLines = removedText.split('\n').filter(Boolean);
+
       for (const pattern of PATTERNS) {
         if (pattern.skipOnNewFile && diff.status === 'added') continue;
-        if (pattern.detect(addedLines, diff.patch)) {
+        if (pattern.detect(addedLines, diff.patch) && !pattern.detect(removedLines, diff.patch)) {
           return {
             moduleId: this.id,
             aspect: pattern.name,
@@ -132,6 +136,10 @@ export class PerformanceModule implements CodeAnalyzer {
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
             contextHint: `${diff.filename} in ${ctx.repo}`,
+            evidence: {
+              before: removedText.slice(0, 300) || undefined,
+              after: extractFirstHunkSnippet(diff.patch) || undefined,
+            },
           };
         }
       }

--- a/src/analysis/modules/python-patterns.ts
+++ b/src/analysis/modules/python-patterns.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 interface PythonPattern {
   readonly name: string;
@@ -129,8 +130,11 @@ export class PythonPatternsModule implements CodeAnalyzer {
 
       if (addedLines.length === 0) continue;
 
+      const removedText = extractRemovedLines(diff.patch);
+      const removedLines = removedText.split('\n').filter(Boolean);
+
       for (const pattern of PATTERNS) {
-        if (pattern.detect(addedLines)) {
+        if (pattern.detect(addedLines) && !pattern.detect(removedLines)) {
           return {
             moduleId: this.id,
             aspect: pattern.name,
@@ -139,6 +143,10 @@ export class PythonPatternsModule implements CodeAnalyzer {
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
             contextHint: `${diff.filename} in ${ctx.repo}`,
+            evidence: {
+              before: removedText.slice(0, 300) || undefined,
+              after: extractFirstHunkSnippet(diff.patch) || undefined,
+            },
           };
         }
       }

--- a/src/analysis/modules/react-patterns.ts
+++ b/src/analysis/modules/react-patterns.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 interface ReactPattern {
   readonly name: string;
@@ -104,8 +105,11 @@ export class ReactPatternsModule implements CodeAnalyzer {
 
       if (addedLines.length === 0) continue;
 
+      const removedText = extractRemovedLines(diff.patch);
+      const removedLines = removedText.split('\n').filter(Boolean);
+
       for (const pattern of PATTERNS) {
-        if (pattern.detect(addedLines)) {
+        if (pattern.detect(addedLines) && !pattern.detect(removedLines)) {
           return {
             moduleId: this.id,
             aspect: pattern.name,
@@ -114,6 +118,10 @@ export class ReactPatternsModule implements CodeAnalyzer {
             plainLanguage: pattern.explanation,
             interestScore: pattern.score,
             contextHint: `${diff.filename} in ${ctx.repo}`,
+            evidence: {
+              before: removedText.slice(0, 300) || undefined,
+              after: extractFirstHunkSnippet(diff.patch) || undefined,
+            },
           };
         }
       }

--- a/src/analysis/modules/security.ts
+++ b/src/analysis/modules/security.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 interface SecurityPattern {
   readonly name: string;
@@ -98,8 +99,11 @@ export class SecurityModule implements CodeAnalyzer {
 
       if (addedLines.length === 0) continue;
 
+      const removedText = extractRemovedLines(diff.patch);
+      const removedLines = removedText.split('\n').filter(Boolean);
+
       for (const pattern of PATTERNS) {
-        if (pattern.detect(addedLines, diff.filename)) {
+        if (pattern.detect(addedLines, diff.filename) && !pattern.detect(removedLines, diff.filename)) {
           const prefix = pattern.isConcern ? 'Potential concern' : 'Added';
           return {
             moduleId: this.id,
@@ -110,6 +114,10 @@ export class SecurityModule implements CodeAnalyzer {
             interestScore: pattern.score,
             contextHint: `${diff.filename} in ${ctx.repo}`,
             retrievalTerms: pattern.retrievalTerms ? [...pattern.retrievalTerms] : undefined,
+            evidence: {
+              before: removedText.slice(0, 300) || undefined,
+              after: extractFirstHunkSnippet(diff.patch) || undefined,
+            },
           };
         }
       }

--- a/src/analysis/modules/testing.ts
+++ b/src/analysis/modules/testing.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 const TEST_FILE_PATTERN = /\.(test|spec)\.(ts|tsx|js|jsx|py)$|__tests__\//;
 const PARAMETRIZED_PATTERN = /\bit\.each\b|\btest\.each\b|\bpytest\.mark\.parametrize\b|@parametrize/;
@@ -23,8 +24,10 @@ export class TestingModule implements CodeAnalyzer {
         .map(l => l.slice(1))
     ).join('\n');
 
-    const hasParametrized = PARAMETRIZED_PATTERN.test(addedText);
-    const hasEdgeCases = EDGE_CASE_KEYWORDS.test(addedText);
+    const removedText = testDiffs.map(d => extractRemovedLines(d.patch)).join('\n');
+
+    const hasParametrized = PARAMETRIZED_PATTERN.test(addedText) && !PARAMETRIZED_PATTERN.test(removedText);
+    const hasEdgeCases = EDGE_CASE_KEYWORDS.test(addedText) && !EDGE_CASE_KEYWORDS.test(removedText);
     const hasMocks = MOCK_PATTERN.test(addedText);
 
     // Count test cases (rough heuristic)
@@ -40,6 +43,10 @@ export class TestingModule implements CodeAnalyzer {
         plainLanguage: 'Parametrized tests express "for all these inputs, I expect these outputs" in one readable block. They make it explicit which specific values were chosen for testing and why — especially useful for numeric boundaries, currency rounding, and state transitions.',
         interestScore: 8,
         contextHint: `${testDiffs[0]?.filename ?? 'unknown'} in ${ctx.repo}`,
+        evidence: {
+          before: removedText.slice(0, 300) || undefined,
+          after: extractFirstHunkSnippet(testDiffs[0]?.patch ?? '') || undefined,
+        },
       };
     }
 
@@ -54,6 +61,10 @@ export class TestingModule implements CodeAnalyzer {
         plainLanguage: `The tests specifically target the scenarios that most implementations get wrong: ${uniqueKeywords.join(', ')}. Edge cases don't throw exceptions — they produce plausible-looking wrong answers until someone checks the math.`,
         interestScore: 7,
         contextHint: `${testDiffs[0]?.filename ?? 'unknown'} in ${ctx.repo}`,
+        evidence: {
+          before: removedText.slice(0, 300) || undefined,
+          after: extractFirstHunkSnippet(testDiffs[0]?.patch ?? '') || undefined,
+        },
       };
     }
 
@@ -66,6 +77,10 @@ export class TestingModule implements CodeAnalyzer {
         plainLanguage: `The commit expanded the test suite with ${testCount} new cases${hasMocks ? ', using mocks to isolate the unit under test from its dependencies' : ''}. More tests mean faster feedback when something breaks.`,
         interestScore: 6,
         contextHint: `${testDiffs[0]?.filename ?? 'unknown'} in ${ctx.repo}`,
+        evidence: {
+          before: removedText.slice(0, 300) || undefined,
+          after: extractFirstHunkSnippet(testDiffs[0]?.patch ?? '') || undefined,
+        },
       };
     }
 

--- a/src/analysis/modules/type-system.ts
+++ b/src/analysis/modules/type-system.ts
@@ -1,4 +1,5 @@
 import type { CodeAnalyzer, AnalysisContext, Finding } from '../types.js';
+import { extractRemovedLines, extractFirstHunkSnippet } from '../diff-parser.js';
 
 interface TypePattern {
   name: string;
@@ -73,10 +74,12 @@ export class TypeSystemModule implements CodeAnalyzer {
 
     if (!addedText) return null;
 
+    const removedText = tsDiffs.map(d => extractRemovedLines(d.patch)).join('\n');
+
     const primaryFile = tsDiffs[0]?.filename ?? 'unknown';
 
     for (const tp of TYPE_PATTERNS) {
-      if (tp.pattern.test(addedText)) {
+      if (tp.pattern.test(addedText) && !tp.pattern.test(removedText)) {
         return {
           moduleId: this.id,
           aspect: tp.name,
@@ -85,6 +88,10 @@ export class TypeSystemModule implements CodeAnalyzer {
           plainLanguage: tp.explanation,
           interestScore: tp.score,
           contextHint: `${primaryFile} in ${ctx.repo}`,
+          evidence: {
+            before: removedText.slice(0, 300) || undefined,
+            after: extractFirstHunkSnippet(tsDiffs[0]?.patch ?? '') || undefined,
+          },
         };
       }
     }


### PR DESCRIPTION
## Summary

- Add `extractAddedLines`, `extractRemovedLines`, `extractFirstHunkSnippet` helpers to `diff-parser.ts`
- Apply delta guard to all 22 vulnerable analysis modules — pattern must fire on added lines AND NOT on removed lines to surface a finding
- Add real code evidence (`before`/`after` snippets) to all module findings
- Include `commit.body` in `buildUserPrompt()` (max 5 lines) for richer Claude context

## What changed

**`src/analysis/diff-parser.ts`** — 3 new exported helpers shared by all modules.

**`src/ai/prompt-builder.ts`** — commit body forwarded to Claude when non-empty.

**22 analysis modules** — delta-aware: a pattern substitution (same pattern in added AND removed) no longer fires. Only genuine additions fire. Special case in `architecture-patterns.ts`: filename-based patterns (detect fires with empty lines) skip the delta guard since they cannot be guarded by line content.

## Spec reference

CEP spec v2.5.1 §15 Fase A checklist — all 5 items satisfied:
- [x] `extractAddedLines` + `extractRemovedLines` in diff-parser.ts
- [x] Delta guard in all 22 vulnerable modules
- [x] `extractFirstHunkSnippet` in diff-parser.ts
- [x] Evidence with real code snippets in all module findings
- [x] `commit.body` in `buildUserPrompt()`, max 5 lines

## Test plan

- [ ] Trigger a commit that renames a security pattern (same import moved to a different file) — security module must NOT fire
- [ ] Trigger a commit that adds a new Redis import — integration module MUST fire
- [ ] Trigger a commit that adds a new Redis import over an existing one (substitution) — integration module must NOT fire
- [ ] Confirm `commit.body` appears in Claude prompt for commits with a multi-line message
- [ ] `npx tsc --noEmit` passes — 0 errors