### PR TITLE
fix(voice): do not seed new author voice from tenant default

### DIFF
--- a/src/voice/moves-calculator.ts
+++ b/src/voice/moves-calculator.ts
@@ -14,7 +14,18 @@ export async function refreshVoiceMoves(
   authorLogin: string,
 ): Promise<void> {
   let stored = await storage.getVoiceProfile(authorLogin);
-  const seedVoice = stored?.voice ?? DEFAULT_VOICE_PROFILE;
+  // Only seed a new author row from an exact match. Tenant-default/legacy voices
+  // belong to the tenant owner, not to this author — copying them would persist
+  // foreign hashtags, bootstrap_posts, etc. as this author's permanent voice.
+  const seedVoice = stored && stored.source === 'exact'
+    ? stored.voice
+    : DEFAULT_VOICE_PROFILE;
+  if (stored && stored.source !== 'exact') {
+    logger.info('voice.moves.seed.default', {
+      authorLogin,
+      reason: stored.source,
+    });
+  }
 
   await storage.saveVoiceProfile(authorLogin, seedVoice, 0);
   stored = await storage.getVoiceProfile(authorLogin);

--- a/src/voice/sqlite-storage.ts
+++ b/src/voice/sqlite-storage.ts
@@ -213,6 +213,7 @@ export class SqliteStorage implements IVoiceStorage {
       return Promise.resolve({
         voice: normalizeVoiceProfile(JSON.parse(exact.voice)) ?? DEFAULT_VOICE_PROFILE,
         version: exact.version,
+        source: 'exact',
       });
     }
 
@@ -222,6 +223,7 @@ export class SqliteStorage implements IVoiceStorage {
         return Promise.resolve({
           voice: normalizeVoiceProfile(JSON.parse(fallback.voice)) ?? DEFAULT_VOICE_PROFILE,
           version: fallback.version,
+          source: 'fallback',
         });
       }
     }
@@ -617,7 +619,7 @@ export class SqliteStorage implements IVoiceStorage {
 
     const voice = normalizeVoiceProfile(config['voice']);
     if (!voice) return null;
-    return { voice, version: 1 };
+    return { voice, version: 1, source: 'legacy' };
   }
 
   private hasTable(name: string): boolean {

--- a/src/voice/storage.ts
+++ b/src/voice/storage.ts
@@ -6,9 +6,15 @@ export type ContextStatus = 'skipped' | 'no_match' | 'matched';
 export type PublishSource = 'buffer' | 'linkedin_direct';
 export type VoiceStage = 'cold' | 'bootstrap' | 'warming' | 'established';
 
+export type VoiceProfileSource = 'exact' | 'fallback' | 'legacy';
+
 export interface StoredVoiceProfile {
   voice: VoiceProfile;
   version: number;
+  // 'exact': row matches the requested authorLogin (or tenant default when authorLogin=null).
+  // 'fallback': author-specific lookup missed and tenant default was returned instead.
+  // 'legacy': migrated from tenants.config.voice; treat like 'fallback' for seeding.
+  source: VoiceProfileSource;
 }
 
 export interface EditAnalysis {

--- a/src/voice/supabase-storage.ts
+++ b/src/voice/supabase-storage.ts
@@ -122,6 +122,7 @@ export class SupabaseStorage implements IVoiceStorage {
       return {
         voice: normalizeVoiceProfile(exact.voice) ?? DEFAULT_VOICE_PROFILE,
         version: exact.version,
+        source: 'exact',
       };
     }
 
@@ -131,6 +132,7 @@ export class SupabaseStorage implements IVoiceStorage {
         return {
           voice: normalizeVoiceProfile(fallback.voice) ?? DEFAULT_VOICE_PROFILE,
           version: fallback.version,
+          source: 'fallback',
         };
       }
     }
@@ -532,7 +534,7 @@ export class SupabaseStorage implements IVoiceStorage {
     const config = (data as { config?: Record<string, unknown> | null }).config ?? {};
     const voice = normalizeVoiceProfile(config['voice']);
     if (!voice) return null;
-    return { voice, version: 1 };
+    return { voice, version: 1, source: 'legacy' };
   }
 }
 


### PR DESCRIPTION
When a new author first runs through moves-calculator and has no voice_profiles row, getVoiceProfile falls back to the tenant default row. The previous seed step copied that voice verbatim into a new author-scoped row, persisting the tenant owner's hashtags and bootstrap_posts as the author's permanent voice. The author then propagated those across all tenants via global author resolution.

Expose StoredVoiceProfile.source ('exact' | 'fallback' | 'legacy') and only seed from 'exact'; otherwise seed with DEFAULT_VOICE_PROFILE so the author's voice starts clean and fills in through real edits.