### PR TITLE
fix(enrichment): thread branchRef to enrichCommit in main-poll and replay-commit

### DIFF
--- a/scripts/replay-commit.ts
+++ b/scripts/replay-commit.ts
@@ -2,10 +2,10 @@
  * replay-commit.ts — end-to-end replay of a commit through the full pipeline.
  *
  * Usage:
- *   npx tsx --env-file=.env.local scripts/replay-commit.ts <owner/repo> <sha> [author-login]
+ *   npx tsx --env-file=.env.local scripts/replay-commit.ts <owner/repo> <sha> [author-login] [branch-ref]
  *
  * Example:
- *   npx tsx --env-file=.env.local scripts/replay-commit.ts microboxlabs/ecm-coordinator f9e98b12fe4863adb1f764617558f38bfc1efc0d korutx
+ *   npx tsx --env-file=.env.local scripts/replay-commit.ts microboxlabs/ecm-coordinator f9e98b12fe4863adb1f764617558f38bfc1efc0d korutx refs/heads/JDWP-debug-port
  *
  * Captures all pipeline stages to stdout. Use > out.json to save.
  */
@@ -25,9 +25,10 @@ async function main(): Promise<void> {
   const fullRepo = args[0];
   const sha = args[1];
   const authorLogin = args[2] ?? null;
+  const branchRef = args[3] ?? undefined;
 
   if (!fullRepo || !sha || !fullRepo.includes('/')) {
-    console.error('Usage: npx tsx --env-file=.env.local scripts/replay-commit.ts <owner/repo> <sha> [author-login]');
+    console.error('Usage: npx tsx --env-file=.env.local scripts/replay-commit.ts <owner/repo> <sha> [author-login] [branch-ref]');
     process.exit(1);
   }
 
@@ -50,7 +51,7 @@ async function main(): Promise<void> {
   const githubClient = new GitHubClient(githubToken);
   let commit;
   try {
-    commit = await enrichCommit(githubClient, owner, repo, sha, authorLogin);
+    commit = await enrichCommit(githubClient, owner, repo, sha, authorLogin, branchRef);
   } catch (e) {
     console.error('enrichCommit failed:', String(e));
     process.exit(1);

--- a/src/github/events-poller.ts
+++ b/src/github/events-poller.ts
@@ -4,6 +4,7 @@ import type { GitHubClient } from './client.js';
 export interface PushEvent {
   id: string;
   repo: string;       // 'owner/repo'
+  ref?: string;       // e.g. 'refs/heads/feature-x'
   commits: PushCommit[];
   pushedAt: string;
 }
@@ -103,6 +104,7 @@ export async function pollNewPushEvents(
     result.push({
       id: e.id,
       repo: e.repo.name,
+      ref: e.payload.ref ?? undefined,
       commits,
       pushedAt: e.created_at,
     });

--- a/src/main-poll.ts
+++ b/src/main-poll.ts
@@ -154,7 +154,7 @@ async function main(): Promise<void> {
       }
 
       // Enrich commit
-      const commit = await enrichCommit(github, owner, repo, pushCommit.sha, pushCommit.authorLogin);
+      const commit = await enrichCommit(github, owner, repo, pushCommit.sha, pushCommit.authorLogin, pushEvent.ref);
 
       // Rule-based filter — zero API cost
       const filterResult = isInteresting(


### PR DESCRIPTION
## Summary

- `PushEvent` lacked a `ref` field — main-poll never passed `branchRef` to `enrichCommit`, so PR context lookup was always skipped and `prContext` remained `undefined` for all commits in the poll path
- Adds `ref?: string` to `PushEvent`; populates from `e.payload.ref` in events-poller
- Passes `pushEvent.ref` as 6th arg to `enrichCommit` in main-poll
- Adds optional `[branch-ref]` 4th arg to `replay-commit.ts` for manual testing

Note: `process-job.ts` already passed `job.ref ?? undefined` — only the legacy poll path was affected.

## Test plan

- [ ] Run `replay-commit.ts` with a feature-branch SHA and `refs/heads/<branch>` as 4th arg — verify `prContext` appears in Stage 1 output
- [ ] Run without branch-ref arg — verify no regression (prContext undefined as before for default-branch commits)
- [ ] TypeScript: `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)