### PR TITLE
fix(synthesis): reject empty or too-short buffer_text from Claude response

### DIFF
--- a/src/ai/synthesis-generator.ts
+++ b/src/ai/synthesis-generator.ts
@@ -75,6 +75,11 @@ export async function generateSynthesisPost(
     throw new Error(`synthesis-generator: missing <buffer_text> in response for ${input.gatillador}/${input.topics.join(',')}`);
   }
   const bufferText = bufferTextMatch[1]?.trim() ?? '';
+  if (bufferText.length < input.voiceProfile.post_length.min) {
+    throw new Error(
+      `synthesis-generator: <buffer_text> too short (${bufferText.length} < ${input.voiceProfile.post_length.min}) for ${input.gatillador}/${input.topics.join(',')}`,
+    );
+  }
 
   const openingMoveMatch = XML_OPENING_MOVE_RE.exec(raw);
   const openingMove = openingMoveMatch?.[1]?.trim() ?? 'unknown';


### PR DESCRIPTION
## Summary

- An empty string after XML trim was silently passed into `saveDraft`, producing a post with no content
- Now throws immediately if `bufferText.length < post_length.min` (schema minimum: 300 chars), preventing blank drafts from reaching Buffer or voice history
- Error message includes actual length vs expected minimum for easy debugging

## Test plan

- [ ] Confirm that a mocked Claude response returning `<buffer_text></buffer_text>` raises an error before `saveDraft` is called
- [ ] Confirm normal responses (≥ min chars) continue to work
- [ ] TypeScript: `npx tsc --noEmit` passes