### PR TITLE
fix(generation): retry once with reinforced prompt when Claude exceeds length cap

### DIFF
--- a/src/ai/post-generator.ts
+++ b/src/ai/post-generator.ts
@@ -73,8 +73,21 @@ export async function generatePosts(
 
   const rawResponse = await client.complete(systemPrompt, userPrompt);
 
-  const parsed = parseResponse(rawResponse);
-  const post = enforceMainPostLength(parsed.post, options.voiceProfile.post_length.max);
+  const maxChars = options.voiceProfile.post_length.max;
+  let parsed = parseResponse(rawResponse);
+
+  if (parsed.post.length > maxChars * 1.05) {
+    logger.warn('ai.generate.length_exceeded_retry', {
+      sha: commit.sha,
+      length: parsed.post.length,
+      maxChars,
+    });
+    const reinforced = `${userPrompt}\n\nREINFORCED: hard cap is ${maxChars} characters. Do not exceed it.`;
+    const retryResponse = await client.complete(systemPrompt, reinforced);
+    parsed = parseResponse(retryResponse);
+  }
+
+  const post = enforceMainPostLength(parsed.post, maxChars);
   const shortPost = parsed.shortPost;
 
   const topFinding = findings[0]?.finding;

--- a/src/ai/synthesis-generator.ts
+++ b/src/ai/synthesis-generator.ts
@@ -74,7 +74,22 @@ export async function generateSynthesisPost(
   if (!bufferTextMatch) {
     throw new Error(`synthesis-generator: missing <buffer_text> in response for ${input.gatillador}/${input.topics.join(',')}`);
   }
-  const bufferText = bufferTextMatch[1]?.trim() ?? '';
+
+  const maxChars = input.voiceProfile.post_length.max;
+  let bufferText = bufferTextMatch[1]?.trim() ?? '';
+
+  if (bufferText.length > maxChars * 1.05) {
+    logger.warn('synthesis-generator.length_exceeded_retry', {
+      length: bufferText.length,
+      maxChars,
+      gatillador: input.gatillador,
+    });
+    const reinforced = `${userPrompt}\n\nREINFORCED: hard cap is ${maxChars} characters. Do not exceed it.`;
+    const retryRaw = await client.complete(systemPrompt, reinforced);
+    const retryMatch = XML_BUFFER_TEXT_RE.exec(retryRaw);
+    if (retryMatch) bufferText = retryMatch[1]?.trim() ?? bufferText;
+  }
+
   if (bufferText.length < input.voiceProfile.post_length.min) {
     throw new Error(
       `synthesis-generator: <buffer_text> too short (${bufferText.length} < ${input.voiceProfile.post_length.min}) for ${input.gatillador}/${input.topics.join(',')}`,


### PR DESCRIPTION
## Summary

- When Claude returns a post longer than `max * 1.05` characters, the prompt is re-sent once with an explicit reinforced length constraint before falling back to truncation
- Applies to both `post-generator.ts` (regular commits) and `synthesis-generator.ts` (CEP synthesis posts)
- In `post-generator.ts`, `enforceMainPostLength` still runs as the final safety net after the retry
- Confirmed by a real replay where Claude generated 1577 chars with a 1500-char cap

## Test plan

- [ ] Run `replay-commit.ts` — if Claude exceeds cap, verify `ai.generate.length_exceeded_retry` appears in logs before the final post
- [ ] Verify no regression when Claude stays within the cap (no extra API call)
- [ ] TypeScript: `npx tsc --noEmit` passes