### PR TITLE
refactor(ranking): switch adjustFindingScore to logarithmic saturation with floor

### DIFF
--- a/src/worker/daily-post-selection.ts
+++ b/src/worker/daily-post-selection.ts
@@ -103,7 +103,8 @@ function adjustFindingScore(
   recentModuleFireCounts: ReadonlyMap<string, number>,
 ): number {
   const fireCount = recentModuleFireCounts.get(finding.moduleId) ?? 0;
-  return finding.interestScore / (fireCount + 1);
+  const floor = finding.interestScore * 0.4;
+  return Math.max(finding.interestScore / Math.log2(fireCount + 2), floor);
 }
 
 function computeSelectionScore<T extends RankedCommitCandidate>(


### PR DESCRIPTION
## Summary

- `adjustFindingScore` used linear division `score / (fireCount + 1)`: a score-10 module dropped to 5 after just one prior fire, making it lose to unrelated lower-quality findings
- Switched to `score / log2(fireCount + 2)` — the penalty grows much more slowly with repetition
- Added a 40% floor (`score * 0.4`) so high-quality modules are never buried entirely by repetition history

**Example**: score=10, fireCount=5 → old: 1.67 | new: max(10/2.81, 4.0) = **4.0** (floor)

## Test plan

- [ ] Verify `computeCandidateRankingScore` with a finding that has fireCount=1 returns a higher adjusted score than before
- [ ] Verify a module with fireCount=20 never drops below 40% of its original score
- [ ] TypeScript: `npx tsc --noEmit` passes