### PR TITLE
refactor(synthesis): split focal_multiple into pre-generate + batch save phases

### DIFF
--- a/src/ai/synthesis-generator.ts
+++ b/src/ai/synthesis-generator.ts
@@ -39,14 +39,24 @@ export interface SynthesisResult {
   readonly openingMove: string;
 }
 
+export interface BufferTextResult {
+  readonly bufferText: string;
+  readonly openingMove: string;
+  readonly representativeSha: string;
+}
+
 const XML_BUFFER_TEXT_RE = /<buffer_text>([\s\S]*?)<\/buffer_text>/;
 const XML_OPENING_MOVE_RE = /<opening_move>([\s\S]*?)<\/opening_move>/;
 
-export async function generateSynthesisPost(
+/**
+ * Calls Claude and parses the response — no storage writes.
+ * Use this for Phase 1 of focal_multiple batches so all texts are generated
+ * before any draft is saved, preventing partial state on Claude failures.
+ */
+export async function generateBufferText(
   client: IAIClient,
-  storage: IVoiceStorage,
   input: SynthesisGeneratorInput,
-): Promise<SynthesisResult> {
+): Promise<BufferTextResult> {
   const commitGroups = groupSignalsByCommit(input.signals);
   const representativeSha = commitGroups[commitGroups.length - 1]?.commitSha ?? 'synthesis';
 
@@ -67,7 +77,6 @@ export async function generateSynthesisPost(
 
   const systemPrompt = buildSynthesisSystemPrompt(promptInput);
   const userPrompt = buildSynthesisUserPrompt(promptInput);
-
   const raw = await client.complete(systemPrompt, userPrompt);
 
   const bufferTextMatch = XML_BUFFER_TEXT_RE.exec(raw);
@@ -79,20 +88,32 @@ export async function generateSynthesisPost(
   const openingMoveMatch = XML_OPENING_MOVE_RE.exec(raw);
   const openingMove = openingMoveMatch?.[1]?.trim() ?? 'unknown';
 
+  return { bufferText, openingMove, representativeSha };
+}
+
+/**
+ * Saves a pre-generated buffer text to storage and logs.
+ * Use this for Phase 2 of focal_multiple batches after all texts are ready.
+ */
+export async function persistSynthesisPost(
+  storage: IVoiceStorage,
+  input: SynthesisGeneratorInput,
+  result: BufferTextResult,
+): Promise<SynthesisResult> {
   const topTopic = input.topics[0] ?? null;
   const draftId = await storage.saveDraft({
-    commit_sha: representativeSha,
+    commit_sha: result.representativeSha,
     repo: input.repo,
     platform: 'linkedin',
-    ai_draft: bufferText,
+    ai_draft: result.bufferText,
     top_module_id: topTopic ?? undefined,
     findings_count: input.signals.length,
     author_login: input.authorLogin,
     generation_system: input.voiceStage === 'cold' ? 'v1' : 'v2_progressive',
-    opening_move: openingMove,
+    opening_move: result.openingMove,
   });
 
-  const detectedMove = detectOpeningMove(bufferText);
+  const detectedMove = detectOpeningMove(result.bufferText);
 
   logger.info('synthesis-generator.done', {
     draftId,
@@ -102,5 +123,14 @@ export async function generateSynthesisPost(
     openingMove: detectedMove,
   });
 
-  return { draftId, bufferText, openingMove: detectedMove };
+  return { draftId, bufferText: result.bufferText, openingMove: detectedMove };
+}
+
+export async function generateSynthesisPost(
+  client: IAIClient,
+  storage: IVoiceStorage,
+  input: SynthesisGeneratorInput,
+): Promise<SynthesisResult> {
+  const result = await generateBufferText(client, input);
+  return persistSynthesisPost(storage, input, result);
 }

--- a/src/main-poll.ts
+++ b/src/main-poll.ts
@@ -36,8 +36,8 @@ import {
 import { check, checkCrossVolume, shouldRunHaikuLazy } from './analysis/accumulation-engine.js';
 import { extractSignalFromDiff } from './analysis/signal-extractor.js';
 import { scoreCoherenceFromSignals } from './analysis/coherence-router.js';
-import { consumeSignalsForPost, type Gatillador } from './analysis/signal-consumer.js';
-import { generateSynthesisPost } from './ai/synthesis-generator.js';
+import { consumeSignalsForPost, rollbackPostConsumption, type Gatillador } from './analysis/signal-consumer.js';
+import { generateBufferText, persistSynthesisPost } from './ai/synthesis-generator.js';
 import type { WeakSignal, DeltaHit } from './analysis/types.js';
 import type { SignalBankEntry, SignalEvent } from './voice/storage.js';
 
@@ -587,24 +587,40 @@ async function runAccumulationCheckPoll(
         }))
       : [{ topics: firedTopics, signals: allSignals, gatillador: gatillador as 'focal' | 'arco' }];
 
-  for (let i = 0; i < topicsToGenerate.length; i++) {
-    const item = topicsToGenerate[i]!;
-    const { draftId } = await generateSynthesisPost(generationAi, storage, {
-      authorLogin,
-      repo,
-      gatillador: item.gatillador,
-      topics: item.topics,
-      signals: item.signals,
-      voiceProfile: authorState.voiceProfile,
-      voiceStage: authorState.voiceStage,
-      config,
-      exposurePool,
-      bootstrapPosts: authorState.voiceProfile.bootstrap_posts ?? [],
-      draftIndexToday: authorState.todayDrafts.length + i,
-    });
+  const synthesisInputs = topicsToGenerate.map((item, i) => ({
+    authorLogin,
+    repo,
+    gatillador: item.gatillador,
+    topics: item.topics,
+    signals: item.signals,
+    voiceProfile: authorState.voiceProfile,
+    voiceStage: authorState.voiceStage,
+    config,
+    exposurePool,
+    bootstrapPosts: authorState.voiceProfile.bootstrap_posts ?? [],
+    draftIndexToday: authorState.todayDrafts.length + i,
+  }));
 
-    await consumeSignalsForPost(storage, draftId, item.gatillador, item.topics, authorLogin, repo);
+  // Phase 1: generate all buffer texts in parallel — fail-fast, no DB writes.
+  // If any Claude call fails, no draft is saved for any topic.
+  const generatedTexts = await Promise.all(synthesisInputs.map((inp) => generateBufferText(generationAi, inp)));
 
-    logger.info('poll.accumulation.done', { draftId, authorLogin, topics: item.topics, gatillador: item.gatillador });
+  // Phase 2: persist sequentially; roll back consumed signals if a later item fails.
+  const savedDraftIds: string[] = [];
+  try {
+    for (let i = 0; i < topicsToGenerate.length; i++) {
+      const item = topicsToGenerate[i]!;
+      const { draftId } = await persistSynthesisPost(storage, synthesisInputs[i]!, generatedTexts[i]!);
+      await consumeSignalsForPost(storage, draftId, item.gatillador, item.topics, authorLogin, repo);
+      savedDraftIds.push(draftId);
+      logger.info('poll.accumulation.done', { draftId, authorLogin, topics: item.topics, gatillador: item.gatillador });
+    }
+  } catch (err) {
+    for (const draftId of savedDraftIds) {
+      await rollbackPostConsumption(storage, draftId, 'focal_multiple_partial_failure')
+        .catch((e) => logger.error('poll.accumulation.rollback.failed', { draftId, error: String(e) }));
+    }
+    logger.error('poll.accumulation.failed', { authorLogin, repo, error: String(err) });
+    throw err;
   }
 }

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -32,8 +32,8 @@ import {
 import { check, checkCrossVolume, shouldRunHaikuLazy } from '../analysis/accumulation-engine.js';
 import { extractSignalFromDiff } from '../analysis/signal-extractor.js';
 import { scoreCoherenceFromSignals } from '../analysis/coherence-router.js';
-import { consumeSignalsForPost, type Gatillador } from '../analysis/signal-consumer.js';
-import { generateSynthesisPost } from '../ai/synthesis-generator.js';
+import { consumeSignalsForPost, rollbackPostConsumption, type Gatillador } from '../analysis/signal-consumer.js';
+import { generateBufferText, persistSynthesisPost } from '../ai/synthesis-generator.js';
 import type { WeakSignal, DeltaHit } from '../analysis/types.js';
 import type { SignalBankEntry, SignalEvent } from '../voice/storage.js';
 
@@ -965,25 +965,41 @@ async function runAccumulationCheck(
     repo: fullRepo,
   } as import('../github/commit-enricher.js').EnrichedCommit;
 
-  for (let i = 0; i < topicsToGenerate.length; i++) {
-    const item = topicsToGenerate[i]!;
-    const { draftId } = await generateSynthesisPost(generationAi, storage, {
-      authorLogin,
-      repo: fullRepo,
-      gatillador: item.gatillador,
-      topics: item.topics,
-      signals: item.signals,
-      voiceProfile: authorState.voiceProfile,
-      voiceStage: authorState.voiceStage,
-      config,
-      exposurePool,
-      bootstrapPosts,
-      draftIndexToday: authorState.todayDrafts.length + i,
-    });
+  const synthesisInputs = topicsToGenerate.map((item, i) => ({
+    authorLogin,
+    repo: fullRepo,
+    gatillador: item.gatillador,
+    topics: item.topics,
+    signals: item.signals,
+    voiceProfile: authorState.voiceProfile,
+    voiceStage: authorState.voiceStage,
+    config,
+    exposurePool,
+    bootstrapPosts,
+    draftIndexToday: authorState.todayDrafts.length + i,
+  }));
 
-    await consumeSignalsForPost(storage, draftId, item.gatillador, item.topics, authorLogin, fullRepo);
-    await notifyNewDraft(github, owner, config.github.notification_repo, fakeCommit, [], appBaseUrl);
+  // Phase 1: generate all buffer texts in parallel — fail-fast, no DB writes.
+  // If any Claude call fails, no draft is saved for any topic.
+  const generatedTexts = await Promise.all(synthesisInputs.map((inp) => generateBufferText(generationAi, inp)));
 
-    logger.info('worker.accumulation.done', { draftId, authorLogin, topics: item.topics, gatillador: item.gatillador });
+  // Phase 2: persist sequentially; roll back consumed signals if a later item fails.
+  const savedDraftIds: string[] = [];
+  try {
+    for (let i = 0; i < topicsToGenerate.length; i++) {
+      const item = topicsToGenerate[i]!;
+      const { draftId } = await persistSynthesisPost(storage, synthesisInputs[i]!, generatedTexts[i]!);
+      await consumeSignalsForPost(storage, draftId, item.gatillador, item.topics, authorLogin, fullRepo);
+      savedDraftIds.push(draftId);
+      await notifyNewDraft(github, owner, config.github.notification_repo, fakeCommit, [], appBaseUrl);
+      logger.info('worker.accumulation.done', { draftId, authorLogin, topics: item.topics, gatillador: item.gatillador });
+    }
+  } catch (err) {
+    for (const draftId of savedDraftIds) {
+      await rollbackPostConsumption(storage, draftId, 'focal_multiple_partial_failure')
+        .catch((e) => logger.error('worker.accumulation.rollback.failed', { draftId, error: String(e) }));
+    }
+    logger.error('worker.accumulation.failed', { authorLogin, repo: fullRepo, error: String(err) });
+    throw err;
   }
 }


### PR DESCRIPTION
## Summary

- The sequential `generate+consume` loop had no transaction: if Claude failed on topic N, topics 0..N-1 were already saved and consumed, leaving partial state that caused duplicate posts on the next poll cycle
- **Phase 1** (`Promise.all` on `generateBufferText`): all Claude calls fire in parallel with no DB writes. If any fails, the entire batch aborts with zero state change
- **Phase 2** (sequential `persistSynthesisPost + consumeSignalsForPost`): persists each topic one by one, rolling back consumed signals for successfully-saved posts if a later item fails
- Adds `generateBufferText()` and `persistSynthesisPost()` to `synthesis-generator.ts`; `generateSynthesisPost()` remains as a convenience wrapper for single-topic callers
- Applied to both `main-poll.ts` and `process-job.ts`

## Test plan

- [ ] Simulate a Claude failure on the 2nd topic in a focal_multiple batch — verify no draft is saved for either topic
- [ ] Verify normal focal_multiple (2 topics, both succeed) produces 2 drafts with consumed signals
- [ ] TypeScript: `npx tsc --noEmit` passes