### PR TITLE
feat(observability): add bestEffort helper and standardize best-effort error handling

### DIFF
--- a/src/buffer/sent-scanner.ts
+++ b/src/buffer/sent-scanner.ts
@@ -1,4 +1,5 @@
 import { logger } from '../utils/logger.js';
+import { bestEffort } from '../utils/best-effort.js';
 import { computeEditRatio } from '../voice/similarity.js';
 import type { BufferClient } from './client.js';
 import type { IVoiceStorage, Platform } from '../voice/storage.js';
@@ -114,12 +115,11 @@ export async function scanPlatform(
       });
       // Adapt signal_bank multiplier via edit_ratio formula: 0.5 + 2.0 × mean_last_10 (best-effort)
       if (bestDraft.top_module_id && bestDraft.author_login && bestDraft.repo) {
-        applyMultiplierFeedback(storage, bestDraft.author_login, bestDraft.repo, bestDraft.top_module_id)
-          .catch((err) => logger.warn('sent_scanner.multiplier_feedback.failed', {
-            draftId: bestDraft.id,
-            topic: bestDraft.top_module_id,
-            error: String(err),
-          }));
+        bestEffort(
+          'sent_scanner.multiplier_feedback',
+          applyMultiplierFeedback(storage, bestDraft.author_login, bestDraft.repo, bestDraft.top_module_id),
+          { draftId: bestDraft.id, topic: bestDraft.top_module_id },
+        );
       }
       // Remove matched draft so it can't be claimed by another sent post
       remaining.splice(bestIdx, 1);

--- a/src/main-poll.ts
+++ b/src/main-poll.ts
@@ -6,6 +6,7 @@
 
 import { loadConfig } from './config/loader.js';
 import { logger } from './utils/logger.js';
+import { bestEffort } from './utils/best-effort.js';
 import { isInteresting } from './utils/commit-filter.js';
 import { GitHubClient } from './github/client.js';
 import { pollNewPushEvents } from './github/events-poller.js';
@@ -207,14 +208,16 @@ async function main(): Promise<void> {
       const depositNowIso = new Date().toISOString();
       const depositAuthorLogin = commit.authorLogin ?? config.author.github_username;
       const commitFiles = commit.diffs.map((d) => d.filename);
-      await depositWeakSignalsPoll(storage, weakFindings, deltaHits, commit.sha, commit.repo, tenantId, depositAuthorLogin, depositNowIso, commitFiles)
-        .catch((err) => logger.warn('poll.deposit_signal.failed', { sha: commit.sha, error: String(err) }));
+      bestEffort('poll.deposit_signal',
+        depositWeakSignalsPoll(storage, weakFindings, deltaHits, commit.sha, commit.repo, tenantId, depositAuthorLogin, depositNowIso, commitFiles),
+        { sha: commit.sha });
 
       // Haiku lazy: semantically evaluate topics near threshold that scored 0 in regex pipeline (best-effort)
       {
         const firedTopicsThisCommit = [...new Set([...weakFindings.map((f) => f.moduleId), ...deltaHits.map((d) => d.topic)])];
-        runHaikuLazyPoll(haikuAi, storage, commit, tenantId, depositAuthorLogin, firedTopicsThisCommit, depositNowIso)
-          .catch((err) => logger.warn('poll.commit.haiku_lazy.failed', { sha: commit.sha, error: String(err) }));
+        bestEffort('poll.commit.haiku_lazy',
+          runHaikuLazyPoll(haikuAi, storage, commit, tenantId, depositAuthorLogin, firedTopicsThisCommit, depositNowIso),
+          { sha: commit.sha });
       }
 
       if (pipelineFindings.length === 0) {
@@ -329,8 +332,9 @@ async function main(): Promise<void> {
           const capa1Topics = [...new Set(candidate.findings.map((f) => f.moduleId))];
           const capa1Gatillador: Gatillador = capa1Topics.length === 1 ? 'individual_mono' : 'individual_multi';
           const capa1Author = candidate.authorLogin ?? config.author.github_username;
-          consumeSignalsForPost(storage, draftId, capa1Gatillador, capa1Topics, capa1Author, candidate.commit.repo)
-            .catch((err) => logger.warn('poll.commit.capa1_consume.failed', { sha: candidate.commit.sha, error: String(err) }));
+          bestEffort('poll.commit.capa1_consume',
+            consumeSignalsForPost(storage, draftId, capa1Gatillador, capa1Topics, capa1Author, candidate.commit.repo),
+            { sha: candidate.commit.sha });
         }
 
         const publishResult = await publishToBuffer(
@@ -523,8 +527,9 @@ async function runAccumulationCheckPoll(
   authorState: PollAuthorState,
   nowIso: string,
 ): Promise<void> {
-  await storage.updateHalfLivesForAuthor(authorLogin, repo)
-    .catch((err) => logger.warn('poll.accumulation.half_lives.failed', { authorLogin, repo, error: String(err) }));
+  bestEffort('poll.accumulation.half_lives',
+    storage.updateHalfLivesForAuthor(authorLogin, repo),
+    { authorLogin, repo });
 
   const entries = await storage.getSignalBankEntries(authorLogin, repo);
   if (entries.length === 0) return;
@@ -552,16 +557,17 @@ async function runAccumulationCheckPoll(
   if (firedTopics.length >= 2) {
     const coherence = scoreCoherenceFromSignals(allSignals, medianIntervalDays);
     gatillador = coherence.decision === 'arco' ? 'arco' : 'focal_multiple';
-    await storage.recordRoutingDecision({
-      github_author_login: authorLogin,
-      voice_post_id: null,
-      commit_shas: [...new Set(allSignals.map((s) => s.commit_sha))],
-      score_coherencia: coherence.total,
-      score_structural: coherence.structural,
-      score_temporal: coherence.temporal,
-      score_lexical: coherence.lexical,
-      decision: coherence.decision,
-    }).catch((err) => logger.warn('poll.accumulation.routing_record.failed', { error: String(err) }));
+    bestEffort('poll.accumulation.routing_record',
+      storage.recordRoutingDecision({
+        github_author_login: authorLogin,
+        voice_post_id: null,
+        commit_shas: [...new Set(allSignals.map((s) => s.commit_sha))],
+        score_coherencia: coherence.total,
+        score_structural: coherence.structural,
+        score_temporal: coherence.temporal,
+        score_lexical: coherence.lexical,
+        decision: coherence.decision,
+      }));
   } else {
     gatillador = 'focal';
   }

--- a/src/utils/best-effort.ts
+++ b/src/utils/best-effort.ts
@@ -1,0 +1,21 @@
+import { logger } from './logger.js';
+
+/**
+ * Fire-and-forget wrapper for best-effort async operations.
+ * Logs a structured warning on failure instead of crashing.
+ * Use this instead of raw `.catch(logger.warn)` to keep the pattern consistent
+ * and make it easy to add metrics/DB writes here in the future.
+ *
+ * @param label Dot-separated log key prefix (e.g. 'poll.deposit_signal')
+ * @param promise The async operation to run best-effort
+ * @param context Extra fields to include in the warning log
+ */
+export function bestEffort(
+  label: string,
+  promise: Promise<unknown>,
+  context?: Record<string, unknown>,
+): void {
+  promise.catch((err: unknown) => {
+    logger.warn(`${label}.failed`, { ...context, error: String(err) });
+  });
+}

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -16,6 +16,7 @@ import { notifyNewDraft } from '../review/notifier.js';
 import { SupabaseStorage } from '../voice/supabase-storage.js';
 import { getInstallationToken } from './github-app-auth.js';
 import { logger } from '../utils/logger.js';
+import { bestEffort } from '../utils/best-effort.js';
 import { ConfigSchema } from '../config/schema.js';
 import type { BootstrapPost, Config, VoiceProfile } from '../config/schema.js';
 import type { IVoiceStorage, SaveDraftInput, VoicePost, VoiceStage } from '../voice/storage.js';
@@ -411,14 +412,16 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
       const nowIso = new Date().toISOString();
       const depositAuthorLogin = commit.authorLogin ?? tenant.github_username;
       const commitFiles = commit.diffs.map((d) => d.filename);
-      await depositWeakSignals(storage, weakFindings, deltaHits, commit.sha, commit.repo, tenant.id, depositAuthorLogin, nowIso, commitFiles)
-        .catch((err) => logger.warn('worker.commit.deposit_signal.failed', { sha: commit.sha, error: String(err) }));
+      bestEffort('worker.commit.deposit_signal',
+        depositWeakSignals(storage, weakFindings, deltaHits, commit.sha, commit.repo, tenant.id, depositAuthorLogin, nowIso, commitFiles),
+        { sha: commit.sha });
 
       // Haiku lazy: semantically evaluate topics near threshold that scored 0 in regex pipeline (best-effort)
       {
         const firedTopicsThisCommit = [...new Set([...weakFindings.map((f) => f.moduleId), ...deltaHits.map((d) => d.topic)])];
-        runHaikuLazy(haikuAi, storage, commit, tenant.id, depositAuthorLogin, firedTopicsThisCommit, nowIso)
-          .catch((err) => logger.warn('worker.commit.haiku_lazy.failed', { sha: commit.sha, error: String(err) }));
+        bestEffort('worker.commit.haiku_lazy',
+          runHaikuLazy(haikuAi, storage, commit, tenant.id, depositAuthorLogin, firedTopicsThisCommit, nowIso),
+          { sha: commit.sha });
       }
 
       if (pipelineFindings.length === 0) {
@@ -647,8 +650,9 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
           const capa1Topics = [...new Set(candidate.findings.map((f) => f.moduleId))];
           const capa1Gatillador: Gatillador = capa1Topics.length === 1 ? 'individual_mono' : 'individual_multi';
           const capa1Author = candidate.authorLogin ?? tenant.github_username;
-          consumeSignalsForPost(storage, draftId, capa1Gatillador, capa1Topics, capa1Author, candidate.commit.repo)
-            .catch((err) => logger.warn('worker.commit.capa1_consume.failed', { sha: candidate.commit.sha, error: String(err) }));
+          bestEffort('worker.commit.capa1_consume',
+            consumeSignalsForPost(storage, draftId, capa1Gatillador, capa1Topics, capa1Author, candidate.commit.repo),
+            { sha: candidate.commit.sha });
         }
 
         // Post directly to LinkedIn — prefer member credentials, fall back to tenant
@@ -890,8 +894,9 @@ async function runAccumulationCheck(
   appBaseUrl: string,
   nowIso: string,
 ): Promise<void> {
-  await storage.updateHalfLivesForAuthor(authorLogin, fullRepo)
-    .catch((err) => logger.warn('worker.accumulation.half_lives.failed', { authorLogin, repo: fullRepo, error: String(err) }));
+  bestEffort('worker.accumulation.half_lives',
+    storage.updateHalfLivesForAuthor(authorLogin, fullRepo),
+    { authorLogin, repo: fullRepo });
 
   const entries = await storage.getSignalBankEntries(authorLogin, fullRepo);
   if (entries.length === 0) return;
@@ -920,16 +925,17 @@ async function runAccumulationCheck(
   if (firedTopics.length >= 2) {
     const coherence = scoreCoherenceFromSignals(allSignals, medianIntervalDays);
     gatillador = coherence.decision === 'arco' ? 'arco' : 'focal_multiple';
-    await storage.recordRoutingDecision({
-      github_author_login: authorLogin,
-      voice_post_id: null,
-      commit_shas: [...new Set(allSignals.map((s) => s.commit_sha))],
-      score_coherencia: coherence.total,
-      score_structural: coherence.structural,
-      score_temporal: coherence.temporal,
-      score_lexical: coherence.lexical,
-      decision: coherence.decision,
-    }).catch((err) => logger.warn('worker.accumulation.routing_record.failed', { error: String(err) }));
+    bestEffort('worker.accumulation.routing_record',
+      storage.recordRoutingDecision({
+        github_author_login: authorLogin,
+        voice_post_id: null,
+        commit_shas: [...new Set(allSignals.map((s) => s.commit_sha))],
+        score_coherencia: coherence.total,
+        score_structural: coherence.structural,
+        score_temporal: coherence.temporal,
+        score_lexical: coherence.lexical,
+        decision: coherence.decision,
+      }));
   } else {
     gatillador = 'focal';
   }


### PR DESCRIPTION
## Summary

- 11 ad-hoc `.catch((err) => logger.warn(...))` blocks across `main-poll.ts`, `process-job.ts`, and `sent-scanner.ts` were replaced with a centralized `bestEffort(label, promise, context)` helper
- The helper standardizes the warning log format (`${label}.failed` with context fields) and makes it trivial to add metrics or a `pipeline_observability` DB table in one place later without touching call sites
- New file: `src/utils/best-effort.ts`

**Covered paths:**
- Signal deposit (deposit_signal)
- Haiku lazy evaluation (haiku_lazy)
- Capa 1 signal consume (capa1_consume)
- Half-lives update (half_lives)
- Routing decision record (routing_record)
- Sent-scanner multiplier feedback (multiplier_feedback)

## Test plan

- [ ] Trigger a best-effort failure (e.g. mock `updateHalfLivesForAuthor` to throw) — verify `worker.accumulation.half_lives.failed` appears in logs with `error` field
- [ ] Verify the pipeline continues normally after the best-effort failure
- [ ] TypeScript: `npx tsc --noEmit` passes