### PR TITLE
feat(editorial): wire all editorial roles into Camino 2 synthesis path

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -364,3 +364,6 @@ CREATE INDEX IF NOT EXISTS idx_voice_retrieval
 
 -- R5: author voice quality rating — 1=👎 2=👍 NULL=unrated
 ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS voice_rating SMALLINT;
+
+-- R3: narrative arc type chosen by selectDevelopmentalAngle() — nullable (posts before R3 have no arc)
+ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS arc_type VARCHAR(30);

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -61,12 +61,14 @@ CREATE TABLE IF NOT EXISTS events_state (
 );
 
 -- Atomic slot claiming — prevents double-booking across concurrent runs
+-- tenant_id added 2026-04-13: each tenant has its own slot namespace
 CREATE TABLE IF NOT EXISTS scheduled_slots (
   id              TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  tenant_id       UUID NOT NULL REFERENCES tenants(id),
   platform        TEXT NOT NULL,
   scheduled_at    TIMESTAMPTZ NOT NULL,
   voice_post_id   TEXT REFERENCES voice_posts(id),
-  UNIQUE(platform, scheduled_at)           -- the invariant that makes scheduling safe
+  UNIQUE(tenant_id, platform, scheduled_at)
 );
 
 -- Fast retrieval of voice examples for prompt assembly
@@ -222,6 +224,7 @@ ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS publish_source           TEXT;
 ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS generation_system        TEXT;
 ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS opening_move             TEXT;
 ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS author_login             TEXT;
+ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS rejection_reason         TEXT;
 
 ALTER TABLE job_queue ADD COLUMN IF NOT EXISTS leased_until               TIMESTAMPTZ;
 ALTER TABLE job_queue ADD COLUMN IF NOT EXISTS idempotency_key            TEXT;
@@ -296,6 +299,26 @@ AS $$
    WHERE id = p_source_id;
 $$;
 
+-- Per-member credentials within a tenant (added 2026-04-14)
+-- Lookup order in worker: tenant_members first, fall back to tenants row.
+CREATE TABLE IF NOT EXISTS tenant_members (
+  id                          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id                   UUID NOT NULL REFERENCES tenants(id),
+  github_author_login         TEXT NOT NULL,
+  buffer_access_token         TEXT,
+  linkedin_access_token       TEXT,
+  linkedin_member_id          TEXT,
+  linkedin_token_expires_at   TIMESTAMPTZ,
+  encrypted_dek               TEXT,
+  voice_bootstrap             TEXT,
+  created_at                  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at                  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(tenant_id, github_author_login)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_members_lookup
+  ON tenant_members(tenant_id, github_author_login);
+
 -- ─────────────────────────────────────────────────────────
 -- ROW LEVEL SECURITY
 -- ─────────────────────────────────────────────────────────
@@ -310,6 +333,7 @@ ALTER TABLE events_state             ENABLE ROW LEVEL SECURITY;
 ALTER TABLE scheduled_slots          ENABLE ROW LEVEL SECURITY;
 ALTER TABLE tenants                  ENABLE ROW LEVEL SECURITY;
 ALTER TABLE job_queue                ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tenant_members           ENABLE ROW LEVEL SECURITY;
 ALTER TABLE content_sources          ENABLE ROW LEVEL SECURITY;
 ALTER TABLE content_items            ENABLE ROW LEVEL SECURITY;
 ALTER TABLE article_chunks           ENABLE ROW LEVEL SECURITY;
@@ -337,3 +361,6 @@ DROP INDEX IF EXISTS idx_voice_retrieval;
 CREATE INDEX IF NOT EXISTS idx_voice_retrieval
   ON voice_posts(platform, engagement_score DESC NULLS LAST, edit_ratio DESC NULLS LAST)
   WHERE status = 'published';
+
+-- R5: author voice quality rating — 1=👎 2=👍 NULL=unrated
+ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS voice_rating SMALLINT;

--- a/experiments/synthesis-hallucination-baseline/src/generate-synthesis.ts
+++ b/experiments/synthesis-hallucination-baseline/src/generate-synthesis.ts
@@ -1,0 +1,296 @@
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { openDb } from './lib/db.js';
+import { callHaiku, callSonnet } from './lib/anthropic-client.js';
+import { splitClaims } from './lib/split-claims.js';
+import { HAIKU_SIGNAL_EXTRACT_SYSTEM, buildHaikuSignalExtractUser } from './prompts/haiku-signal-extract.js';
+import { buildSonnetFocalUser, buildSonnetArcUser, buildSonnetSingleUser, type SignalForPrompt } from './prompts/sonnet-synthesize.js';
+import type { SynthesisGroup, HaikuSignalOutput, VoiceProfileCacheEntry } from './lib/types.js';
+import { buildSystemPrompt } from '../../../src/ai/prompt-builder.js';
+import { VoiceProfileSchema, ConfigSchema } from '../../../src/config/schema.js';
+import { extractFirstHunkSnippet } from '../../../src/analysis/diff-parser.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const VOICE_PROFILES_CACHE = join(__dirname, '../db/voice-profiles-cache.json');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+function loadProfileCache(): VoiceProfileCacheEntry[] {
+  try {
+    return JSON.parse(readFileSync(VOICE_PROFILES_CACHE, 'utf8')) as VoiceProfileCacheEntry[];
+  } catch {
+    throw new Error('voice-profiles-cache.json not found — run npm run select first');
+  }
+}
+
+function getProfile(cache: VoiceProfileCacheEntry[], authorLogin: string) {
+  const entry = cache.find((p) => p.github_author_login === authorLogin);
+  if (!entry) return null;
+  const parsed = VoiceProfileSchema.safeParse(entry.voice);
+  return parsed.success ? parsed.data : null;
+}
+
+function buildMinimalSystemPrompt(authorLogin: string, voiceProfileRaw: Record<string, unknown>): string {
+  const voiceProfile = VoiceProfileSchema.parse(voiceProfileRaw);
+  const config = ConfigSchema.parse({
+    author: { github_username: authorLogin, name: authorLogin },
+    buffer: { organization_id: 'experiment' },
+    platforms: { linkedin: { enabled: true }, instagram: { enabled: false } },
+    github: {},
+    scheduling: {},
+    posting: {},
+    ai: {},
+  });
+  return buildSystemPrompt(config, voiceProfile, {
+    stage: 'established',
+    exposurePool: [],
+    bootstrapPosts: [],
+    commitSha: 'experiment',
+    draftIndexToday: 0,
+  });
+}
+
+function isDeclined(output: string): boolean {
+  return /^\s*<no_post\s*\/>\s*$/.test(output) || output.trim() === '<no_post/>';
+}
+
+function extractEvidenceSnippet(patch: string): string {
+  return extractFirstHunkSnippet(patch, 6);
+}
+
+async function processGroup(
+  db: ReturnType<typeof openDb>,
+  group: SynthesisGroup,
+  profileCache: VoiceProfileCacheEntry[],
+): Promise<void> {
+  // Skip if already processed
+  const existing = db.prepare('SELECT group_id FROM synthesis_posts WHERE group_id = ?').get(group.id);
+  if (existing) return;
+
+  const profile = getProfile(profileCache, group.author_login);
+  if (!profile) {
+    console.warn(`  [skip] No voice profile for ${group.author_login}`);
+    return;
+  }
+
+  if (group.variant === 'SINGLE') {
+    await processSingle(db, group, profileCache);
+    return;
+  }
+
+  // ── Paso A: signal extraction per commit ──────────────────────────────
+  const signals: SignalForPrompt[] = [];
+  let totalCost = 0;
+
+  for (let i = 0; i < group.commit_shas.length; i++) {
+    const sha = group.commit_shas[i]!;
+    const message = group.commit_messages[i] ?? '';
+    const diff = group.commit_diffs[i] ?? '';
+
+    const alreadySignal = db.prepare('SELECT id FROM weak_signals WHERE group_id = ? AND commit_sha = ?').get(group.id, sha);
+    if (alreadySignal) {
+      const row = db.prepare('SELECT * FROM weak_signals WHERE group_id = ? AND commit_sha = ?').get(group.id, sha) as {
+        topic: string; strength: number; pattern_kind: string | null;
+        affected_symbols: string; specific_change: string; evidence_snippet: string;
+        haiku_raw: string;
+      };
+      signals.push({
+        date: '',
+        sha,
+        message,
+        repo: group.repo,
+        topic: row.topic ?? group.topic,
+        strength: row.strength ?? 5,
+        pattern_kind: row.pattern_kind,
+        description: row.specific_change ?? '',
+        evidence: row.evidence_snippet ?? '',
+      });
+      continue;
+    }
+
+    if (DRY_RUN) {
+      console.log(`    [dry-run] Haiku signal extract for ${sha.slice(0, 7)}`);
+      continue;
+    }
+
+    const userPrompt = buildHaikuSignalExtractUser(message, diff);
+    const { text, cost_usd } = await callHaiku(HAIKU_SIGNAL_EXTRACT_SYSTEM, userPrompt);
+    totalCost += cost_usd;
+
+    let parsed: HaikuSignalOutput & { trivial?: boolean } | null = null;
+    try {
+      const cleaned = text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
+      const raw = JSON.parse(cleaned) as unknown;
+      // Haiku sometimes returns an array of signals — take the first element
+      parsed = (Array.isArray(raw) ? raw[0] : raw) as HaikuSignalOutput & { trivial?: boolean } | null;
+    } catch {
+      parsed = null;
+    }
+
+    const evidenceSnippet = extractEvidenceSnippet(diff);
+
+    db.prepare(`
+      INSERT OR IGNORE INTO weak_signals
+        (group_id, commit_sha, haiku_raw, topic, strength, pattern_kind, affected_symbols, specific_change, evidence_snippet)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      group.id,
+      sha,
+      text,
+      parsed?.trivial ? null : (parsed?.topic ?? null),
+      parsed?.trivial ? null : (parsed?.strength ?? null),
+      parsed?.trivial ? null : (parsed?.pattern_kind ?? null),
+      JSON.stringify(parsed?.trivial ? [] : (parsed?.affected_symbols ?? [])),
+      parsed?.trivial ? null : (parsed?.specific_change ?? null),
+      evidenceSnippet || null,
+    );
+
+    if (parsed && !parsed.trivial) {
+      signals.push({
+        date: '',
+        sha,
+        message,
+        repo: group.repo,
+        topic: parsed.topic ?? group.topic,
+        strength: parsed.strength ?? 5,
+        pattern_kind: parsed.pattern_kind ?? null,
+        description: parsed.specific_change ?? '',
+        evidence: evidenceSnippet,
+      });
+    }
+  }
+
+  if (DRY_RUN) {
+    console.log(`  [dry-run] Would call Sonnet for group ${group.id.slice(0, 8)} (${group.variant})`);
+    return;
+  }
+
+  if (signals.length === 0) {
+    console.warn(`  [skip] No non-trivial signals for group ${group.id.slice(0, 8)}`);
+    return;
+  }
+
+  // ── Paso B: synthesis (Sonnet) ─────────────────────────────────────────
+  const systemPrompt = buildMinimalSystemPrompt(group.author_login, profileCache.find((p) => p.github_author_login === group.author_login)!.voice);
+
+  const dates = group.commit_shas.map((_, i) => {
+    const created = group.commit_messages[i] ?? '';
+    return created;
+  });
+  const spanMs = signals.length > 1
+    ? 0
+    : 0;
+
+  // Compute span_days from DB commit dates (approximate using group record)
+  const spanDays = 7; // approximate; real span would need stored dates
+
+  let userPrompt: string;
+  if (group.variant === 'FOCAL') {
+    userPrompt = buildSonnetFocalUser(signals, group.topic, spanDays);
+  } else {
+    const topics = group.topic.split(',');
+    const allFiles = signals.flatMap((s) => {
+      // Extract file paths from evidence snippets as rough proxy
+      const lines = s.evidence.split('\n').filter((l) => l.startsWith('---') || l.startsWith('+++'));
+      return lines.map((l) => l.replace(/^[-+]{3} /, '').replace(/\t.*$/, '').trim());
+    }).filter(Boolean);
+    const sharedFiles = [...new Set(allFiles)].slice(0, 5);
+    userPrompt = buildSonnetArcUser(signals, topics, sharedFiles, spanDays);
+  }
+
+  const { text: sonnetOutput, cost_usd: sonnetCost } = await callSonnet(systemPrompt, userPrompt);
+  totalCost += sonnetCost;
+
+  const declined = isDeclined(sonnetOutput) ? 1 : 0;
+  const claims = declined ? [] : splitClaims(sonnetOutput);
+
+  db.prepare(`
+    INSERT OR REPLACE INTO synthesis_posts
+      (group_id, sonnet_input, sonnet_output, declined, claim_count, cost_usd)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(group.id, `${systemPrompt}\n\n---\n\n${userPrompt}`, sonnetOutput, declined, claims.length, totalCost);
+
+  const status = declined ? 'DECLINED' : `${claims.length} claims`;
+  console.log(`  [done] group ${group.id.slice(0, 8)} ${group.variant}/${group.origin} → ${status}`);
+}
+
+async function processSingle(
+  db: ReturnType<typeof openDb>,
+  group: SynthesisGroup,
+  profileCache: VoiceProfileCacheEntry[],
+): Promise<void> {
+  const sha = group.commit_shas[0]!;
+  const message = group.commit_messages[0] ?? '';
+  const diff = group.commit_diffs[0] ?? '';
+
+  const profileEntry = profileCache.find((p) => p.github_author_login === group.author_login);
+  if (!profileEntry) return;
+
+  if (DRY_RUN) {
+    console.log(`  [dry-run] SINGLE Sonnet for ${sha.slice(0, 7)}`);
+    return;
+  }
+
+  const systemPrompt = buildMinimalSystemPrompt(group.author_login, profileEntry.voice);
+  const userPrompt = buildSonnetSingleUser(message, group.repo, group.topic, message, diff);
+
+  const { text: sonnetOutput, cost_usd } = await callSonnet(systemPrompt, userPrompt);
+  const claims = splitClaims(sonnetOutput);
+
+  db.prepare(`
+    INSERT OR REPLACE INTO synthesis_posts
+      (group_id, sonnet_input, sonnet_output, declined, claim_count, cost_usd)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(group.id, `${systemPrompt}\n\n---\n\n${userPrompt}`, sonnetOutput, 0, claims.length, cost_usd);
+
+  console.log(`  [done] SINGLE ${sha.slice(0, 7)} → ${claims.length} claims`);
+}
+
+async function main(): Promise<void> {
+  const db = openDb();
+  const profileCache = loadProfileCache();
+
+  const groups = db.prepare('SELECT * FROM synthesis_groups').all() as Array<{
+    id: string; author_login: string; tenant_id: string | null;
+    repo: string; topic: string; variant: string; origin: string;
+    coherence_score: number | null; commit_shas: string; commit_messages: string; commit_diffs: string;
+  }>;
+
+  if (groups.length === 0) {
+    console.log('[generate-synthesis] No groups found. Run npm run select first.');
+    return;
+  }
+
+  console.log(`[generate-synthesis] Processing ${groups.length} groups...`);
+
+  for (const raw of groups) {
+    const group: SynthesisGroup = {
+      ...raw,
+      variant: raw.variant as SynthesisGroup['variant'],
+      origin: raw.origin as SynthesisGroup['origin'],
+      commit_shas: JSON.parse(raw.commit_shas) as string[],
+      commit_messages: JSON.parse(raw.commit_messages) as string[],
+      commit_diffs: JSON.parse(raw.commit_diffs) as string[],
+    };
+
+    console.log(`  Processing ${group.variant}/${group.origin} ${group.id.slice(0, 8)}...`);
+    try {
+      await processGroup(db, group, profileCache);
+    } catch (err) {
+      const msg = String(err);
+      if (msg.includes('Cost cap')) {
+        console.error(`[generate-synthesis] Cost cap reached: ${msg}`);
+        process.exit(1);
+      }
+      console.error(`  [error] group ${group.id.slice(0, 8)}: ${msg}`);
+    }
+  }
+
+  console.log('\n[generate-synthesis] Done. Run npm run prelabel next.\n');
+}
+
+main().catch((err) => {
+  console.error('[generate-synthesis] Fatal:', String(err));
+  process.exit(1);
+});

--- a/experiments/synthesis-hallucination-baseline/src/preflight.ts
+++ b/experiments/synthesis-hallucination-baseline/src/preflight.ts
@@ -1,0 +1,213 @@
+import { writeFileSync, mkdirSync, existsSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { homedir } from 'os';
+import { getSupabaseReadonly } from './lib/supabase-readonly.js';
+import { openDb } from './lib/db.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DB_DIR = join(__dirname, '../db');
+const WINDOW_DAYS = 120;
+
+interface PreflightReport {
+  timestamp: string;
+  passed: boolean;
+  checks: Array<{ name: string; status: 'ok' | 'fail'; detail: string }>;
+  author_stats?: Record<string, { commits: number; emails: string[]; repos: string[] }>;
+  repos_found?: string[];
+  repos_missing?: string[];
+}
+
+function abort(message: string): never {
+  console.error(`\n[preflight] ABORT: ${message}`);
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  const report: PreflightReport = {
+    timestamp: new Date().toISOString(),
+    passed: false,
+    checks: [],
+  };
+
+  const ok = (name: string, detail: string) => {
+    console.log(`  ✓ ${name}: ${detail}`);
+    report.checks.push({ name, status: 'ok', detail });
+  };
+
+  const fail = (name: string, detail: string): never => {
+    report.checks.push({ name, status: 'fail', detail });
+    mkdirSync(DB_DIR, { recursive: true });
+    writeFileSync(join(DB_DIR, 'preflight-report.json'), JSON.stringify(report, null, 2));
+    abort(detail);
+  };
+
+  console.log('\n[preflight] Starting checks (v1.4 — commit-stream resampling)...\n');
+
+  // 1. Credentials
+  const required = ['ANTHROPIC_API_KEY', 'SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'];
+  for (const key of required) {
+    if (!process.env[key]) fail(`env.${key}`, `${key} is not set`);
+    ok(`env.${key}`, 'present');
+  }
+  // GITHUB_TOKEN is no longer required — resampling reads from local git clones
+  if (!process.env['GITHUB_TOKEN']) {
+    console.log('  ℹ  env.GITHUB_TOKEN: not set (local-git mode — OK)');
+  } else {
+    ok('env.GITHUB_TOKEN', 'present (unused by resampling, kept for legacy)');
+  }
+
+  // 2. git CLI available
+  try {
+    const gitVersion = execFileSync('git', ['--version'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    ok('env.git', gitVersion);
+  } catch {
+    fail('env.git', 'git CLI not found in PATH');
+  }
+
+  // 3. REPOS_ROOT exists
+  const reposRoot = process.env['REPOS_ROOT'] ?? join(homedir(), 'Documents/git');
+  if (!existsSync(reposRoot)) {
+    fail('env.REPOS_ROOT', `${reposRoot} does not exist. Set REPOS_ROOT env var or clone repos there.`);
+  }
+  ok('env.REPOS_ROOT', reposRoot);
+
+  // 4. Supabase connectivity (SELECT only)
+  const supabase = getSupabaseReadonly();
+  const { error: connError } = await supabase.from('voice_posts').select('id').limit(1);
+  if (connError) fail('supabase.connect', `Cannot query voice_posts: ${connError.message}`);
+  ok('supabase.connect', 'SELECT access confirmed — no writes will be made');
+
+  // 5. voice_profiles schema
+  const { error: vprofProbeError } = await supabase
+    .from('voice_profiles')
+    .select('tenant_id, github_author_login')
+    .limit(1);
+  if (vprofProbeError) {
+    fail(
+      'schema.voice_profiles',
+      'voice_profiles schema does not match expected (missing tenant_id or github_author_login). ' +
+      `Error: ${String(vprofProbeError)}.`,
+    );
+  }
+  ok('schema.voice_profiles', 'expected columns present');
+
+  // 6. voice_profiles data — ≥ 3 distinct authors
+  const { data: profiles, error: profError } = await supabase
+    .from('voice_profiles')
+    .select('tenant_id, github_author_login')
+    .not('github_author_login', 'is', null);
+  if (profError) fail('data.voice_profiles', `Query failed: ${profError.message}`);
+  const distinctAuthors = [...new Set((profiles ?? []).map((p) => p.github_author_login as string))];
+  if (distinctAuthors.length < 3) {
+    fail('data.voice_profiles', `Only ${distinctAuthors.length} distinct author profile(s) found. Minimum 3 required.`);
+  }
+  ok('data.voice_profiles', `${distinctAuthors.length} distinct author profiles: ${distinctAuthors.join(', ')}`);
+
+  // 7. Discover repos referenced in voice_posts (last 120d) and check local clones
+  const cutoff = new Date(Date.now() - WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  const { data: repoRows, error: repoError } = await supabase
+    .from('voice_posts')
+    .select('repo')
+    .gte('created_at', cutoff)
+    .not('repo', 'is', null);
+  if (repoError) fail('supabase.voice_posts_repos', `Query failed: ${repoError.message}`);
+  const distinctRepos = [...new Set((repoRows ?? []).map((r) => r.repo as string))];
+  const foundRepos: string[] = [];
+  const missingRepos: string[] = [];
+  for (const repo of distinctRepos) {
+    const [, repoName] = repo.split('/');
+    if (!repoName) {
+      missingRepos.push(repo);
+      continue;
+    }
+    const localPath = join(reposRoot, repoName);
+    if (existsSync(join(localPath, '.git'))) foundRepos.push(localPath);
+    else missingRepos.push(repo);
+  }
+  report.repos_found = foundRepos;
+  report.repos_missing = missingRepos;
+  if (foundRepos.length === 0) {
+    fail('local_repos', `No local clones found under ${reposRoot}. Expected: ${distinctRepos.join(', ')}`);
+  }
+  ok('local_repos', `${foundRepos.length}/${distinctRepos.length} repos present locally`);
+  if (missingRepos.length > 0) {
+    console.warn(`  ⚠  Missing repos (commits from these will have empty diffs): ${missingRepos.join(', ')}`);
+  }
+
+  // 8. Per-author local commit presence (last 120d)
+  const sinceArg = `--since=${cutoff}`;
+  const authorStats: Record<string, { commits: number; emails: string[]; repos: string[] }> = {};
+
+  for (const login of distinctAuthors) {
+    const emails = new Set<string>();
+    const reposHit = new Set<string>();
+    let commits = 0;
+    const loginLower = login.toLowerCase();
+
+    for (const repoPath of foundRepos) {
+      try {
+        const out = execFileSync(
+          'git',
+          ['-C', repoPath, 'log', '--all', sinceArg, '--format=%an|%ae|%H'],
+          { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], maxBuffer: 32 * 1024 * 1024 },
+        );
+        let repoMatched = false;
+        for (const line of out.split('\n').filter(Boolean)) {
+          const parts = line.split('|');
+          const name = parts[0] ?? '';
+          const email = parts[1] ?? '';
+          const nameLower = name.toLowerCase();
+          const emailLocal = email.split('@')[0]?.toLowerCase() ?? '';
+          // Tight match: login appears in name OR is the email local-part (or prefix thereof)
+          if (nameLower.includes(loginLower) || emailLocal === loginLower || emailLocal.startsWith(loginLower + '+')) {
+            emails.add(email);
+            commits++;
+            repoMatched = true;
+          }
+        }
+        if (repoMatched) reposHit.add(repoPath.split('/').pop() ?? repoPath);
+      } catch {
+        /* skip unreadable repo */
+      }
+    }
+    authorStats[login] = { commits, emails: [...emails], repos: [...reposHit] };
+  }
+  report.author_stats = authorStats;
+
+  const authorsWithZero = Object.entries(authorStats).filter(([, s]) => s.commits === 0);
+  if (authorsWithZero.length > 0) {
+    const names = authorsWithZero.map(([a]) => a).join(', ');
+    const hint = missingRepos.length > 0
+      ? ` Missing repos in voice_posts that you may need to clone: ${missingRepos.join(', ')}.`
+      : '';
+    fail(
+      'author_local_commits',
+      `Authors with 0 local commits in last ${WINDOW_DAYS}d: ${names}.${hint} ` +
+      `Clone the relevant repos under ${reposRoot} or remove these profiles from voice_profiles.`,
+    );
+  }
+
+  console.log('\n  Author → local commits (last 120d):');
+  for (const [login, s] of Object.entries(authorStats)) {
+    console.log(`    ${login}: ${s.commits} commits across ${s.repos.length} repo(s) [${s.repos.join(', ')}] (${s.emails.length} email(s))`);
+  }
+  ok('author_local_commits', `${Object.keys(authorStats).length} authors with ≥1 commit locally`);
+
+  // All checks passed
+  report.passed = true;
+  mkdirSync(DB_DIR, { recursive: true });
+  writeFileSync(join(DB_DIR, 'preflight-report.json'), JSON.stringify(report, null, 2));
+
+  // Initialize SQLite DB (ensures new v1.4 tables exist)
+  openDb();
+
+  console.log('\n[preflight] All checks passed. preflight-report.json written.\n');
+  console.log('  Ready to run: npm run select\n');
+}
+
+main().catch((err) => {
+  console.error('[preflight] Unexpected error:', String(err));
+  process.exit(1);
+});

--- a/experiments/synthesis-hallucination-baseline/src/prelabel.ts
+++ b/experiments/synthesis-hallucination-baseline/src/prelabel.ts
@@ -1,0 +1,97 @@
+import { openDb } from './lib/db.js';
+import { callHaiku } from './lib/anthropic-client.js';
+import { HAIKU_PRELABEL_SYSTEM, buildHaikuPrelabelUser } from './prompts/haiku-prelabel.js';
+import { splitClaims } from './lib/split-claims.js';
+import type { HaikuPrelabelOutput, StructuralCheck } from './lib/types.js';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function main(): Promise<void> {
+  const db = openDb();
+
+  const posts = db.prepare(`
+    SELECT sp.group_id, sp.sonnet_output, sp.declined,
+           sg.commit_shas, sg.commit_messages, sg.commit_diffs
+    FROM synthesis_posts sp
+    JOIN synthesis_groups sg ON sg.id = sp.group_id
+    WHERE sp.declined = 0
+  `).all() as Array<{
+    group_id: string;
+    sonnet_output: string;
+    declined: number;
+    commit_shas: string;
+    commit_messages: string;
+    commit_diffs: string;
+  }>;
+
+  if (posts.length === 0) {
+    console.log('[prelabel] No non-declined posts found. Run npm run generate first.');
+    return;
+  }
+
+  console.log(`[prelabel] Labeling ${posts.length} posts...`);
+
+  for (const post of posts) {
+    const claims = splitClaims(post.sonnet_output);
+    if (claims.length === 0) continue;
+
+    const commitShas: string[] = JSON.parse(post.commit_shas) as string[];
+    const commitMessages: string[] = JSON.parse(post.commit_messages) as string[];
+    const commitDiffs: string[] = JSON.parse(post.commit_diffs) as string[];
+
+    const diffs = commitShas.map((sha, i) => `=== ${sha.slice(0, 7)} ===\n${commitDiffs[i] ?? ''}`).join('\n\n');
+    const messages = commitMessages.join('\n');
+
+    for (let idx = 0; idx < claims.length; idx++) {
+      const claim = claims[idx]!;
+
+      // Skip if already labeled
+      const existing = db.prepare(
+        'SELECT id FROM prelabels WHERE group_id = ? AND claim_index = ?',
+      ).get(post.group_id, idx);
+      if (existing) continue;
+
+      if (DRY_RUN) {
+        console.log(`  [dry-run] prelabel group=${post.group_id.slice(0, 8)} claim[${idx}]: "${claim.slice(0, 60)}..."`);
+        continue;
+      }
+
+      try {
+        const userPrompt = buildHaikuPrelabelUser(claim, diffs, messages);
+        const { text } = await callHaiku(HAIKU_PRELABEL_SYSTEM, userPrompt);
+
+        let parsed: HaikuPrelabelOutput | null = null;
+        try {
+          const cleaned = text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
+          parsed = JSON.parse(cleaned) as HaikuPrelabelOutput;
+        } catch {
+          parsed = null;
+        }
+
+        const check: StructuralCheck = parsed?.check ?? 'needs_human';
+        const evidence = parsed?.evidence ?? 'Parse error — needs human review';
+
+        db.prepare(`
+          INSERT OR IGNORE INTO prelabels (group_id, claim_index, claim_text, structural_check, evidence)
+          VALUES (?, ?, ?, ?, ?)
+        `).run(post.group_id, idx, claim, check, evidence);
+      } catch (err) {
+        const msg = String(err);
+        if (msg.includes('Cost cap')) {
+          console.error(`[prelabel] Cost cap reached: ${msg}`);
+          process.exit(1);
+        }
+        console.error(`  [error] group=${post.group_id.slice(0, 8)} claim[${idx}]: ${msg}`);
+      }
+    }
+
+    console.log(`  [done] group ${post.group_id.slice(0, 8)} — ${claims.length} claims labeled`);
+  }
+
+  console.log('\n[prelabel] Done. Run npm run export next.\n');
+}
+
+main().catch((err) => {
+  console.error('[prelabel] Fatal:', String(err));
+  process.exit(1);
+});

--- a/scripts/replay-commit.ts
+++ b/scripts/replay-commit.ts
@@ -16,6 +16,8 @@ import { runPipeline } from '../src/analysis/pipeline.js';
 import { buildSystemPrompt, buildUserPrompt } from '../src/ai/prompt-builder.js';
 import { AnthropicAdapter } from '../src/ai/anthropic-adapter.js';
 import { SupabaseStorage } from '../src/voice/supabase-storage.js';
+import { selectDevelopmentalAngle, buildAngleBlock, type ArcType } from '../src/ai/developmental-editor.js';
+import { detectCommitIntent, computeCollaborationWeight } from '../src/utils/commit-classifier.js';
 import { DEFAULT_VOICE_PROFILE } from '../src/config/schema.js';
 
 const SEP = '─'.repeat(72);
@@ -127,9 +129,46 @@ async function main(): Promise<void> {
 
   console.log(`profile: tone=${voiceProfile.tone} rhythm=${voiceProfile.rhythm ?? 'default'} max=${voiceProfile.post_length.max}chars`);
 
-  // ── Stage 5: Build prompt ────────────────────────────────────────────────
+  // ── Stage 5: R3 — narrative arc (fail-open) ─────────────────────────────
   console.log(`\n${SEP}`);
-  console.log('STAGE 5 — buildUserPrompt');
+  console.log('STAGE 5 — R3 narrative arc');
+  console.log(SEP);
+
+  let developmentalAngle: string | undefined;
+  try {
+    const recentArcs: ArcType[] = supabaseUrl && supabaseKey && authorLogin
+      ? ((await new SupabaseStorage(supabaseUrl, supabaseKey, tenantId).getRecentArcTypes(authorLogin, 5)) as ArcType[])
+      : [];
+    const commitIntent = detectCommitIntent({
+      message: commit.message,
+      branchRef: commit.branchRef,
+      prTitle: commit.prContext?.prTitle,
+      moduleIds: findings.map((f) => f.moduleId),
+    });
+    const collabWeight = computeCollaborationWeight(commit.prContext);
+    const angle = selectDevelopmentalAngle({
+      findings,
+      commitIntent,
+      closingIssues: commit.prContext?.closingIssues,
+      changesRequestedCount: commit.prContext?.changesRequestedCount ?? 0,
+      collaborationWeight: collabWeight,
+      recentArcTypes: recentArcs,
+      discouragedArcTypes: (voiceProfile.content_preferences?.penalized_arc_types ?? []) as ArcType[],
+    });
+    if (angle) {
+      developmentalAngle = buildAngleBlock(angle, collabWeight);
+      console.log(`  arc_type: ${angle.arcType}`);
+      console.log(`  tension:  ${angle.tension}`);
+    } else {
+      console.log('  No arc selected (not enough evidence)');
+    }
+  } catch (e) {
+    console.warn(`  R3 failed (${String(e)}) — skipping`);
+  }
+
+  // ── Stage 6: Build prompt ────────────────────────────────────────────────
+  console.log(`\n${SEP}`);
+  console.log('STAGE 6 — buildUserPrompt');
   console.log(SEP);
 
   const minConfig = {
@@ -145,15 +184,15 @@ async function main(): Promise<void> {
     { stage: 'cold', exposurePool: [], bootstrapPosts: [], commitSha: commit.sha, draftIndexToday: 0 },
   );
 
-  const userPrompt = buildUserPrompt(commit, findings);
+  const userPrompt = buildUserPrompt(commit, findings, [], undefined, undefined, developmentalAngle);
 
   console.log('\n[userPrompt excerpt — first 1500 chars]');
   console.log(userPrompt.slice(0, 1500));
   if (userPrompt.length > 1500) console.log(`... [${userPrompt.length - 1500} more chars]`);
 
-  // ── Stage 6: Claude call ─────────────────────────────────────────────────
+  // ── Stage 7: Claude call ─────────────────────────────────────────────────
   console.log(`\n${SEP}`);
-  console.log('STAGE 6 — Claude generation');
+  console.log('STAGE 7 — Claude generation');
   console.log(SEP);
 
   const ai = new AnthropicAdapter(anthropicKey);
@@ -165,13 +204,15 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // ── Stage 7: Parse and display final post ───────────────────────────────
+  // ── Stage 8: Parse and display final post ───────────────────────────────
   console.log(`\n${SEP}`);
-  console.log('STAGE 7 — final post');
+  console.log('STAGE 8 — final post');
   console.log(SEP);
 
-  const postMatch = rawResponse.match(/<post_draft>([\s\S]*?)<\/post_draft>/);
-  const shortMatch = rawResponse.match(/<short_draft>([\s\S]*?)<\/short_draft>/);
+  const postMatch = rawResponse.match(/<linkedin_draft>([\s\S]*?)<\/linkedin_draft>/)
+    ?? rawResponse.match(/<post_draft>([\s\S]*?)<\/post_draft>/);
+  const shortMatch = rawResponse.match(/<twitter_draft>([\s\S]*?)<\/twitter_draft>/)
+    ?? rawResponse.match(/<short_draft>([\s\S]*?)<\/short_draft>/);
 
   if (!postMatch || !shortMatch) {
     console.error('Claude response missing XML tags. Raw response:');
@@ -182,13 +223,13 @@ async function main(): Promise<void> {
   const mainPost = (postMatch[1] ?? '').trim();
   const shortPost = (shortMatch[1] ?? '').trim();
 
-  console.log('\n── MAIN POST ──────────────────────────────────────────────────────────\n');
+  console.log('\n── LINKEDIN ───────────────────────────────────────────────────────────\n');
   console.log(mainPost);
-  console.log('\n── SHORT VARIANT ──────────────────────────────────────────────────────\n');
+  console.log('\n── TWITTER/X ──────────────────────────────────────────────────────────\n');
   console.log(shortPost);
   console.log(`\n── STATS ──────────────────────────────────────────────────────────────`);
-  console.log(`main post: ${mainPost.length} chars (max ${voiceProfile.post_length.max})`);
-  console.log(`short:     ${shortPost.length} chars`);
+  console.log(`linkedin: ${mainPost.length} chars (max ${voiceProfile.post_length.max})`);
+  console.log(`twitter:  ${shortPost.length} chars`);
   console.log(`top module: ${findings[0]?.moduleId} (score ${findings[0]?.interestScore})`);
   console.log(`private repo: ${commit.isPrivateRepo}`);
   console.log('');

--- a/scripts/replay-synthesis.ts
+++ b/scripts/replay-synthesis.ts
@@ -17,6 +17,9 @@ import { AnthropicAdapter } from '../src/ai/anthropic-adapter.js';
 import { generateBufferText } from '../src/ai/synthesis-generator.js';
 import { check, checkCrossVolume } from '../src/analysis/accumulation-engine.js';
 import { selectDevelopmentalAngle, buildAngleBlock, type ArcType } from '../src/ai/developmental-editor.js';
+import { matchFindingsToArticles } from '../src/content/matcher.js';
+import { buildIndustryContextBlock } from '../src/ai/prompt-builder.js';
+import { createEmbedder, createAIClient } from '../src/ai/factory.js';
 import { DEFAULT_VOICE_PROFILE } from '../src/config/schema.js';
 import type { SignalBankEntry, SignalEvent } from '../src/voice/storage.js';
 
@@ -38,9 +41,12 @@ async function main(): Promise<void> {
   if (!anthropicKey) { console.error('ANTHROPIC_API_KEY not set'); process.exit(1); }
   if (!supabaseUrl || !supabaseKey) { console.error('SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY not set'); process.exit(1); }
 
+  const openaiKey = process.env['OPENAI_API_KEY'] ?? '';
   const db = createClient(supabaseUrl, supabaseKey);
   const storage = new SupabaseStorage(supabaseUrl, supabaseKey, tenantId);
   const ai = new AnthropicAdapter(anthropicKey);
+  const matcherAi = createAIClient('anthropic', anthropicKey, 'claude-haiku-4-5-20251001', 400);
+  const embedder = openaiKey ? createEmbedder('openai', openaiKey, 'text-embedding-3-small') : null;
   const nowIso = new Date().toISOString();
 
   // ── Stage 1: Signal bank ────────────────────────────────────────────────
@@ -154,7 +160,39 @@ async function main(): Promise<void> {
     console.warn(`  R3 failed (${String(e)}) — skipping`);
   }
 
-  // ── Stage 5: Build synthesis input ──────────────────────────────────────
+  // ── Stage 5: Industry context (fail-open) ───────────────────────────────
+  console.log(`\n${SEP}`);
+  console.log(`STAGE 5 — industry context`);
+  console.log(SEP);
+
+  let industryContext: string | undefined;
+  if (embedder) {
+    try {
+      const synFindingsForMatch = allSignals.map((s: SignalEvent) => ({
+        moduleId: s.topic,
+        aspect: s.topic.replace(/_/g, ' '),
+        finding: s.specific_change,
+        technicalDetail: s.specific_change,
+        plainLanguage: s.specific_change,
+        interestScore: s.strength * 2,
+        contextHint: s.affected_files[0] ? `${s.affected_files[0]} in ${s.repo}` : undefined,
+      }));
+      const match = await matchFindingsToArticles(synFindingsForMatch, embedder, matcherAi, db);
+      if (match) {
+        industryContext = buildIndustryContextBlock({ connection: match.connection, articleUrl: match.articleUrl });
+        console.log(`  matched: ${match.articleTitle}`);
+        console.log(`  connection: ${match.connection}`);
+      } else {
+        console.log('  No article match found');
+      }
+    } catch (e) {
+      console.warn(`  Industry context failed (${String(e)}) — skipping`);
+    }
+  } else {
+    console.log('  Skipped — OPENAI_API_KEY not set');
+  }
+
+  // ── Stage 6: Build synthesis input ──────────────────────────────────────
   const gatillador = 'focal' as const;
   const minConfig = {
     author: { name: authorLogin, github_login: authorLogin },
@@ -177,19 +215,20 @@ async function main(): Promise<void> {
     bootstrapPosts: voiceProfile.bootstrap_posts ?? [],
     draftIndexToday: 0,
     developmentalAngle,
+    industryContext,
   };
 
-  // ── Stage 6: Claude synthesis ────────────────────────────────────────────
+  // ── Stage 7: Claude synthesis ────────────────────────────────────────────
   console.log(`\n${SEP}`);
-  console.log(`STAGE 6 — Claude synthesis (dry-run, signals NOT consumed)`);
+  console.log(`STAGE 7 — Claude synthesis (dry-run, signals NOT consumed)`);
   console.log(SEP);
   console.log(`  gatillador: ${gatillador}  topics: ${topics.join(', ')}  signals: ${allSignals.length}`);
 
   const result = await generateBufferText(ai, input);
 
-  // ── Stage 7: Result ──────────────────────────────────────────────────────
+  // ── Stage 8: Result ──────────────────────────────────────────────────────
   console.log(`\n${SEP}`);
-  console.log('STAGE 7 — generated synthesis post');
+  console.log('STAGE 8 — generated synthesis post');
   console.log(SEP);
   console.log('\n── POST ───────────────────────────────────────────────────────────────\n');
   console.log(result.bufferText);

--- a/scripts/replay-synthesis.ts
+++ b/scripts/replay-synthesis.ts
@@ -166,6 +166,7 @@ async function main(): Promise<void> {
   console.log(SEP);
 
   let industryContext: string | undefined;
+  let featuredSignal: string | undefined;
   if (embedder) {
     try {
       const synFindingsForMatch = allSignals.map((s: SignalEvent) => ({
@@ -180,7 +181,9 @@ async function main(): Promise<void> {
       const match = await matchFindingsToArticles(synFindingsForMatch, embedder, matcherAi, db);
       if (match) {
         industryContext = buildIndustryContextBlock({ connection: match.connection, articleUrl: match.articleUrl });
+        featuredSignal = match.matchedFinding;
         console.log(`  matched: ${match.articleTitle}`);
+        console.log(`  featured signal: ${match.matchedFinding}`);
         console.log(`  connection: ${match.connection}`);
       } else {
         console.log('  No article match found');
@@ -216,6 +219,7 @@ async function main(): Promise<void> {
     draftIndexToday: 0,
     developmentalAngle,
     industryContext,
+    featuredSignal,
   };
 
   // ── Stage 7: Claude synthesis ────────────────────────────────────────────

--- a/scripts/replay-synthesis.ts
+++ b/scripts/replay-synthesis.ts
@@ -1,0 +1,209 @@
+/**
+ * replay-synthesis.ts — dry-run of the CEP synthesis path (Camino 2) for a given author/repo/topic.
+ *
+ * Fetches unconsumed signals from Supabase, loads the voice profile, calls generateBufferText()
+ * exactly as runAccumulationCheck() would, but does NOT consume signals or save drafts.
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/replay-synthesis.ts <author-login> <owner/repo> [topic]
+ *
+ * Example:
+ *   npx tsx --env-file=.env.local scripts/replay-synthesis.ts korutx microboxlabs/ecm-coordinator complexity
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { SupabaseStorage } from '../src/voice/supabase-storage.js';
+import { AnthropicAdapter } from '../src/ai/anthropic-adapter.js';
+import { generateBufferText } from '../src/ai/synthesis-generator.js';
+import { check, checkCrossVolume } from '../src/analysis/accumulation-engine.js';
+import { selectDevelopmentalAngle, buildAngleBlock, type ArcType } from '../src/ai/developmental-editor.js';
+import { DEFAULT_VOICE_PROFILE } from '../src/config/schema.js';
+import type { SignalBankEntry, SignalEvent } from '../src/voice/storage.js';
+
+const SEP = '─'.repeat(72);
+
+async function main(): Promise<void> {
+  const [authorLogin, fullRepo, topicFilter] = process.argv.slice(2) as [string, string, string | undefined];
+
+  if (!authorLogin || !fullRepo || !fullRepo.includes('/')) {
+    console.error('Usage: npx tsx --env-file=.env.local scripts/replay-synthesis.ts <author-login> <owner/repo> [topic]');
+    process.exit(1);
+  }
+
+  const anthropicKey = process.env['ANTHROPIC_API_KEY'] ?? '';
+  const supabaseUrl = process.env['SUPABASE_URL'] ?? '';
+  const supabaseKey = process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '';
+  const tenantId = process.env['TENANT_ID'] ?? 'default';
+
+  if (!anthropicKey) { console.error('ANTHROPIC_API_KEY not set'); process.exit(1); }
+  if (!supabaseUrl || !supabaseKey) { console.error('SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY not set'); process.exit(1); }
+
+  const db = createClient(supabaseUrl, supabaseKey);
+  const storage = new SupabaseStorage(supabaseUrl, supabaseKey, tenantId);
+  const ai = new AnthropicAdapter(anthropicKey);
+  const nowIso = new Date().toISOString();
+
+  // ── Stage 1: Signal bank ────────────────────────────────────────────────
+  console.log(`\n${SEP}`);
+  console.log(`STAGE 1 — signal bank for ${authorLogin} / ${fullRepo}`);
+  console.log(SEP);
+
+  const entries = await storage.getSignalBankEntries(authorLogin, fullRepo);
+  if (entries.length === 0) {
+    console.log('No signal_bank entries — nothing to synthesize.');
+    process.exit(0);
+  }
+
+  for (const e of entries) {
+    const { shouldFire, reason, decayedWeight, thresholdEffective } = check(e, nowIso);
+    const mark = shouldFire ? '✓ FIRE' : '  skip';
+    console.log(`  ${mark}  topic=${e.topic.padEnd(22)} weight=${e.weight_sum.toFixed(1).padStart(6)} cnt=${e.signal_count.toString().padStart(3)} decayed=${decayedWeight.toFixed(2).padStart(6)} thresh=${thresholdEffective.toFixed(2).padStart(6)} reason=${reason ?? '-'}`);
+  }
+
+  const crossVolume = checkCrossVolume(entries, nowIso);
+  if (crossVolume) console.log('\n  → cross-volume threshold crossed (sum decayed > 25)');
+
+  const firedEntries = entries.filter((e: SignalBankEntry) => check(e, nowIso).shouldFire);
+  if (firedEntries.length === 0 && !crossVolume) {
+    console.log('\nNo topics at threshold. Nothing to synthesize right now.');
+    process.exit(0);
+  }
+
+  const firedTopics = firedEntries.length > 0
+    ? firedEntries.map((e: SignalBankEntry) => e.topic)
+    : entries.map((e: SignalBankEntry) => e.topic);
+
+  const topics = topicFilter ? firedTopics.filter((t) => t === topicFilter) : firedTopics;
+  if (topics.length === 0) {
+    console.log(`\nTopic '${topicFilter}' is not at threshold. Available fired topics: ${firedTopics.join(', ')}`);
+    process.exit(0);
+  }
+
+  // ── Stage 2: Unconsumed signals ─────────────────────────────────────────
+  console.log(`\n${SEP}`);
+  console.log(`STAGE 2 — unconsumed signals for topic(s): ${topics.join(', ')}`);
+  console.log(SEP);
+
+  const allSignals = [];
+  for (const topic of topics) {
+    const sigs = await storage.getUnconsumedSignals(authorLogin, fullRepo, topic);
+    console.log(`  topic=${topic}: ${sigs.length} unconsumed signals`);
+    for (const s of sigs) {
+      console.log(`    sha=${s.commit_sha.slice(0, 10)}  strength=${s.strength}  ${s.specific_change.slice(0, 80)}`);
+    }
+    allSignals.push(...sigs);
+  }
+
+  if (allSignals.length === 0) {
+    console.log('\nAll signals already consumed — nothing to synthesize.');
+    process.exit(0);
+  }
+
+  // ── Stage 3: Voice profile ───────────────────────────────────────────────
+  console.log(`\n${SEP}`);
+  console.log(`STAGE 3 — voice profile for ${authorLogin}`);
+  console.log(SEP);
+
+  let voiceProfile = DEFAULT_VOICE_PROFILE;
+  try {
+    const stored = await storage.getVoiceProfile(authorLogin);
+    if (stored) {
+      voiceProfile = stored.voice;
+      console.log(`  Found: tone=${voiceProfile.tone} rhythm=${voiceProfile.rhythm ?? 'default'} source=${stored.source}`);
+    } else {
+      console.log(`  No profile found — using DEFAULT_VOICE_PROFILE`);
+    }
+  } catch (e) {
+    console.warn(`  Voice fetch failed (${String(e)}) — using DEFAULT`);
+  }
+
+  // ── Stage 4: R3 — narrative arc (fail-open) ─────────────────────────────
+  console.log(`\n${SEP}`);
+  console.log(`STAGE 4 — R3 narrative arc`);
+  console.log(SEP);
+
+  let developmentalAngle: string | undefined;
+  try {
+    const recentArcs = (await storage.getRecentArcTypes(authorLogin, 5)) as ArcType[];
+    const synFindings = allSignals.map((s: SignalEvent) => ({
+      moduleId: s.topic,
+      aspect: s.topic.replace(/_/g, ' '),
+      finding: s.specific_change,
+      technicalDetail: s.specific_change,
+      plainLanguage: s.specific_change,
+      interestScore: s.strength * 2,
+      contextHint: s.affected_files[0] ? `${s.affected_files[0]} in ${s.repo}` : undefined,
+    }));
+    const angle = selectDevelopmentalAngle({
+      findings: synFindings,
+      commitIntent: 'planned_feature',
+      closingIssues: [],
+      changesRequestedCount: 0,
+      collaborationWeight: 0,
+      recentArcTypes: recentArcs,
+      discouragedArcTypes: (voiceProfile.content_preferences?.penalized_arc_types ?? []) as ArcType[],
+    });
+    if (angle) {
+      developmentalAngle = buildAngleBlock(angle, 0);
+      console.log(`  arc_type: ${angle.arcType}`);
+      console.log(`  tension:  ${angle.tension}`);
+    } else {
+      console.log('  No arc selected (not enough evidence)');
+    }
+  } catch (e) {
+    console.warn(`  R3 failed (${String(e)}) — skipping`);
+  }
+
+  // ── Stage 5: Build synthesis input ──────────────────────────────────────
+  const gatillador = 'focal' as const;
+  const minConfig = {
+    author: { name: authorLogin, github_login: authorLogin },
+    platforms: { linkedin: { enabled: true }, instagram: { enabled: false } },
+    pipeline: { max_daily_posts_per_author: 2 },
+    voice: voiceProfile,
+    github: { notification_repo: undefined },
+  } as never;
+
+  const input = {
+    authorLogin,
+    repo: fullRepo,
+    gatillador,
+    topics,
+    signals: allSignals,
+    voiceProfile,
+    voiceStage: 'warming' as const,
+    config: minConfig,
+    exposurePool: [],
+    bootstrapPosts: voiceProfile.bootstrap_posts ?? [],
+    draftIndexToday: 0,
+    developmentalAngle,
+  };
+
+  // ── Stage 6: Claude synthesis ────────────────────────────────────────────
+  console.log(`\n${SEP}`);
+  console.log(`STAGE 6 — Claude synthesis (dry-run, signals NOT consumed)`);
+  console.log(SEP);
+  console.log(`  gatillador: ${gatillador}  topics: ${topics.join(', ')}  signals: ${allSignals.length}`);
+
+  const result = await generateBufferText(ai, input);
+
+  // ── Stage 7: Result ──────────────────────────────────────────────────────
+  console.log(`\n${SEP}`);
+  console.log('STAGE 7 — generated synthesis post');
+  console.log(SEP);
+  console.log('\n── POST ───────────────────────────────────────────────────────────────\n');
+  console.log(result.bufferText);
+  console.log('\n── STATS ──────────────────────────────────────────────────────────────');
+  console.log(`chars:         ${result.bufferText.length}`);
+  console.log(`opening_move:  ${result.openingMove}`);
+  console.log(`repr sha:      ${result.representativeSha}`);
+  console.log(`topics:        ${topics.join(', ')}`);
+  console.log(`signals used:  ${allSignals.length}`);
+  console.log('\n⚠  DRY RUN — signals NOT consumed, draft NOT saved to DB');
+  console.log('');
+}
+
+main().catch((err) => {
+  console.error('Fatal:', String(err));
+  process.exit(1);
+});

--- a/src/ai/developmental-editor.ts
+++ b/src/ai/developmental-editor.ts
@@ -1,0 +1,221 @@
+import type { Finding } from '../analysis/types.js';
+import type { PrContext } from '../github/commit-enricher.js';
+import type { CommitIntent } from '../utils/commit-classifier.js';
+
+export type ArcType =
+  | 'quantified_improvement'
+  | 'broken_assumption'
+  | 'tradeoff_made'
+  | 'operational_consequence'
+  | 'problem_dissolved'
+  | 'design_shipped';
+
+export interface R3Context {
+  readonly findings:              Finding[];
+  readonly commitIntent:          CommitIntent;
+  readonly closingIssues:         PrContext['closingIssues'];
+  readonly changesRequestedCount: number;
+  readonly collaborationWeight:   number;
+  readonly recentArcTypes:        ArcType[];
+}
+
+export interface NarrativeScore {
+  readonly tension:     number;
+  readonly resolution:  number;
+  readonly consequence: number;
+  total():     number;
+  normalized(): number;
+}
+
+export interface DevelopmentalAngle {
+  readonly arcType:         ArcType;
+  readonly leadFinding:     Finding;
+  readonly score:           NarrativeScore;
+  readonly tension:         string;
+  readonly resolution:      string;
+  readonly consequence:     string;
+  readonly angleHint:       string;
+  readonly missingNote:     string;
+  readonly arcPatternNote:  string;
+}
+
+function scoreNarrative(f: Finding, ctx: R3Context): NarrativeScore {
+  let tension = 0, resolution = 0, consequence = 0;
+
+  if (f.evidence?.before?.trim())                                                  tension++;
+  if (/\b(was|caused|broke|assumed|failed|wrong|instead of)\b/i.test(f.technicalDetail)) tension++;
+  if (['security', 'error_resilience', 'performance'].includes(f.moduleId))        tension++;
+  if ((ctx.closingIssues ?? []).some((i) => i.totalReactions >= 5))                tension++;
+  tension = Math.min(tension, 3);
+
+  if (f.evidence?.after?.trim())                                                   resolution++;
+  if ((f.verifiableFacts?.length ?? 0) >= 2)                                       resolution++;
+  if (f.contextHint?.includes('/'))                                                resolution++;
+  resolution = Math.min(resolution, 3);
+
+  if (/\b(now|enables|prevents|no longer|users can|reduces)\b/i.test(`${f.plainLanguage} ${f.finding}`)) consequence++;
+  if (/\d+(%|ms|x\b| lines| files)/.test(`${f.verifiableFacts?.join(' ') ?? ''}${f.technicalDetail}`))   consequence++;
+  consequence = Math.min(consequence, 2);
+
+  return {
+    tension,
+    resolution,
+    consequence,
+    total:      () => tension + resolution + consequence,
+    normalized: () => (tension + resolution + consequence) / 8,
+  };
+}
+
+function selectLeadFinding(
+  findings: Finding[],
+  ctx: R3Context,
+): { finding: Finding; score: NarrativeScore } {
+  const MAX_INTEREST = 10;
+  const ranked = findings.map((f) => {
+    const ns = scoreNarrative(f, ctx);
+    const base = (f.interestScore / MAX_INTEREST) * 0.4 + ns.normalized() * 0.6;
+    const composite = base * ctx.collaborationWeight;
+    return { finding: f, score: ns, composite };
+  });
+  ranked.sort((a, b) => b.composite - a.composite);
+  return ranked[0]!;
+}
+
+function candidateArcs(f: Finding, ctx: R3Context): ArcType[] {
+  const arcs: ArcType[] = [];
+  const facts = f.verifiableFacts?.join(' ') ?? '';
+  const detail = f.technicalDetail;
+
+  if (/\d+(%|ms|x\b| lines)/.test(facts + detail))
+    arcs.push('quantified_improvement');
+
+  if (
+    f.evidence?.before?.trim() &&
+    /\b(was wrong|assumed|turned out|actually|in fact)\b/i.test(`${detail}${f.finding}`)
+  ) arcs.push('broken_assumption');
+
+  if (
+    /\b(instead of|over|rather than|vs\.?|chose)\b/i.test(detail) ||
+    ctx.changesRequestedCount > 0
+  ) arcs.push('tradeoff_made');
+
+  if (
+    ['observability', 'error_resilience', 'devops', 'security'].includes(f.moduleId) &&
+    /\b(now|no longer|prevents|enables|users)\b/i.test(`${f.plainLanguage}${f.finding}`)
+  ) arcs.push('operational_consequence');
+
+  if (
+    (ctx.closingIssues ?? []).length > 0 &&
+    (ctx.commitIntent === 'urgent_fix' || f.evidence?.before?.trim())
+  ) arcs.push('problem_dissolved');
+
+  if (
+    ['architecture_patterns', 'api_design', 'integration'].includes(f.moduleId) &&
+    !f.evidence?.before?.trim()
+  ) arcs.push('design_shipped');
+
+  return arcs;
+}
+
+const INTENT_ARC_PREFERENCE: Partial<Record<CommitIntent, ArcType[]>> = {
+  urgent_fix:      ['problem_dissolved', 'operational_consequence'],
+  planned_feature: ['design_shipped', 'quantified_improvement'],
+  tech_debt:       ['tradeoff_made', 'broken_assumption'],
+  optimization:    ['quantified_improvement', 'operational_consequence'],
+};
+
+function selectArc(
+  candidates: ArcType[],
+  commitIntent: CommitIntent,
+  recentArcTypes: ArcType[],
+): { arc: ArcType; arcPatternNote: string } {
+  if (candidates.length === 0) return { arc: 'design_shipped', arcPatternNote: '' };
+
+  const arcFreq = new Map<ArcType, number>();
+  for (const a of recentArcTypes) arcFreq.set(a, (arcFreq.get(a) ?? 0) + 1);
+  const penalized = new Set(
+    [...arcFreq.entries()].filter(([, n]) => n >= 3).map(([a]) => a),
+  );
+
+  const preferred = INTENT_ARC_PREFERENCE[commitIntent] ?? [];
+  const intentMatch = preferred.find((a) => candidates.includes(a) && !penalized.has(a));
+  if (intentMatch) return { arc: intentMatch, arcPatternNote: '' };
+
+  const unpunished = candidates.find((a) => !penalized.has(a));
+  if (unpunished) {
+    const first = candidates[0]!;
+    const note = penalized.has(first)
+      ? `Arc pattern: ${first} used in ${arcFreq.get(first)} of last 5 posts — using ${unpunished} instead.`
+      : '';
+    return { arc: unpunished, arcPatternNote: note };
+  }
+
+  return { arc: candidates[0]!, arcPatternNote: 'All candidate arcs used recently — repeating best fit.' };
+}
+
+export function selectDevelopmentalAngle(ctx: R3Context): DevelopmentalAngle | null {
+  if (ctx.findings.length === 0) return null;
+
+  const { finding: lead, score } = selectLeadFinding(ctx.findings, ctx);
+  const candidates = candidateArcs(lead, ctx);
+  const { arc, arcPatternNote } = selectArc(candidates, ctx.commitIntent, ctx.recentArcTypes);
+
+  const tension = lead.evidence?.before?.trim()
+    ? lead.evidence.before.trim().slice(0, 150)
+    : lead.finding;
+
+  const resolution = lead.evidence?.after?.trim()
+    ? lead.evidence.after.trim().slice(0, 150)
+    : lead.technicalDetail.slice(0, 150);
+
+  const verifiableStr = (lead.verifiableFacts?.join(' | ') ?? '').slice(0, 120);
+  const consequence = verifiableStr || lead.plainLanguage.slice(0, 150);
+
+  const missing: string[] = [];
+  if (arc === 'quantified_improvement' && !verifiableStr)
+    missing.push('No verified numbers in the diff — do not invent percentages or timings.');
+  if (arc === 'problem_dissolved' && (ctx.closingIssues ?? []).length === 0)
+    missing.push('No closing issue available — do not invent a user-reported problem.');
+  if (!lead.evidence?.before?.trim())
+    missing.push('Before state not in diff — do not describe what the old code looked like.');
+
+  const arcLabel = arc === 'operational_consequence' ? 'consequence'
+    : arc === 'problem_dissolved' ? 'problem'
+    : 'decision';
+
+  return {
+    arcType:        arc,
+    leadFinding:    lead,
+    score,
+    tension,
+    resolution,
+    consequence,
+    angleHint:      `Lead with the ${arcLabel}, not the mechanism.`,
+    missingNote:    missing.join(' '),
+    arcPatternNote,
+  };
+}
+
+export function buildAngleBlock(angle: DevelopmentalAngle): string {
+  const { arcType, score, tension, resolution, consequence, angleHint, missingNote, arcPatternNote } = angle;
+  const totalScore = score.total();
+  const completeness = totalScore >= 6 ? 'high' : totalScore >= 3 ? 'medium' : 'low';
+
+  const lines: string[] = [
+    `Arc: ${arcType}`,
+    `Completeness: ${completeness} (tension: ${score.tension}/3, resolution: ${score.resolution}/3, consequence: ${score.consequence}/2)`,
+    '',
+  ];
+
+  if (completeness !== 'low') {
+    lines.push(`Tension: ${tension}`);
+    lines.push(`Resolution: ${resolution}`);
+    lines.push(`Consequence: ${consequence}`);
+    lines.push('');
+    lines.push(`Angle: ${angleHint}`);
+  }
+  if (missingNote)    lines.push(`Missing: ${missingNote}`);
+  if (arcPatternNote) lines.push(`Arc pattern: ${arcPatternNote}`);
+
+  return `<developmental_angle>\n${lines.join('\n')}\n</developmental_angle>`;
+}

--- a/src/ai/developmental-editor.ts
+++ b/src/ai/developmental-editor.ts
@@ -17,6 +17,7 @@ export interface R3Context {
   readonly changesRequestedCount: number;
   readonly collaborationWeight:   number;
   readonly recentArcTypes:        ArcType[];
+  readonly discouragedArcTypes:   ArcType[];
 }
 
 export interface NarrativeScore {
@@ -128,14 +129,16 @@ function selectArc(
   candidates: ArcType[],
   commitIntent: CommitIntent,
   recentArcTypes: ArcType[],
+  discouragedArcTypes: ArcType[] = [],
 ): { arc: ArcType; arcPatternNote: string } {
   if (candidates.length === 0) return { arc: 'design_shipped', arcPatternNote: '' };
 
   const arcFreq = new Map<ArcType, number>();
   for (const a of recentArcTypes) arcFreq.set(a, (arcFreq.get(a) ?? 0) + 1);
-  const penalized = new Set(
-    [...arcFreq.entries()].filter(([, n]) => n >= 3).map(([a]) => a),
-  );
+  const penalized = new Set([
+    ...([...arcFreq.entries()].filter(([, n]) => n >= 3).map(([a]) => a)),
+    ...discouragedArcTypes,
+  ]);
 
   const preferred = INTENT_ARC_PREFERENCE[commitIntent] ?? [];
   const intentMatch = preferred.find((a) => candidates.includes(a) && !penalized.has(a));
@@ -158,7 +161,7 @@ export function selectDevelopmentalAngle(ctx: R3Context): DevelopmentalAngle | n
 
   const { finding: lead, score } = selectLeadFinding(ctx.findings, ctx);
   const candidates = candidateArcs(lead, ctx);
-  const { arc, arcPatternNote } = selectArc(candidates, ctx.commitIntent, ctx.recentArcTypes);
+  const { arc, arcPatternNote } = selectArc(candidates, ctx.commitIntent, ctx.recentArcTypes, ctx.discouragedArcTypes);
 
   const tension = lead.evidence?.before?.trim()
     ? lead.evidence.before.trim().slice(0, 150)

--- a/src/ai/developmental-editor.ts
+++ b/src/ai/developmental-editor.ts
@@ -196,7 +196,7 @@ export function selectDevelopmentalAngle(ctx: R3Context): DevelopmentalAngle | n
   };
 }
 
-export function buildAngleBlock(angle: DevelopmentalAngle): string {
+export function buildAngleBlock(angle: DevelopmentalAngle, collaborationWeight = 1.0): string {
   const { arcType, score, tension, resolution, consequence, angleHint, missingNote, arcPatternNote } = angle;
   const totalScore = score.total();
   const completeness = totalScore >= 6 ? 'high' : totalScore >= 3 ? 'medium' : 'low';
@@ -216,6 +216,15 @@ export function buildAngleBlock(angle: DevelopmentalAngle): string {
   }
   if (missingNote)    lines.push(`Missing: ${missingNote}`);
   if (arcPatternNote) lines.push(`Arc pattern: ${arcPatternNote}`);
+
+  if (collaborationWeight >= 1.4) {
+    lines.push('Collaboration signal: high (PR merged into upstream by maintainer)');
+    lines.push('→ The review process itself is part of the story — the author shipped work that required significant iteration.');
+    lines.push('→ Prefer arcs that show reasoning process (tradeoff_made, broken_assumption) over result-only arcs.');
+  } else if (collaborationWeight >= 1.15) {
+    lines.push(`Collaboration signal: medium (active PR discussion)`);
+    lines.push('→ This work went through review iteration — the decision process adds narrative value.');
+  }
 
   return `<developmental_angle>\n${lines.join('\n')}\n</developmental_angle>`;
 }

--- a/src/ai/post-generator.ts
+++ b/src/ai/post-generator.ts
@@ -9,6 +9,7 @@ import { detectOpeningMove } from '../voice/exposure.js';
 
 export interface GeneratedPosts {
   linkedinPost: string;   // clean LinkedIn text for direct posting
+  instagramPost: string;  // Instagram caption (empty string if Instagram disabled)
   shortPost: string;      // short variant for Twitter/X
   bufferText: string;     // combined text for Buffer Idea
   draftId: string;
@@ -23,6 +24,7 @@ export interface GeneratePostsOptions {
   recentModuleIds?: string[];
   chapterContext?: string;
   industryContext?: string;
+  developmentalAngle?: string;
   draftMetadata?: Partial<SaveDraftInput>;
   draftIndexToday?: number;
   varietyConstraint?: string;
@@ -55,6 +57,8 @@ export async function generatePosts(
     varietyConstraint: options.varietyConstraint,
   };
 
+  const instagramEnabled = config.platforms.instagram.enabled;
+
   const systemPrompt = buildSystemPrompt(config, options.voiceProfile, voiceContext);
   const userPrompt = buildUserPrompt(
     commit,
@@ -62,6 +66,8 @@ export async function generatePosts(
     options.recentModuleIds ?? [],
     options.chapterContext,
     options.industryContext,
+    options.developmentalAngle,
+    instagramEnabled,
   );
 
   logger.info('ai.generate.start', {
@@ -88,6 +94,7 @@ export async function generatePosts(
   }
 
   const post = enforceMainPostLength(parsed.post, maxChars);
+  const instagramPost = parsed.instagramPost ? enforceInstagramHook(parsed.instagramPost) : '';
   const shortPost = parsed.shortPost;
 
   const topFinding = findings[0]?.finding;
@@ -110,27 +117,60 @@ export async function generatePosts(
     opening_move: draftMetadata.opening_move ?? openingMove,
   });
 
-  // Buffer Idea text includes both variants so Liliana can copy per platform in the UI
-  const bufferText = `${post}\n\n─────────────────\n🐦 Twitter:\n${shortPost}`;
+  if (instagramEnabled && instagramPost) {
+    await storage.saveDraft({
+      commit_sha: commit.sha,
+      repo: commit.repo,
+      platform: 'instagram',
+      ai_draft: instagramPost,
+      top_finding: topFinding,
+      top_module_id: topModuleId,
+      findings_count: findingsCount,
+      ...draftMetadata,
+      generation_system: draftMetadata.generation_system ?? (options.voiceStage === 'cold' ? 'v1' : 'v2_progressive'),
+      opening_move: detectOpeningMove(instagramPost),
+    });
+  }
 
-  logger.info('ai.generate.done', { sha: commit.sha, draftId });
+  // Buffer Idea text includes all generated variants for manual platform selection in the UI
+  const bufferText = instagramEnabled && instagramPost
+    ? `${post}\n\n─────────────────\n📸 Instagram:\n${instagramPost}\n\n─────────────────\n🐦 Twitter:\n${shortPost}`
+    : `${post}\n\n─────────────────\n🐦 Twitter:\n${shortPost}`;
 
-  return { linkedinPost: post, shortPost, bufferText, draftId, openingMove };
+  logger.info('ai.generate.done', { sha: commit.sha, draftId, instagramEnabled });
+
+  return { linkedinPost: post, instagramPost, shortPost, bufferText, draftId, openingMove };
 }
 
-function parseResponse(raw: string): { post: string; shortPost: string } {
-  const postMatch = raw.match(/<post_draft>([\s\S]*?)<\/post_draft>/);
-  const shortMatch = raw.match(/<short_draft>([\s\S]*?)<\/short_draft>/);
+function parseResponse(raw: string): { post: string; instagramPost: string; shortPost: string } {
+  // Accept new linkedin_draft tag with fallback to legacy post_draft during transition
+  const linkedinMatch = raw.match(/<linkedin_draft>([\s\S]*?)<\/linkedin_draft>/)
+    ?? raw.match(/<post_draft>([\s\S]*?)<\/post_draft>/);
 
-  if (!postMatch || !shortMatch) {
+  const instagramMatch = raw.match(/<instagram_draft>([\s\S]*?)<\/instagram_draft>/);
+
+  // Accept new twitter_draft tag with fallback to legacy short_draft during transition
+  const twitterMatch = raw.match(/<twitter_draft>([\s\S]*?)<\/twitter_draft>/)
+    ?? raw.match(/<short_draft>([\s\S]*?)<\/short_draft>/);
+
+  if (!linkedinMatch || !twitterMatch) {
     logger.error('ai.parse.missing_tags', { preview: raw.slice(0, 200) });
     throw new Error('Claude response missing XML tags — draft discarded to avoid broken posts');
   }
 
   return {
-    post: (postMatch[1] ?? '').trim(),
-    shortPost: (shortMatch[1] ?? '').trim(),
+    post: (linkedinMatch[1] ?? '').trim(),
+    instagramPost: (instagramMatch?.[1] ?? '').trim(),
+    shortPost: (twitterMatch[1] ?? '').trim(),
   };
+}
+
+function enforceInstagramHook(text: string, maxHookChars = 125): string {
+  const lines = text.split('\n');
+  const firstLine = lines[0] ?? '';
+  if (firstLine.length <= maxHookChars) return text;
+  const trimmed = firstLine.slice(0, maxHookChars).replace(/\s\S*$/, '');
+  return [trimmed, ...lines.slice(1)].join('\n');
 }
 
 function enforceMainPostLength(post: string, maxChars: number): string {

--- a/src/ai/prompt-builder.ts
+++ b/src/ai/prompt-builder.ts
@@ -658,10 +658,14 @@ function buildContributorVoiceBlock(prContext: PrContext, isPrivateRepo: boolean
       const bodyLine = issue.bodySnippet ? `Problem description: ${issue.bodySnippet}` : '';
       return bodyLine ? `${titleLine}\n${bodyLine}` : titleLine;
     });
+    const hasOpenIssue = closingIssues.some((i) => i.state === 'OPEN');
+    const openNote = hasOpenIssue
+      ? '\nNote: this issue is still open — the commit partially addresses it. Do not present it as fully resolved tension.'
+      : '';
     const privacyNote = isPrivateRepo
       ? '\nDescribe the engineering challenge and solution at the engineering blog level. Omit internal service names, endpoint paths, customer-specific details, and proprietary business logic. Focus on the pattern: what was the problem class, what was the decision, what was the consequence.'
       : '';
-    return `Issue context (what this commit resolves):\n${lines.join('\n\n')}\n\nUse this as the tension source for the narrative. Do not invent additional problems beyond what is described here.${privacyNote}\n`;
+    return `Issue context (what this commit resolves):\n${lines.join('\n\n')}\n\nUse this as the tension source for the narrative. Do not invent additional problems beyond what is described here.${openNote}${privacyNote}\n`;
   })();
 
   const reviewBlock = (() => {
@@ -671,7 +675,10 @@ function buildContributorVoiceBlock(prContext: PrContext, isPrivateRepo: boolean
       ? `Review context (${count} change request${count !== 1 ? 's' : ''} before merge):`
       : 'Review context:';
     const lines = reviewSummaries.map((r) => `- ${r.state}: "${r.body}"`);
-    return `${header}\n${lines.join('\n')}\n\nThe iteration process is part of the story — the author refined the design under reviewer feedback.\n`;
+    const arcSignal = count > 0
+      ? ' This is a signal of tradeoff_made or broken_assumption arc.'
+      : '';
+    return `${header}\n${lines.join('\n')}\n\nThe iteration process is part of the story — the author refined the design under reviewer feedback.${arcSignal}\n`;
   })();
 
   return `<contributor_voice>

--- a/src/ai/prompt-builder.ts
+++ b/src/ai/prompt-builder.ts
@@ -275,7 +275,7 @@ export function buildUserPrompt(
   }
   parts.push('Use concrete implementation details. Do not invent files, numbers, or project context.');
   parts.push('If a finding touches AI, translate that into the human-made constraint, interface, or behavior change. Do not give the model authorship credit for the commit.');
-  parts.push('If <industry_context> is used, treat it as parallel validation from the industry, never as a citation or proof of the argument.');
+  parts.push('If <industry_context> is present, use it as the editorial frame — it names the unresolved tension the field is navigating that makes this commit worth writing about. The code is the evidence; the industry context is why the evidence matters. Never cite it as a source or proof.');
   parts.push('The main post must stay at or under the configured character cap.');
   parts.push('Keep the main post under the configured hard cap. If needed, prefer fewer points and cleaner sentences over extra explanation.');
   parts.push('If <voice_exposure> exists, match its level of directness and structure without copying phrases literally.');
@@ -308,18 +308,17 @@ export function buildUserPrompt(
 export function buildIndustryContextBlock(input: IndustryContextPromptInput): string {
   const sourceFamily = inferIndustrySourceFamily(input.articleUrl);
   const lines = [
-    'This is parallel industry signal, not source attribution.',
-    'The author is speaking from their own code and judgment. Do not imply they read the matched article.',
-    'Only use this if it reinforces a point already present in the commit and findings.',
-    'Keep it subordinate to the main argument. If removed, the post should still work.',
+    'This is the industry tension that makes the author\'s specific decision editorially significant.',
+    'The author is speaking from their own code and judgment — do not imply they read the matched article.',
     `Shared pattern: ${input.connection}`,
-    'Use this pattern to position the author\'s specific decision within the broader industry movement.',
-    'Be specific: name the pattern, say who else is navigating it (teams, companies, the field in general), and surface what is distinct or notable about how the author approached it.',
-    'The goal is not to say "others do this too" — it is to show why this particular implementation choice is interesting given what the industry is wrestling with.',
-    'Ask implicitly: who is dealing with this? are they solving it the same way? what is different here and why does that matter?',
+    'Use this as the frame, not the footnote: name the unresolved tension the field is navigating, then show how the author\'s decision is a concrete answer to it.',
+    'The technical detail in the commit is the evidence. The industry context is what explains why that evidence matters beyond this one codebase.',
+    'A reader who does not know this author should finish the post understanding both what was built and why the broader engineering community is still working through this class of problem.',
+    'Be specific: name the pattern and the tension it carries. Say what teams or the field in general are still trading off. Surface what is distinct or notable about how this author approached it.',
+    'Do not use the industry context to validate the author. Use it to show that the author is working on something that has no fully settled answer yet.',
     'Never mention the article title.',
     'Never write "according to", "as this article explains", "after reading", or "inspired by".',
-    'Never use filler phrases like "more and more teams are doing this" without specifying the pattern and the tension it resolves.',
+    'Never use filler phrases like "more and more teams are doing this" without naming the specific tradeoff that makes the pattern hard.',
   ];
 
   if (sourceFamily) {

--- a/src/ai/prompt-builder.ts
+++ b/src/ai/prompt-builder.ts
@@ -164,6 +164,8 @@ export function buildUserPrompt(
   recentModuleIds: string[] = [],
   chapterContext?: string,
   industryContext?: string,
+  developmentalAngle?: string,
+  instagramEnabled = false,
 ): string {
   const parts: string[] = [];
 
@@ -273,13 +275,26 @@ export function buildUserPrompt(
   parts.push('Keep the main post under the configured hard cap. If needed, prefer fewer points and cleaner sentences over extra explanation.');
   parts.push('If <voice_exposure> exists, match its level of directness and structure without copying phrases literally.');
   parts.push('');
-  parts.push('<post_draft>');
-  parts.push('Main post here.');
-  parts.push('</post_draft>');
+  parts.push('Write the following variants:');
+  parts.push('- LinkedIn: full narrative post within the configured character cap.');
+  if (instagramEnabled) {
+    parts.push('- Instagram: first line ≤125 chars, must work as a standalone hook before "see more". Optional: 1-2 short supporting lines. Hashtags on last line only.');
+  }
+  parts.push('- Twitter: maximum density. One claim + mechanism. No filler.');
   parts.push('');
-  parts.push('<short_draft>');
-  parts.push('Short variant here.');
-  parts.push('</short_draft>');
+  parts.push('<linkedin_draft>');
+  parts.push('LinkedIn post here.');
+  parts.push('</linkedin_draft>');
+  parts.push('');
+  if (instagramEnabled) {
+    parts.push('<instagram_draft>');
+    parts.push('Instagram caption here.');
+    parts.push('</instagram_draft>');
+    parts.push('');
+  }
+  parts.push('<twitter_draft>');
+  parts.push('Twitter post here.');
+  parts.push('</twitter_draft>');
   parts.push('</task>');
 
   return parts.join('\n');

--- a/src/ai/prompt-builder.ts
+++ b/src/ai/prompt-builder.ts
@@ -245,6 +245,11 @@ export function buildUserPrompt(
     parts.push(buildContributorVoiceBlock(commit.prContext, commit.isPrivateRepo));
   }
 
+  if (developmentalAngle) {
+    parts.push('');
+    parts.push(developmentalAngle);
+  }
+
   const hasVerifiableFacts = findings.some((f) => f.verifiableFacts && f.verifiableFacts.length > 0);
 
   parts.push('');

--- a/src/ai/prompt-builder.ts
+++ b/src/ai/prompt-builder.ts
@@ -240,7 +240,7 @@ export function buildUserPrompt(
 
   if (commit.prContext) {
     parts.push('');
-    parts.push(buildContributorVoiceBlock(commit.prContext));
+    parts.push(buildContributorVoiceBlock(commit.prContext, commit.isPrivateRepo));
   }
 
   const hasVerifiableFacts = findings.some((f) => f.verifiableFacts && f.verifiableFacts.length > 0);
@@ -250,6 +250,11 @@ export function buildUserPrompt(
   if (hasVerifiableFacts) {
     parts.push('Where a finding includes a <facts> block: you may state, rephrase, condense, or omit any listed fact. You may add ONE interpretive sentence connecting the facts to a broader engineering principle.');
     parts.push('You MAY NOT: state structural facts not in the list; compare to a prior state unless the commit body explicitly states the prior behavior; make absence claims about code you cannot see; describe internal logic of files whose contents are not in the facts list.');
+    parts.push('');
+  } else {
+    parts.push('None of the findings include a verified-facts list.');
+    parts.push('Do not state specific percentages, timing measurements, or line counts — they cannot be verified from the information provided.');
+    parts.push('You may describe the structural change (e.g., "removed nested branching") but not quantify it (e.g., "removed 40% of branches").');
     parts.push('');
   }
   parts.push('Write one main post and one short variant.');
@@ -596,8 +601,8 @@ function inferIndustrySourceFamily(articleUrl?: string | null): string | null {
   return null;
 }
 
-function buildContributorVoiceBlock(prContext: PrContext): string {
-  const { outcome, upstreamOwner, upstreamRepo, prNumber, prTitle, supersededEvidence } = prContext;
+function buildContributorVoiceBlock(prContext: PrContext, isPrivateRepo: boolean): string {
+  const { outcome, upstreamOwner, upstreamRepo, prNumber, prTitle, supersededEvidence, prDescription } = prContext;
 
   // Gate: medium confidence is not strong enough to assert incorporation in the post.
   const effectiveOutcome =
@@ -619,10 +624,18 @@ function buildContributorVoiceBlock(prContext: PrContext): string {
       ? `Maintainer reference: "${supersededEvidence.maintainerComment}"\n`
       : '';
 
+  const descriptionBlock = prDescription
+    ? `PR description (author's own words — use as context, do not quote directly):\n${prDescription}\n`
+    : '';
+
+  const privateNote = isPrivateRepo && prDescription
+    ? 'The PR description comes from a private repository. Apply the same abstraction rules as for the rest of the code: do not surface internal service names, business identifiers, or customer-specific terminology in the post.\n'
+    : '';
+
   return `<contributor_voice>
 This commit is from a fork. PR context: ${outcomeText}.
 PR title: "${prTitle}".
-${maintainerLine}
+${descriptionBlock}${privateNote}${maintainerLine}
 Rules:
 - Cite the project as ${upstreamOwner}/${upstreamRepo} (the upstream), not the fork.
 - If outcome is open: describe the work as submitted and under review, not as accepted. Do not predict reviewer reactions. Acceptable: "I proposed X to ${upstreamOwner}/${upstreamRepo}." Not acceptable: "I added X to ${upstreamOwner}/${upstreamRepo}."

--- a/src/ai/prompt-builder.ts
+++ b/src/ai/prompt-builder.ts
@@ -602,7 +602,10 @@ function inferIndustrySourceFamily(articleUrl?: string | null): string | null {
 }
 
 function buildContributorVoiceBlock(prContext: PrContext, isPrivateRepo: boolean): string {
-  const { outcome, upstreamOwner, upstreamRepo, prNumber, prTitle, supersededEvidence, prDescription } = prContext;
+  const {
+    outcome, upstreamOwner, upstreamRepo, prNumber, prTitle, supersededEvidence,
+    prDescription, closingIssues, reviewSummaries, changesRequestedCount,
+  } = prContext;
 
   // Gate: medium confidence is not strong enough to assert incorporation in the post.
   const effectiveOutcome =
@@ -629,13 +632,37 @@ function buildContributorVoiceBlock(prContext: PrContext, isPrivateRepo: boolean
     : '';
 
   const privateNote = isPrivateRepo && prDescription
-    ? 'The PR description comes from a private repository. Apply the same abstraction rules as for the rest of the code: do not surface internal service names, business identifiers, or customer-specific terminology in the post.\n'
+    ? 'This PR description comes from a private repository. Describe the engineering challenge and solution at the level of an engineering blog post (Uber Engineering, Slack Engineering). Safe to include: the technical pattern, the problem class, the design decision, the operational consequence. Do not include: internal service names, endpoint paths, customer-specific terminology, proprietary business logic, or specific numbers that reveal competitive position.\n'
     : '';
+
+  const issueBlock = (() => {
+    if (!closingIssues || closingIssues.length === 0) return '';
+    const lines = closingIssues.map((issue) => {
+      const statsStr = `${issue.totalReactions} reactions, ${issue.totalComments} comments`;
+      const titleLine = `Closes #${issue.number} — "${issue.title}" (${statsStr})`;
+      const bodyLine = issue.bodySnippet ? `Problem description: ${issue.bodySnippet}` : '';
+      return bodyLine ? `${titleLine}\n${bodyLine}` : titleLine;
+    });
+    const privacyNote = isPrivateRepo
+      ? '\nDescribe the engineering challenge and solution at the engineering blog level. Omit internal service names, endpoint paths, customer-specific details, and proprietary business logic. Focus on the pattern: what was the problem class, what was the decision, what was the consequence.'
+      : '';
+    return `Issue context (what this commit resolves):\n${lines.join('\n\n')}\n\nUse this as the tension source for the narrative. Do not invent additional problems beyond what is described here.${privacyNote}\n`;
+  })();
+
+  const reviewBlock = (() => {
+    if (!reviewSummaries || reviewSummaries.length === 0) return '';
+    const count = changesRequestedCount ?? 0;
+    const header = count > 0
+      ? `Review context (${count} change request${count !== 1 ? 's' : ''} before merge):`
+      : 'Review context:';
+    const lines = reviewSummaries.map((r) => `- ${r.state}: "${r.body}"`);
+    return `${header}\n${lines.join('\n')}\n\nThe iteration process is part of the story — the author refined the design under reviewer feedback.\n`;
+  })();
 
   return `<contributor_voice>
 This commit is from a fork. PR context: ${outcomeText}.
 PR title: "${prTitle}".
-${descriptionBlock}${privateNote}${maintainerLine}
+${descriptionBlock}${privateNote}${issueBlock}${reviewBlock}${maintainerLine}
 Rules:
 - Cite the project as ${upstreamOwner}/${upstreamRepo} (the upstream), not the fork.
 - If outcome is open: describe the work as submitted and under review, not as accepted. Do not predict reviewer reactions. Acceptable: "I proposed X to ${upstreamOwner}/${upstreamRepo}." Not acceptable: "I added X to ${upstreamOwner}/${upstreamRepo}."

--- a/src/ai/synthesis-generator.ts
+++ b/src/ai/synthesis-generator.ts
@@ -21,6 +21,7 @@ export interface SynthesisGeneratorInput {
   readonly signals: SignalEvent[];          // all unconsumed signals for the topic(s)
   readonly coherenceScore?: CoherenceScore; // only for arco
   readonly lastPostSummary?: string;
+  readonly developmentalAngle?: string;     // R3 arc guidance block
   readonly voiceProfile: VoiceProfile;
   readonly voiceStage: VoiceStage;
   readonly config: Config;
@@ -43,9 +44,12 @@ export interface BufferTextResult {
   readonly bufferText: string;
   readonly openingMove: string;
   readonly representativeSha: string;
+  readonly instagramText?: string;
 }
 
-const XML_BUFFER_TEXT_RE = /<buffer_text>([\s\S]*?)<\/buffer_text>/;
+// Accept linkedin_draft (current tag after R6) with fallback to legacy buffer_text
+const XML_BUFFER_TEXT_RE = /<linkedin_draft>([\s\S]*?)<\/linkedin_draft>|<buffer_text>([\s\S]*?)<\/buffer_text>/;
+const XML_INSTAGRAM_RE = /<instagram_draft>([\s\S]*?)<\/instagram_draft>/;
 const XML_OPENING_MOVE_RE = /<opening_move>([\s\S]*?)<\/opening_move>/;
 
 /**
@@ -81,11 +85,13 @@ export async function generateBufferText(
 
   const bufferTextMatch = XML_BUFFER_TEXT_RE.exec(raw);
   if (!bufferTextMatch) {
-    throw new Error(`synthesis-generator: missing <buffer_text> in response for ${input.gatillador}/${input.topics.join(',')}`);
+    throw new Error(`synthesis-generator: missing <linkedin_draft>/<buffer_text> in response for ${input.gatillador}/${input.topics.join(',')}`);
   }
 
+  const extractText = (m: RegExpExecArray): string => (m[1] ?? m[2] ?? '').trim();
+
   const maxChars = input.voiceProfile.post_length.max;
-  let bufferText = bufferTextMatch[1]?.trim() ?? '';
+  let bufferText = extractText(bufferTextMatch);
 
   if (bufferText.length > maxChars * 1.05) {
     logger.warn('synthesis-generator.length_exceeded_retry', {
@@ -96,19 +102,22 @@ export async function generateBufferText(
     const reinforced = `${userPrompt}\n\nREINFORCED: hard cap is ${maxChars} characters. Do not exceed it.`;
     const retryRaw = await client.complete(systemPrompt, reinforced);
     const retryMatch = XML_BUFFER_TEXT_RE.exec(retryRaw);
-    if (retryMatch) bufferText = retryMatch[1]?.trim() ?? bufferText;
+    if (retryMatch) bufferText = extractText(retryMatch);
   }
 
   if (bufferText.length < input.voiceProfile.post_length.min) {
     throw new Error(
-      `synthesis-generator: <buffer_text> too short (${bufferText.length} < ${input.voiceProfile.post_length.min}) for ${input.gatillador}/${input.topics.join(',')}`,
+      `synthesis-generator: post too short (${bufferText.length} < ${input.voiceProfile.post_length.min}) for ${input.gatillador}/${input.topics.join(',')}`,
     );
   }
 
   const openingMoveMatch = XML_OPENING_MOVE_RE.exec(raw);
   const openingMove = openingMoveMatch?.[1]?.trim() ?? 'unknown';
 
-  return { bufferText, openingMove, representativeSha };
+  const instagramMatch = XML_INSTAGRAM_RE.exec(raw);
+  const instagramText = instagramMatch?.[1]?.trim();
+
+  return { bufferText, openingMove, representativeSha, instagramText };
 }
 
 /**
@@ -121,6 +130,7 @@ export async function persistSynthesisPost(
   result: BufferTextResult,
 ): Promise<SynthesisResult> {
   const topTopic = input.topics[0] ?? null;
+  const generationSystem = input.voiceStage === 'cold' ? 'v1' : 'v2_progressive';
   const draftId = await storage.saveDraft({
     commit_sha: result.representativeSha,
     repo: input.repo,
@@ -129,9 +139,23 @@ export async function persistSynthesisPost(
     top_module_id: topTopic ?? undefined,
     findings_count: input.signals.length,
     author_login: input.authorLogin,
-    generation_system: input.voiceStage === 'cold' ? 'v1' : 'v2_progressive',
+    generation_system: generationSystem,
     opening_move: result.openingMove,
   });
+
+  if (input.config.platforms.instagram.enabled && result.instagramText) {
+    await storage.saveDraft({
+      commit_sha: result.representativeSha,
+      repo: input.repo,
+      platform: 'instagram',
+      ai_draft: result.instagramText,
+      top_module_id: topTopic ?? undefined,
+      findings_count: input.signals.length,
+      author_login: input.authorLogin,
+      generation_system: generationSystem,
+      opening_move: detectOpeningMove(result.instagramText),
+    });
+  }
 
   const detectedMove = detectOpeningMove(result.bufferText);
 
@@ -141,6 +165,7 @@ export async function persistSynthesisPost(
     topics: input.topics,
     signalCount: input.signals.length,
     openingMove: detectedMove,
+    instagramSaved: input.config.platforms.instagram.enabled && !!result.instagramText,
   });
 
   return { draftId, bufferText: result.bufferText, openingMove: detectedMove };

--- a/src/ai/synthesis-generator.ts
+++ b/src/ai/synthesis-generator.ts
@@ -22,7 +22,8 @@ export interface SynthesisGeneratorInput {
   readonly coherenceScore?: CoherenceScore; // only for arco
   readonly lastPostSummary?: string;
   readonly developmentalAngle?: string;     // R3 arc guidance block
-  readonly industryContext?: string;        // R4 editorial tension frame from article match
+  readonly industryContext?: string;        // editorial tension frame from article match
+  readonly featuredSignal?: string;         // specific_change text that triggered the article match
   readonly voiceProfile: VoiceProfile;
   readonly voiceStage: VoiceStage;
   readonly config: Config;
@@ -79,6 +80,7 @@ export async function generateBufferText(
     draftIndexToday: input.draftIndexToday,
     commitSha: representativeSha,
     industryContext: input.industryContext,
+    featuredSignal: input.featuredSignal,
   };
 
   const systemPrompt = buildSynthesisSystemPrompt(promptInput);

--- a/src/ai/synthesis-generator.ts
+++ b/src/ai/synthesis-generator.ts
@@ -22,6 +22,7 @@ export interface SynthesisGeneratorInput {
   readonly coherenceScore?: CoherenceScore; // only for arco
   readonly lastPostSummary?: string;
   readonly developmentalAngle?: string;     // R3 arc guidance block
+  readonly industryContext?: string;        // R4 editorial tension frame from article match
   readonly voiceProfile: VoiceProfile;
   readonly voiceStage: VoiceStage;
   readonly config: Config;
@@ -77,6 +78,7 @@ export async function generateBufferText(
     bootstrapPosts: input.bootstrapPosts,
     draftIndexToday: input.draftIndexToday,
     commitSha: representativeSha,
+    industryContext: input.industryContext,
   };
 
   const systemPrompt = buildSynthesisSystemPrompt(promptInput);

--- a/src/ai/synthesis-prompt-builder.ts
+++ b/src/ai/synthesis-prompt-builder.ts
@@ -110,8 +110,7 @@ export function buildSynthesisUserPrompt(input: SynthesisPromptInput): string {
   }
 
   parts.push('');
-  parts.push('Among all signals, identify the single decision or change that carries the strongest complete story (clearest tension + resolution). Write the post around that one decision only.');
-  parts.push('The other signals are context for you to understand the work — do not mention them in the post.');
+  parts.push('Among all signals, identify the single decision or change that carries the strongest complete story (clearest tension + resolution). Write the post exclusively about that one decision. Do not reference other signals, other work, or the time span.');
 
   const instagramEnabled = input.config.platforms.instagram.enabled;
 

--- a/src/ai/synthesis-prompt-builder.ts
+++ b/src/ai/synthesis-prompt-builder.ts
@@ -19,6 +19,7 @@ export interface SynthesisPromptInput {
   readonly coherenceScore?: CoherenceScore;       // only for arco
   readonly lastPostSummary?: string;
   readonly developmentalAngle?: string;           // R3 arc guidance block
+  readonly industryContext?: string;              // editorial tension frame from article match
   readonly voiceProfile: VoiceProfile;
   readonly voiceStage: VoiceStage;
   readonly config: Config;
@@ -64,6 +65,14 @@ export function buildSynthesisUserPrompt(input: SynthesisPromptInput): string {
     parts.push(`  <span_days>${computeSpanDays(input.commitGroups)}</span_days>`);
     parts.push(`  <topics>${input.topics.join(', ')}</topics>`);
     parts.push('</coherence_evidence>');
+  }
+
+  // Industry context (editorial tension frame)
+  if (input.industryContext) {
+    parts.push('');
+    parts.push('<industry_context>');
+    parts.push(input.industryContext);
+    parts.push('</industry_context>');
   }
 
   // Synthesis task

--- a/src/ai/synthesis-prompt-builder.ts
+++ b/src/ai/synthesis-prompt-builder.ts
@@ -20,6 +20,7 @@ export interface SynthesisPromptInput {
   readonly lastPostSummary?: string;
   readonly developmentalAngle?: string;           // R3 arc guidance block
   readonly industryContext?: string;              // editorial tension frame from article match
+  readonly featuredSignal?: string;              // specific_change that triggered the article match
   readonly voiceProfile: VoiceProfile;
   readonly voiceStage: VoiceStage;
   readonly config: Config;
@@ -110,7 +111,11 @@ export function buildSynthesisUserPrompt(input: SynthesisPromptInput): string {
   }
 
   parts.push('');
-  parts.push('Among all signals, identify the single decision or change that carries the strongest complete story (clearest tension + resolution). Write the post exclusively about that one decision. Do not reference other signals, other work, or the time span.');
+  if (input.featuredSignal) {
+    parts.push(`Write the post about this specific decision: "${input.featuredSignal}". It connects to the industry context above and carries the strongest editorial story. Do not reference other signals, other work, or the time span.`);
+  } else {
+    parts.push('Among all signals, identify the single decision or change that carries the strongest complete story (clearest tension + resolution). Write the post exclusively about that one decision. Do not reference other signals, other work, or the time span.');
+  }
 
   const instagramEnabled = input.config.platforms.instagram.enabled;
 

--- a/src/ai/synthesis-prompt-builder.ts
+++ b/src/ai/synthesis-prompt-builder.ts
@@ -109,6 +109,10 @@ export function buildSynthesisUserPrompt(input: SynthesisPromptInput): string {
     parts.push(input.developmentalAngle);
   }
 
+  parts.push('');
+  parts.push('Among all signals, identify the single decision or change that carries the strongest complete story (clearest tension + resolution). Write the post around that one decision.');
+  parts.push('Other signals may appear only as brief background context if they directly reinforce the same story. Do not list them as parallel items or give them equal narrative weight.');
+
   const instagramEnabled = input.config.platforms.instagram.enabled;
 
   parts.push('');

--- a/src/ai/synthesis-prompt-builder.ts
+++ b/src/ai/synthesis-prompt-builder.ts
@@ -110,8 +110,8 @@ export function buildSynthesisUserPrompt(input: SynthesisPromptInput): string {
   }
 
   parts.push('');
-  parts.push('Among all signals, identify the single decision or change that carries the strongest complete story (clearest tension + resolution). Write the post around that one decision.');
-  parts.push('Other signals may appear only as brief background context if they directly reinforce the same story. Do not list them as parallel items or give them equal narrative weight.');
+  parts.push('Among all signals, identify the single decision or change that carries the strongest complete story (clearest tension + resolution). Write the post around that one decision only.');
+  parts.push('The other signals are context for you to understand the work — do not mention them in the post.');
 
   const instagramEnabled = input.config.platforms.instagram.enabled;
 

--- a/src/ai/synthesis-prompt-builder.ts
+++ b/src/ai/synthesis-prompt-builder.ts
@@ -100,12 +100,23 @@ export function buildSynthesisUserPrompt(input: SynthesisPromptInput): string {
     parts.push(input.developmentalAngle);
   }
 
+  const instagramEnabled = input.config.platforms.instagram.enabled;
+
   parts.push('');
-  parts.push('Write the post. Wrap it in these XML tags exactly:');
+  parts.push('Write the following variants. Wrap each in these XML tags exactly:');
+  parts.push('');
   parts.push('<linkedin_draft>');
   parts.push('LinkedIn post here.');
   parts.push('</linkedin_draft>');
   parts.push('');
+  if (instagramEnabled) {
+    parts.push('- Instagram: first line ≤125 chars, must work as a standalone hook before "see more". Optional: 1-2 short supporting lines. Hashtags on last line only.');
+    parts.push('');
+    parts.push('<instagram_draft>');
+    parts.push('Instagram caption here.');
+    parts.push('</instagram_draft>');
+    parts.push('');
+  }
   parts.push('<opening_move>');
   parts.push('One-word label for the opening technique used (e.g. question, statistic, anecdote, contradiction, problem-first, declarative).');
   parts.push('</opening_move>');

--- a/src/ai/synthesis-prompt-builder.ts
+++ b/src/ai/synthesis-prompt-builder.ts
@@ -18,6 +18,7 @@ export interface SynthesisPromptInput {
   readonly commitGroups: SynthesisCommitGroup[]; // oldest first
   readonly coherenceScore?: CoherenceScore;       // only for arco
   readonly lastPostSummary?: string;
+  readonly developmentalAngle?: string;           // R3 arc guidance block
   readonly voiceProfile: VoiceProfile;
   readonly voiceStage: VoiceStage;
   readonly config: Config;
@@ -87,7 +88,27 @@ export function buildSynthesisUserPrompt(input: SynthesisPromptInput): string {
   }
 
   parts.push(lastPostNote);
+
+  // R4: technical accuracy constraint — signals carry no verified fact list
+  parts.push('');
+  parts.push('Do not state specific percentages, timing measurements, or line counts — they cannot be verified from the signal descriptions provided.');
+  parts.push('You may describe structural changes (e.g., "removed nested branching") but not quantify them (e.g., "removed 40% of branches").');
   parts.push('</synthesis_task>');
+
+  if (input.developmentalAngle) {
+    parts.push('');
+    parts.push(input.developmentalAngle);
+  }
+
+  parts.push('');
+  parts.push('Write the post. Wrap it in these XML tags exactly:');
+  parts.push('<linkedin_draft>');
+  parts.push('LinkedIn post here.');
+  parts.push('</linkedin_draft>');
+  parts.push('');
+  parts.push('<opening_move>');
+  parts.push('One-word label for the opening technique used (e.g. question, statistic, anecdote, contradiction, problem-first, declarative).');
+  parts.push('</opening_move>');
 
   return parts.join('\n');
 }

--- a/src/analysis/modules/complexity.ts
+++ b/src/analysis/modules/complexity.ts
@@ -60,6 +60,10 @@ export class ComplexityModule implements CodeAnalyzer {
           before: `~${removedDecisions} decision branches`,
           after: `~${addedDecisions} decision branches (reduced by ${delta})`,
         },
+        verifiableFacts: [
+          `Reduced decision points from ~${removedDecisions} to ~${addedDecisions} (delta: -${delta})`,
+          `${affectedFiles.length} file(s) affected: ${affectedFiles.slice(0, 3).join(', ')}`,
+        ],
       };
     } else {
       // Complexity increase — low signal, only flag if very large
@@ -74,6 +78,9 @@ export class ComplexityModule implements CodeAnalyzer {
         plainLanguage: `The commit added significant branching logic. This may be intentional (handling more cases) but is worth noting as an area to watch.`,
         interestScore: score,
         contextHint: `${affectedFiles[0] ?? 'the codebase'} in ${ctx.repo}`,
+        verifiableFacts: [
+          `Added ~${increase} decision points across ${affectedFiles.length} file(s)`,
+        ],
       };
     }
   }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -37,6 +37,7 @@ export const ContentPreferencesSchema = z.object({
   industry_context_preference: z.enum(['prefer', 'neutral', 'avoid']).optional(),
   expired_rate_30d: z.number().min(0).max(1).optional(),
   penalized_modules: z.array(z.string()).optional(),
+  penalized_arc_types: z.array(z.string()).optional(),
   updated_at: z.string().optional(),
 });
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -36,6 +36,7 @@ export const ContentPreferencesSchema = z.object({
   typical_length_delta: z.number().optional(),
   industry_context_preference: z.enum(['prefer', 'neutral', 'avoid']).optional(),
   expired_rate_30d: z.number().min(0).max(1).optional(),
+  penalized_modules: z.array(z.string()).optional(),
   updated_at: z.string().optional(),
 });
 

--- a/src/content/matcher.ts
+++ b/src/content/matcher.ts
@@ -31,6 +31,7 @@ export interface MatchedContext {
   readonly connection: string;   // one shared-pattern sentence from cross-encoder
   readonly articleTitle: string;
   readonly articleUrl: string;
+  readonly matchedFinding: string; // the finding text that triggered the match
 }
 
 interface FindingInput {
@@ -337,6 +338,7 @@ export async function matchFindingsToArticles(
         connection: match.connection,
         articleTitle: match.title,
         articleUrl: match.url,
+        matchedFinding: finding.finding,
       };
     } catch (err) {
       logger.warn('content.match.finding_error', { moduleId: finding.moduleId, error: String(err) });

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -9,6 +9,15 @@ export interface RepoMeta {
   readonly parentRepo?: string;
 }
 
+export interface ClosingIssue {
+  readonly number: number;
+  readonly title: string;
+  readonly bodySnippet?: string;
+  readonly totalReactions: number;
+  readonly totalComments: number;
+  readonly state: 'OPEN' | 'CLOSED';
+}
+
 export interface PrLookupResult {
   readonly number: number;
   readonly title: string;
@@ -16,10 +25,14 @@ export interface PrLookupResult {
   readonly url: string;
   readonly upstreamOwner: string;
   readonly upstreamRepo: string;
+  readonly body?: string | null;
   readonly timelineItems: ReadonlyArray<{
     readonly body: string;
     readonly authorLogin: string;
+    readonly itemType: 'issue_comment' | 'pr_review';
+    readonly reviewState?: 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED';
   }>;
+  readonly closingIssues: ReadonlyArray<ClosingIssue>;
 }
 
 // Module-level caches survive across GitHubClient instances in the same process.
@@ -49,14 +62,30 @@ query ListPullsForRef($owner: String!, $name: String!, $refName: String!) {
           title
           state
           url
+          body
           baseRepository {
             owner { login }
             name
           }
-          timelineItems(itemTypes: [ISSUE_COMMENT], last: 20) {
+          closingIssuesReferences(first: 3) {
+            nodes {
+              number
+              title
+              body
+              state
+              reactions  { totalCount }
+              comments   { totalCount }
+            }
+          }
+          timelineItems(itemTypes: [ISSUE_COMMENT, PULL_REQUEST_REVIEW], last: 20) {
             nodes {
               ... on IssueComment {
                 body
+                author { login }
+              }
+              ... on PullRequestReview {
+                body
+                state
                 author { login }
               }
             }
@@ -67,18 +96,110 @@ query ListPullsForRef($owner: String!, $name: String!, $refName: String!) {
   }
 }`.trim();
 
+const PR_LOOKUP_BY_COMMIT_GRAPHQL = `
+query ListPullsForCommit($owner: String!, $name: String!, $sha: String!) {
+  repository(owner: $owner, name: $name) {
+    object(expression: $sha) {
+      ... on Commit {
+        associatedPullRequests(first: 5) {
+          nodes {
+            number
+            title
+            state
+            url
+            body
+            baseRepository {
+              owner { login }
+              name
+            }
+            closingIssuesReferences(first: 3) {
+              nodes {
+                number
+                title
+                body
+                state
+                reactions  { totalCount }
+                comments   { totalCount }
+              }
+            }
+            timelineItems(itemTypes: [ISSUE_COMMENT, PULL_REQUEST_REVIEW], last: 20) {
+              nodes {
+                ... on IssueComment {
+                  body
+                  author { login }
+                }
+                ... on PullRequestReview {
+                  body
+                  state
+                  author { login }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`.trim();
+
+interface GraphqlIssueNode {
+  number: number;
+  title: string;
+  body?: string | null;
+  state: 'OPEN' | 'CLOSED';
+  reactions: { totalCount: number };
+  comments: { totalCount: number };
+}
+
 interface GraphqlPrNode {
   number: number;
   title: string;
   state: 'OPEN' | 'CLOSED' | 'MERGED';
   url: string;
+  body?: string | null;
   baseRepository: { owner: { login: string }; name: string } | null;
+  closingIssuesReferences: { nodes: GraphqlIssueNode[] };
   timelineItems: {
     nodes: Array<{
       body?: string;
+      state?: 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED';
       author?: { login: string } | null;
     }>;
   };
+}
+
+const MIN_ISSUE_BODY_CHARS = 30;
+const MAX_ISSUE_BODY_CHARS = 200;
+
+function sanitizeIssueBody(raw: string): string {
+  const cleaned = raw
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/```[\s\S]*?```/gm, '')
+    .replace(/`[^`\n]+`/g, '')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/^[-*]\s+\[[ x]\].*/gim, '')
+    .replace(/https?:\/\/\S+/g, '')
+    .replace(/@\w+/g, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+    .slice(0, MAX_ISSUE_BODY_CHARS)
+    .replace(/\s\S*$/, '')
+    .trim();
+  return cleaned.length < MIN_ISSUE_BODY_CHARS ? '' : cleaned;
+}
+
+function mapClosingIssues(nodes: GraphqlIssueNode[]): ClosingIssue[] {
+  return nodes.map((n) => {
+    const bodySnippet = n.body ? sanitizeIssueBody(n.body) || undefined : undefined;
+    return {
+      number: n.number,
+      title: n.title,
+      bodySnippet,
+      totalReactions: n.reactions.totalCount,
+      totalComments: n.comments.totalCount,
+      state: n.state,
+    };
+  });
 }
 
 export class GitHubClient {
@@ -209,13 +330,79 @@ export class GitHubClient {
         title: node.title,
         state: node.state,
         url: node.url,
+        body: node.body ?? null,
         upstreamOwner: node.baseRepository!.owner.login,
         upstreamRepo: node.baseRepository!.name,
+        closingIssues: mapClosingIssues(node.closingIssuesReferences.nodes),
         timelineItems: node.timelineItems.nodes
           .filter((item) => item.body !== undefined)
           .map((item) => ({
             body: item.body!,
             authorLogin: item.author?.login ?? '',
+            itemType: (item.state !== undefined ? 'pr_review' : 'issue_comment') as 'issue_comment' | 'pr_review',
+            reviewState: item.state,
+          })),
+      }));
+
+    prLookupCache.set(key, { results, cachedAt: Date.now() });
+    return results;
+  }
+
+  async listPullsForCommit(
+    owner: string,
+    repo: string,
+    sha: string,
+  ): Promise<PrLookupResult[]> {
+    const key = `commit:${owner}/${repo}@${sha}`;
+    const cached = prLookupCache.get(key);
+    if (cached && Date.now() - cached.cachedAt < PR_TTL_FINAL_MS) {
+      return cached.results;
+    }
+
+    const response = await fetch('https://api.github.com/graphql', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${this.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: PR_LOOKUP_BY_COMMIT_GRAPHQL,
+        variables: { owner, name: repo, sha },
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`GitHub GraphQL error: ${response.status} ${response.statusText}`);
+    }
+
+    const json = await response.json() as {
+      data?: { repository?: { object?: { associatedPullRequests?: { nodes: GraphqlPrNode[] } } } };
+      errors?: Array<{ message: string }>;
+    };
+
+    if (json.errors?.length) {
+      throw new Error(`GitHub GraphQL errors: ${json.errors.map((e) => e.message).join('; ')}`);
+    }
+
+    const nodes = json.data?.repository?.object?.associatedPullRequests?.nodes ?? [];
+    const results: PrLookupResult[] = nodes
+      .filter((node) => node.baseRepository !== null)
+      .map((node) => ({
+        number: node.number,
+        title: node.title,
+        state: node.state,
+        url: node.url,
+        body: node.body ?? null,
+        upstreamOwner: node.baseRepository!.owner.login,
+        upstreamRepo: node.baseRepository!.name,
+        closingIssues: mapClosingIssues(node.closingIssuesReferences.nodes),
+        timelineItems: node.timelineItems.nodes
+          .filter((item) => item.body !== undefined)
+          .map((item) => ({
+            body: item.body!,
+            authorLogin: item.author?.login ?? '',
+            itemType: (item.state !== undefined ? 'pr_review' : 'issue_comment') as 'issue_comment' | 'pr_review',
+            reviewState: item.state,
           })),
       }));
 

--- a/src/github/commit-enricher.ts
+++ b/src/github/commit-enricher.ts
@@ -31,6 +31,7 @@ export interface PrContext {
   readonly closingIssues?: ReadonlyArray<IssueRef>;
   readonly reviewSummaries?: ReadonlyArray<ReviewSummary>;
   readonly changesRequestedCount?: number;
+  readonly timelineItemsCount?: number;
   readonly supersededEvidence?: {
     readonly supersededByPr?: number;
     readonly maintainerComment?: string;
@@ -51,6 +52,7 @@ export interface EnrichedCommit {
   languages: string[];
   committedAt: string;
   isPrivateRepo: boolean;
+  branchRef?: string;
   prContext?: PrContext;
 }
 
@@ -215,6 +217,7 @@ async function resolvePrContext(
       closingIssues: closingIssues.length > 0 ? closingIssues : undefined,
       reviewSummaries: reviewSummaries.length > 0 ? reviewSummaries : undefined,
       changesRequestedCount: changesRequestedCount > 0 ? changesRequestedCount : undefined,
+      timelineItemsCount: pr.timelineItems.length > 0 ? pr.timelineItems.length : undefined,
       supersededEvidence,
     };
   } catch {
@@ -287,6 +290,7 @@ export async function enrichCommit(
     languages,
     committedAt: raw.commit.committer?.date ?? new Date().toISOString(),
     isPrivateRepo,
+    branchRef,
     prContext,
   };
 }

--- a/src/github/commit-enricher.ts
+++ b/src/github/commit-enricher.ts
@@ -2,8 +2,23 @@ import { parseCommitFiles } from '../analysis/diff-parser.js';
 import { detectLanguages } from '../analysis/language-detector.js';
 import { RepoNotFoundError, type GitHubClient, type PrLookupResult } from './client.js';
 import type { FileDiff } from '../analysis/types.js';
+import { logger } from '../utils/logger.js';
 
 export type PrOutcome = 'open' | 'merged' | 'closed_unmerged' | 'closed_superseded';
+
+export interface IssueRef {
+  readonly number: number;
+  readonly title: string;
+  readonly bodySnippet?: string;
+  readonly totalReactions: number;
+  readonly totalComments: number;
+}
+
+export interface ReviewSummary {
+  readonly body: string;
+  readonly authorLogin: string;
+  readonly state: 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED';
+}
 
 export interface PrContext {
   readonly upstreamOwner: string;
@@ -12,6 +27,10 @@ export interface PrContext {
   readonly prUrl: string;
   readonly prTitle: string;
   readonly outcome: PrOutcome;
+  readonly prDescription?: string;
+  readonly closingIssues?: ReadonlyArray<IssueRef>;
+  readonly reviewSummaries?: ReadonlyArray<ReviewSummary>;
+  readonly changesRequestedCount?: number;
   readonly supersededEvidence?: {
     readonly supersededByPr?: number;
     readonly maintainerComment?: string;
@@ -50,6 +69,39 @@ interface RawCommitData {
     deletions?: number;
     patch?: string;
   }>;
+}
+
+const MIN_PR_DESCRIPTION_CHARS = 50;
+const MAX_PR_DESCRIPTION_CHARS = 500;
+
+function sanitizePrBody(raw: string): string {
+  const cleaned = raw
+    .replace(/<!--[\s\S]*?-->/g, '')          // GitHub template comments
+    .replace(/```[\s\S]*?```/gm, '')           // fenced code blocks
+    .replace(/`[^`\n]+`/g, '')                 // inline code
+    .replace(/^#{1,6}\s+/gm, '')               // header markers (keep text, strip ##)
+    .replace(/^[-*]\s+\[[ x]\].*/gim, '')      // checklist items
+    .replace(/https?:\/\/\S+/g, '')            // URLs
+    .replace(/@\w+/g, '')                      // @ mentions
+    .replace(/\n{3,}/g, '\n\n')               // collapse excess blank lines
+    .trim()
+    .slice(0, MAX_PR_DESCRIPTION_CHARS)
+    .replace(/\s\S*$/, '')                     // trim to last word boundary
+    .trim();
+
+  return cleaned.length < MIN_PR_DESCRIPTION_CHARS ? '' : cleaned;
+}
+
+// Regex for low-value review feedback (quality noise — not design reasoning)
+const REVIEW_NOISE_RE = /\b(sonar(qube|lint)?|lint|checkstyle|pmd|spotbugs|codeclimate|coverage|tests?\s+missing|nit[:\s]|nitpick|typo|formatting|rename|style\s+guide|code\s+style|trailing\s+space|unused\s+(import|variable))\b/i;
+// Regex for high-value review feedback (design reasoning, operational implications)
+const REVIEW_SIGNAL_RE = /\b(won'?t\s+(scale|work)|consider|instead\s+of|alternative|will\s+cause|assumption|edge\s+case|race\s+condition|concurrent|production|latency|memory\s+leak|thundering|deadlock|have\s+you\s+(thought|considered)|what\s+(about|if|happens))\b/i;
+
+function hasNarrativeValue(body: string): boolean {
+  if (body.trim().length < 20) return false;
+  if (REVIEW_NOISE_RE.test(body)) return false;
+  if (REVIEW_SIGNAL_RE.test(body)) return true;
+  return body.trim().length >= 60;
 }
 
 // Regex for high-confidence superseded: verb of incorporation + explicit reference
@@ -102,16 +154,55 @@ async function resolvePrContext(
   client: GitHubClient,
   owner: string,
   repo: string,
-  branchRef: string,
+  sha: string,
+  branchRef: string | null,
   authorLogin: string,
 ): Promise<PrContext | undefined> {
   try {
-    const prs = await client.listPullsForRef(owner, repo, branchRef);
+    const prs = branchRef !== null
+      ? await client.listPullsForRef(owner, repo, branchRef)
+      : await client.listPullsForCommit(owner, repo, sha);
+
     if (prs.length === 0) return undefined;
 
-    // Use the first PR found (most recent match to this branch)
+    // Use the first PR found (most recent match to this ref/commit)
     const pr = prs[0]!;
     const { outcome, supersededEvidence } = detectOutcome(pr, authorLogin);
+
+    const prDescription = sanitizePrBody(pr.body ?? '') || undefined;
+
+    logger.debug('commit.pr_description', {
+      sha,
+      repo: `${owner}/${repo}`,
+      prNumber: pr.number,
+      hasDescription: !!prDescription,
+      chars: prDescription?.length ?? 0,
+      source: branchRef !== null ? 'branch_ref' : 'commit_sha',
+    });
+
+    const closingIssues: IssueRef[] = pr.closingIssues.map((issue) => ({
+      number: issue.number,
+      title: issue.title,
+      bodySnippet: issue.bodySnippet,
+      totalReactions: issue.totalReactions,
+      totalComments: issue.totalComments,
+    }));
+
+    const reviewSummaries: ReviewSummary[] = pr.timelineItems
+      .filter((item) =>
+        item.itemType === 'pr_review' &&
+        item.reviewState !== undefined &&
+        hasNarrativeValue(item.body),
+      )
+      .map((item) => ({
+        body: item.body.slice(0, 150).replace(/\s\S*$/, '').trim(),
+        authorLogin: item.authorLogin,
+        state: item.reviewState!,
+      }));
+
+    const changesRequestedCount = pr.timelineItems.filter(
+      (item) => item.itemType === 'pr_review' && item.reviewState === 'CHANGES_REQUESTED',
+    ).length;
 
     return {
       upstreamOwner: pr.upstreamOwner,
@@ -120,6 +211,10 @@ async function resolvePrContext(
       prUrl: pr.url,
       prTitle: pr.title,
       outcome,
+      prDescription,
+      closingIssues: closingIssues.length > 0 ? closingIssues : undefined,
+      reviewSummaries: reviewSummaries.length > 0 ? reviewSummaries : undefined,
+      changesRequestedCount: changesRequestedCount > 0 ? changesRequestedCount : undefined,
       supersededEvidence,
     };
   } catch {
@@ -163,12 +258,16 @@ export async function enrichCommit(
     const repoMeta = await client.getRepoMeta(owner, repo);
     isPrivateRepo = repoMeta.isPrivate;
 
-    // PR lookup: only for non-default-branch pushes (feature branches, fork branches)
     if (branchRef) {
       const refBranch = branchRef.replace('refs/heads/', '');
       const isPushToNonDefaultBranch = refBranch !== repoMeta.defaultBranch;
       if (isPushToNonDefaultBranch) {
-        prContext = await resolvePrContext(client, owner, repo, branchRef, authorLogin);
+        // Feature branch push: look up PRs by branch ref (open or merged PR for this branch)
+        prContext = await resolvePrContext(client, owner, repo, sha, branchRef, authorLogin);
+      } else {
+        // Direct push to default branch: look up PRs by commit SHA.
+        // Handles squash-merges and merge commits where the PR body has context.
+        prContext = await resolvePrContext(client, owner, repo, sha, null, authorLogin);
       }
     }
   } catch {

--- a/src/github/commit-enricher.ts
+++ b/src/github/commit-enricher.ts
@@ -12,6 +12,7 @@ export interface IssueRef {
   readonly bodySnippet?: string;
   readonly totalReactions: number;
   readonly totalComments: number;
+  readonly state: 'OPEN' | 'CLOSED';
 }
 
 export interface ReviewSummary {
@@ -188,6 +189,7 @@ async function resolvePrContext(
       bodySnippet: issue.bodySnippet,
       totalReactions: issue.totalReactions,
       totalComments: issue.totalComments,
+      state: issue.state,
     }));
 
     const reviewSummaries: ReviewSummary[] = pr.timelineItems

--- a/src/main-poll.ts
+++ b/src/main-poll.ts
@@ -158,7 +158,6 @@ async function main(): Promise<void> {
 
       // Enrich commit
       const commit = await enrichCommit(github, owner, repo, pushCommit.sha, pushCommit.authorLogin, pushEvent.ref);
-      const collaborationWeight = computeCollaborationWeight(commit.prContext);
 
       // Rule-based filter — zero API cost
       const filterResult = isInteresting(
@@ -206,13 +205,6 @@ async function main(): Promise<void> {
         modules,
         recentModuleIds,
       );
-
-      const commitIntent = detectCommitIntent({
-        message: commit.message,
-        branchRef: commit.branchRef,
-        prTitle: commit.prContext?.prTitle,
-        moduleIds: pipelineFindings.map((f) => f.moduleId),
-      });
 
       // Deposit weak signals (best-effort — never blocks post generation)
       const depositNowIso = new Date().toISOString();

--- a/src/main-poll.ts
+++ b/src/main-poll.ts
@@ -335,7 +335,7 @@ async function main(): Promise<void> {
             recentArcTypes,
           });
           if (angle) {
-            developmentalAngle = buildAngleBlock(angle);
+            developmentalAngle = buildAngleBlock(angle, candidateCollabWeight);
             selectedArcType = angle.arcType;
           }
         } catch { /* fail-open */ }

--- a/src/main-poll.ts
+++ b/src/main-poll.ts
@@ -9,6 +9,7 @@ import { logger } from './utils/logger.js';
 import { bestEffort } from './utils/best-effort.js';
 import { isInteresting } from './utils/commit-filter.js';
 import { detectCommitIntent, computeCollaborationWeight } from './utils/commit-classifier.js';
+import { selectDevelopmentalAngle, buildAngleBlock, type ArcType } from './ai/developmental-editor.js';
 import { GitHubClient } from './github/client.js';
 import { pollNewPushEvents } from './github/events-poller.js';
 import { enrichCommit, type EnrichedCommit } from './github/commit-enricher.js';
@@ -274,6 +275,12 @@ async function main(): Promise<void> {
     const authorState = authorStates.get(authorKey);
     if (!authorState) continue;
 
+    // Fetch arc history once per author (fail-open — anti-repetition disabled if query fails)
+    let recentArcTypes: ArcType[] = [];
+    try {
+      recentArcTypes = (await storage.getRecentArcTypes(authorState.authorLogin, 5)) as ArcType[];
+    } catch { /* fail-open */ }
+
     while (authorState.todayDrafts.length < dailyLimit && candidates.length > 0) {
       const [candidate] = selectTopDailyCandidates(candidates, authorState.todayDrafts, 1);
       if (!candidate) break;
@@ -308,6 +315,31 @@ async function main(): Promise<void> {
             ) ?? undefined
           : undefined;
 
+        // R3: select narrative arc — fail-open if no evidence
+        const candidateCollabWeight = computeCollaborationWeight(candidate.commit.prContext);
+        const candidateIntent = detectCommitIntent({
+          message: candidate.commit.message,
+          branchRef: candidate.commit.branchRef,
+          prTitle: candidate.commit.prContext?.prTitle,
+          moduleIds: candidate.findings.map((f) => f.moduleId),
+        });
+        let developmentalAngle: string | undefined;
+        let selectedArcType: string | null = null;
+        try {
+          const angle = selectDevelopmentalAngle({
+            findings: candidate.findings,
+            commitIntent: candidateIntent,
+            closingIssues: candidate.commit.prContext?.closingIssues,
+            changesRequestedCount: candidate.commit.prContext?.changesRequestedCount ?? 0,
+            collaborationWeight: candidateCollabWeight,
+            recentArcTypes,
+          });
+          if (angle) {
+            developmentalAngle = buildAngleBlock(angle);
+            selectedArcType = angle.arcType;
+          }
+        } catch { /* fail-open */ }
+
         const { bufferText, draftId, openingMove } = await generatePosts(
           anthropic,
           candidate.commit,
@@ -321,9 +353,11 @@ async function main(): Promise<void> {
             bootstrapPosts: candidate.voiceProfile.bootstrap_posts ?? [],
             recentModuleIds,
             chapterContext,
+            developmentalAngle,
             draftMetadata: {
               author_login: candidate.authorLogin,
               generation_system: authorState.voiceStage === 'cold' ? 'v1' : 'v2_progressive',
+              arc_type: selectedArcType,
             },
             draftIndexToday,
             varietyConstraint,

--- a/src/main-poll.ts
+++ b/src/main-poll.ts
@@ -8,6 +8,7 @@ import { loadConfig } from './config/loader.js';
 import { logger } from './utils/logger.js';
 import { bestEffort } from './utils/best-effort.js';
 import { isInteresting } from './utils/commit-filter.js';
+import { detectCommitIntent, computeCollaborationWeight } from './utils/commit-classifier.js';
 import { GitHubClient } from './github/client.js';
 import { pollNewPushEvents } from './github/events-poller.js';
 import { enrichCommit, type EnrichedCommit } from './github/commit-enricher.js';
@@ -156,6 +157,7 @@ async function main(): Promise<void> {
 
       // Enrich commit
       const commit = await enrichCommit(github, owner, repo, pushCommit.sha, pushCommit.authorLogin, pushEvent.ref);
+      const collaborationWeight = computeCollaborationWeight(commit.prContext);
 
       // Rule-based filter — zero API cost
       const filterResult = isInteresting(
@@ -203,6 +205,13 @@ async function main(): Promise<void> {
         modules,
         recentModuleIds,
       );
+
+      const commitIntent = detectCommitIntent({
+        message: commit.message,
+        branchRef: commit.branchRef,
+        prTitle: commit.prContext?.prTitle,
+        moduleIds: pipelineFindings.map((f) => f.moduleId),
+      });
 
       // Deposit weak signals (best-effort — never blocks post generation)
       const depositNowIso = new Date().toISOString();

--- a/src/main-poll.ts
+++ b/src/main-poll.ts
@@ -325,6 +325,7 @@ async function main(): Promise<void> {
             changesRequestedCount: candidate.commit.prContext?.changesRequestedCount ?? 0,
             collaborationWeight: candidateCollabWeight,
             recentArcTypes,
+            discouragedArcTypes: (candidate.voiceProfile.content_preferences?.penalized_arc_types ?? []) as ArcType[],
           });
           if (angle) {
             developmentalAngle = buildAngleBlock(angle, candidateCollabWeight);

--- a/src/main-poll.ts
+++ b/src/main-poll.ts
@@ -104,7 +104,7 @@ async function main(): Promise<void> {
   );
 
   logger.info('poll.events_found', { count: events.length });
-  const recentModuleIds = await storage.getRecentModuleIds(30);
+  const recentModuleIds = await storage.getRecentModuleIds(30, config.author.github_username);
   const recentModuleFireCounts = buildModuleFireCounts(recentModuleIds);
   const dayStartIso = getStartOfDayIso(config.scheduling.timezone);
   const dailyLimit = config.posting.max_daily_posts_per_author;

--- a/src/review/notifier.ts
+++ b/src/review/notifier.ts
@@ -10,7 +10,7 @@ import type { EnrichedCommit } from '../github/commit-enricher.js';
  * The issue auto-closes after 48 hours via a comment (the workflow runs this
  * function, then a separate step closes old issues via the GitHub API).
  */
-const REJECTION_REASONS = ['hook', 'tone', 'too-technical', 'too-long', 'off-topic'] as const;
+const REJECTION_REASONS = ['hook', 'tone', 'too-technical', 'too-long', 'off-topic', 'factual'] as const;
 export type RejectionReason = typeof REJECTION_REASONS[number];
 export const VALID_REJECTION_REASONS: ReadonlySet<string> = new Set(REJECTION_REASONS);
 
@@ -20,6 +20,7 @@ const REASON_LABELS: Record<RejectionReason, string> = {
   'too-technical': 'muy técnico',
   'too-long': 'muy largo',
   'off-topic': 'fuera de tema',
+  'factual': 'dato incorrecto',
 };
 
 export async function notifyNewDraft(

--- a/src/utils/commit-classifier.ts
+++ b/src/utils/commit-classifier.ts
@@ -1,0 +1,89 @@
+import type { PrContext } from '../github/commit-enricher.js';
+
+export type CommitIntent =
+  | 'urgent_fix'
+  | 'planned_feature'
+  | 'tech_debt'
+  | 'optimization'
+  | 'unknown';
+
+const BRANCH_URGENT_RE  = /\/hotfix\//i;
+const BRANCH_FIX_RE     = /\/fix\//i;
+const BRANCH_FEATURE_RE = /\/(feat|feature)\//i;
+const BRANCH_DEBT_RE    = /\/(refactor|chore|cleanup)\//i;
+const BRANCH_PERF_RE    = /\/perf\//i;
+
+const MSG_URGENT_RE  = /^(fix|hotfix|patch)(\([^)]+\))?!?\s*:|\b(critical|urgent|cve|security[\s-]patch)\b/i;
+const MSG_FEATURE_RE = /^feat(\([^)]+\))?!?\s*:|^(add|introduce|implement)\b/i;
+const MSG_DEBT_RE    = /^(refactor|chore|cleanup|remove|extract)(\([^)]+\))?!?\s*:/i;
+const MSG_PERF_RE    = /^perf(\([^)]+\))?!?\s*:|\b(optim|cache|batch|memoiz)\w*\b/i;
+
+const URGENT_MODULES  = new Set(['security', 'error_resilience']);
+const FEATURE_MODULES = new Set(['architecture_patterns', 'api_design', 'integration']);
+const DEBT_MODULES    = new Set(['clean_code', 'evolutionary', 'type_system']);
+const PERF_MODULES    = new Set(['performance', 'concurrency']);
+
+export interface IntentInput {
+  readonly message:    string;
+  readonly branchRef?: string;
+  readonly prTitle?:   string;
+  readonly moduleIds?: string[];
+}
+
+export function detectCommitIntent(input: IntentInput): CommitIntent {
+  const { message, branchRef = '', prTitle = '', moduleIds = [] } = input;
+  const scores: Record<CommitIntent, number> = {
+    urgent_fix: 0, planned_feature: 0, tech_debt: 0, optimization: 0, unknown: 0,
+  };
+
+  // Branch ref — weight 3 (highest confidence)
+  if (BRANCH_URGENT_RE.test(branchRef))  scores.urgent_fix      += 3;
+  if (BRANCH_FIX_RE.test(branchRef))     scores.urgent_fix      += 2;
+  if (BRANCH_FEATURE_RE.test(branchRef)) scores.planned_feature += 3;
+  if (BRANCH_DEBT_RE.test(branchRef))    scores.tech_debt       += 3;
+  if (BRANCH_PERF_RE.test(branchRef))    scores.optimization    += 3;
+
+  // Commit message — weight 2
+  if (MSG_URGENT_RE.test(message))  scores.urgent_fix      += 2;
+  if (MSG_FEATURE_RE.test(message)) scores.planned_feature += 2;
+  if (MSG_DEBT_RE.test(message))    scores.tech_debt       += 2;
+  if (MSG_PERF_RE.test(message))    scores.optimization    += 2;
+
+  // PR title — weight 2 (more deliberate than commit message)
+  if (MSG_URGENT_RE.test(prTitle))  scores.urgent_fix      += 2;
+  if (MSG_FEATURE_RE.test(prTitle)) scores.planned_feature += 2;
+  if (MSG_DEBT_RE.test(prTitle))    scores.tech_debt       += 2;
+  if (MSG_PERF_RE.test(prTitle))    scores.optimization    += 2;
+
+  // Module IDs — weight 1 (semantic diff signal, not declarative)
+  for (const id of moduleIds) {
+    if (URGENT_MODULES.has(id))  scores.urgent_fix      += 1;
+    if (FEATURE_MODULES.has(id)) scores.planned_feature += 1;
+    if (DEBT_MODULES.has(id))    scores.tech_debt       += 1;
+    if (PERF_MODULES.has(id))    scores.optimization    += 1;
+  }
+
+  const best = (Object.entries(scores) as [CommitIntent, number][])
+    .filter(([k]) => k !== 'unknown')
+    .sort((a, b) => b[1] - a[1])[0];
+
+  return best && best[1] > 0 ? best[0] : 'unknown';
+}
+
+export function computeCollaborationWeight(prContext: PrContext | undefined): number {
+  if (!prContext) return 1.0;
+
+  const comments = prContext.timelineItemsCount ?? 0;
+
+  if (
+    prContext.outcome === 'closed_superseded' &&
+    prContext.supersededEvidence?.confidence === 'high'
+  ) {
+    return 1.4;
+  }
+
+  if (comments >= 10) return 1.3;
+  if (comments >= 5)  return 1.15;
+  if (comments >= 2)  return 1.05;
+  return 1.0;
+}

--- a/src/voice/exposure.ts
+++ b/src/voice/exposure.ts
@@ -8,17 +8,27 @@ export interface ExposureCandidate {
   published?: string | null;
   text?: string;
   edit_ratio?: number | null;
+  voice_rating?: number | null;
   top_module_id?: string | null;
 }
 
 export const MAX_EXPOSURE_CHARS = 4000;
 
-export function exposureWeight(editRatio: number | null | undefined): number {
-  const value = editRatio ?? 0;
-  if (value < 0.3) return 0;
-  if (value <= 0.65) return 1.2;
-  if (value <= 0.9) return 1.0;
-  return 0.8;
+export function exposureWeight(post: ExposureCandidate): number {
+  const ratio = post.edit_ratio ?? 0;
+  if (ratio < 0.3) return 0;
+  if (post.voice_rating === 1) return 0;
+
+  if (post.voice_rating === 2) {
+    if (ratio > 0.90) return 1.6;
+    if (ratio > 0.65) return 1.3;
+    return 1.1;
+  }
+
+  // Unrated — preserve previous behaviour
+  if (ratio > 0.90) return 0.8;
+  if (ratio > 0.65) return 1.0;
+  return 1.2;
 }
 
 export function selectExposureExamples(
@@ -34,7 +44,7 @@ export function selectExposureExamples(
   const shuffled = weightedShuffle(
     pool.map((post) => ({
       item: post,
-      weight: exposureWeight(post.edit_ratio),
+      weight: exposureWeight(post),
     })),
     rng,
   );

--- a/src/voice/feedback.ts
+++ b/src/voice/feedback.ts
@@ -59,10 +59,10 @@ export function classifyHookStyle(text: string): HookStyle {
 
 export function deriveContentPreferences(outcomes: VoicePost[], now = new Date()): ContentPreferences {
   const published = outcomes.filter((post) => post.status === 'published');
-  // Exclude linkedin_direct posts from edit-signal computation: their edit_ratio is
-  // hardcoded 1.0 (no human review step), so they would artificially suppress hook/length signals.
+  // Exclude linkedin_direct (edit_ratio hardcoded 1.0) and 👎-rated posts (author
+  // explicitly rejected them) from hook/length signal computation.
   const latestPublished = published
-    .filter((post) => post.publish_source !== 'linkedin_direct')
+    .filter((post) => post.publish_source !== 'linkedin_direct' && post.voice_rating !== 1)
     .slice(0, 10);
   const recentWindowStart = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
 

--- a/src/voice/feedback.ts
+++ b/src/voice/feedback.ts
@@ -147,18 +147,31 @@ export function deriveContentPreferences(outcomes: VoicePost[], now = new Date()
   }
 
   const PENALIZE_REASONS = new Set(['off-topic', 'too-technical']);
-  const recentRejections = outcomes
-    .filter((post) => post.status === 'expired' && post.rejection_reason && post.top_module_id)
-    .slice(0, 10);
-  const rejectionCounts = new Map<string, number>();
-  for (const post of recentRejections) {
+  const modulePenaltyCounts = new Map<string, number>();
+  // Expired posts with topic-mismatch rejection reason
+  for (const post of outcomes.filter((p) => p.status === 'expired' && p.rejection_reason && p.top_module_id).slice(0, 10)) {
     if (!PENALIZE_REASONS.has(post.rejection_reason!)) continue;
-    const moduleId = post.top_module_id!;
-    rejectionCounts.set(moduleId, (rejectionCounts.get(moduleId) ?? 0) + 1);
+    const id = post.top_module_id!;
+    modulePenaltyCounts.set(id, (modulePenaltyCounts.get(id) ?? 0) + 1);
   }
-  const penalizedModules = [...rejectionCounts.entries()]
+  // Published posts the author explicitly disliked (👎)
+  for (const post of published.filter((p) => p.voice_rating === 1 && p.top_module_id).slice(0, 10)) {
+    const id = post.top_module_id!;
+    modulePenaltyCounts.set(id, (modulePenaltyCounts.get(id) ?? 0) + 1);
+  }
+  const penalizedModules = [...modulePenaltyCounts.entries()]
     .filter(([, count]) => count >= 3)
     .map(([moduleId]) => moduleId);
+
+  // Penalize arc_types where 'hook' rejection is recurrent
+  const arcPenaltyCounts = new Map<string, number>();
+  for (const post of outcomes.filter((p) => p.status === 'expired' && p.rejection_reason === 'hook' && p.arc_type).slice(0, 10)) {
+    const arc = post.arc_type!;
+    arcPenaltyCounts.set(arc, (arcPenaltyCounts.get(arc) ?? 0) + 1);
+  }
+  const penalizedArcTypes = [...arcPenaltyCounts.entries()]
+    .filter(([, count]) => count >= 3)
+    .map(([arc]) => arc);
 
   return {
     ...(preferredModules.length > 0 && { preferred_modules: preferredModules }),
@@ -167,6 +180,7 @@ export function deriveContentPreferences(outcomes: VoicePost[], now = new Date()
     industry_context_preference: industryContextPreference,
     expired_rate_30d: Number(expiredRate30d.toFixed(3)),
     ...(penalizedModules.length > 0 && { penalized_modules: penalizedModules }),
+    ...(penalizedArcTypes.length > 0 && { penalized_arc_types: penalizedArcTypes }),
     updated_at: now.toISOString(),
   };
 }

--- a/src/voice/feedback.ts
+++ b/src/voice/feedback.ts
@@ -146,12 +146,27 @@ export function deriveContentPreferences(outcomes: VoicePost[], now = new Date()
     industryContextPreference = 'neutral';
   }
 
+  const PENALIZE_REASONS = new Set(['off-topic', 'too-technical']);
+  const recentRejections = outcomes
+    .filter((post) => post.status === 'expired' && post.rejection_reason && post.top_module_id)
+    .slice(0, 10);
+  const rejectionCounts = new Map<string, number>();
+  for (const post of recentRejections) {
+    if (!PENALIZE_REASONS.has(post.rejection_reason!)) continue;
+    const moduleId = post.top_module_id!;
+    rejectionCounts.set(moduleId, (rejectionCounts.get(moduleId) ?? 0) + 1);
+  }
+  const penalizedModules = [...rejectionCounts.entries()]
+    .filter(([, count]) => count >= 3)
+    .map(([moduleId]) => moduleId);
+
   return {
     ...(preferredModules.length > 0 && { preferred_modules: preferredModules }),
     ...(discouragedHookStyles.length > 0 && { discouraged_hook_styles: discouragedHookStyles }),
     ...(typicalLengthDelta !== undefined && { typical_length_delta: typicalLengthDelta }),
     industry_context_preference: industryContextPreference,
     expired_rate_30d: Number(expiredRate30d.toFixed(3)),
+    ...(penalizedModules.length > 0 && { penalized_modules: penalizedModules }),
     updated_at: now.toISOString(),
   };
 }

--- a/src/voice/profile-utils.ts
+++ b/src/voice/profile-utils.ts
@@ -47,6 +47,19 @@ export function filterFindingsByContentStrategy(
   return findings.filter((finding) => focusSet.has(finding.moduleId));
 }
 
+export function applyPenalizedModules(
+  findings: Finding[],
+  voiceProfile: VoiceProfile,
+): Finding[] {
+  const penalized = voiceProfile.content_preferences?.penalized_modules;
+  if (!penalized || penalized.length === 0) return findings;
+  const penalizedSet = new Set(penalized);
+  const preferred = findings.filter((f) => !penalizedSet.has(f.moduleId));
+  const deprioritized = findings.filter((f) => penalizedSet.has(f.moduleId));
+  // Fail-open: if all findings are penalized, return them anyway rather than skipping the commit.
+  return preferred.length > 0 ? [...preferred, ...deprioritized] : findings;
+}
+
 export function matchesSkipPatterns(
   commit: EnrichedCommit,
   findings: Finding[],

--- a/src/voice/sqlite-storage.ts
+++ b/src/voice/sqlite-storage.ts
@@ -404,13 +404,21 @@ export class SqliteStorage implements IVoiceStorage {
     return Promise.resolve(result.changes > 0);
   }
 
-  getRecentModuleIds(days: number): Promise<string[]> {
-    const rows = this.db.prepare(`
-      SELECT top_module_id FROM voice_posts
-      WHERE tenant_id = ?
-        AND created_at >= datetime('now', '-' || ? || ' days')
-        AND top_module_id IS NOT NULL
-    `).all(this.tenantId, days) as { top_module_id: string }[];
+  getRecentModuleIds(days: number, authorLogin?: string): Promise<string[]> {
+    const rows = authorLogin
+      ? this.db.prepare(`
+          SELECT top_module_id FROM voice_posts
+          WHERE tenant_id = ?
+            AND created_at >= datetime('now', '-' || ? || ' days')
+            AND top_module_id IS NOT NULL
+            AND author_login = ?
+        `).all(this.tenantId, days, authorLogin) as { top_module_id: string }[]
+      : this.db.prepare(`
+          SELECT top_module_id FROM voice_posts
+          WHERE tenant_id = ?
+            AND created_at >= datetime('now', '-' || ? || ' days')
+            AND top_module_id IS NOT NULL
+        `).all(this.tenantId, days) as { top_module_id: string }[];
     return Promise.resolve(rows.map((r) => r.top_module_id));
   }
 

--- a/src/voice/sqlite-storage.ts
+++ b/src/voice/sqlite-storage.ts
@@ -175,6 +175,8 @@ export class SqliteStorage implements IVoiceStorage {
       ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS generation_system TEXT;
       ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS opening_move     TEXT;
       ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS tenant_id        TEXT;
+      ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS voice_rating     INTEGER;
+      ALTER TABLE voice_posts ADD COLUMN IF NOT EXISTS arc_type         TEXT;
 
       CREATE UNIQUE INDEX IF NOT EXISTS idx_sha_platform
         ON voice_posts(commit_sha, platform);
@@ -318,9 +320,9 @@ export class SqliteStorage implements IVoiceStorage {
       INSERT INTO voice_posts (
         id, commit_sha, repo, platform, ai_draft, top_finding, top_module_id, findings_count,
         author_login, context_status, has_industry_context, matched_article_id, matched_source_id,
-        match_strength, match_connection, generation_system, opening_move, status, tenant_id
+        match_strength, match_connection, generation_system, opening_move, arc_type, status, tenant_id
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
     `).run(
       id,
       input.commit_sha,
@@ -339,6 +341,7 @@ export class SqliteStorage implements IVoiceStorage {
       input.match_connection ?? null,
       input.generation_system ?? null,
       input.opening_move ?? null,
+      input.arc_type ?? null,
       this.tenantId,
     );
     return Promise.resolve(id);
@@ -420,6 +423,21 @@ export class SqliteStorage implements IVoiceStorage {
             AND top_module_id IS NOT NULL
         `).all(this.tenantId, days) as { top_module_id: string }[];
     return Promise.resolve(rows.map((r) => r.top_module_id));
+  }
+
+  getRecentArcTypes(authorLogin: string | null, limit: number): Promise<string[]> {
+    const rows = authorLogin
+      ? this.db.prepare(`
+          SELECT arc_type FROM voice_posts
+          WHERE tenant_id = ? AND arc_type IS NOT NULL AND author_login = ?
+          ORDER BY created_at DESC LIMIT ?
+        `).all(this.tenantId, authorLogin, limit) as { arc_type: string }[]
+      : this.db.prepare(`
+          SELECT arc_type FROM voice_posts
+          WHERE tenant_id = ? AND arc_type IS NOT NULL
+          ORDER BY created_at DESC LIMIT ?
+        `).all(this.tenantId, limit) as { arc_type: string }[];
+    return Promise.resolve(rows.map((r) => r.arc_type));
   }
 
   updatePublished(input: UpdatePublishedInput): Promise<void> {

--- a/src/voice/storage.ts
+++ b/src/voice/storage.ts
@@ -59,6 +59,7 @@ export interface VoicePost {
   generation_system?: 'v1' | 'v2_progressive' | null;
   opening_move?: string | null;
   rejection_reason?: string | null;
+  voice_rating?: number | null;
 }
 
 export interface SaveDraftInput {

--- a/src/voice/storage.ts
+++ b/src/voice/storage.ts
@@ -58,6 +58,7 @@ export interface VoicePost {
   publish_source: PublishSource | null;
   generation_system?: 'v1' | 'v2_progressive' | null;
   opening_move?: string | null;
+  arc_type?: string | null;
   rejection_reason?: string | null;
   voice_rating?: number | null;
 }

--- a/src/voice/storage.ts
+++ b/src/voice/storage.ts
@@ -78,6 +78,7 @@ export interface SaveDraftInput {
   match_connection?: string | null;
   generation_system?: 'v1' | 'v2_progressive' | null;
   opening_move?: string | null;
+  arc_type?: string | null;
 }
 
 export interface UpdatePublishedInput {
@@ -247,6 +248,9 @@ export interface IVoiceStorage {
    * Used by the pipeline to apply the freshness multiplier to recently-fired modules.
    */
   getRecentModuleIds(days: number, authorLogin?: string): Promise<string[]>;
+
+  /** Get the last N arc_types for an author, ordered by created_at DESC. */
+  getRecentArcTypes(authorLogin: string | null, limit: number): Promise<string[]>;
 
   /** Get all posts with status='queued' for a given platform. */
   getQueuedPosts(platform: Platform): Promise<VoicePost[]>;

--- a/src/voice/storage.ts
+++ b/src/voice/storage.ts
@@ -167,16 +167,23 @@ export interface RoutingDecisionInput {
 }
 
 export interface IVoiceStorage {
-  /** The tenant this storage instance is scoped to. All queries filter by this. */
+  /**
+   * Tenant this instance is bound to for drafts, posts, and tenant-default voice.
+   * Most queries filter by this; Supabase author-specific `getVoiceProfile` reads
+   * the latest `voice_profiles` row for that login across tenants (see `supabase-storage.ts`).
+   */
   readonly tenantId: string;
 
   /** Save an AI draft immediately after generation. Returns the new row ID. */
   saveDraft(input: SaveDraftInput): Promise<string>;
 
-  /** Lookup voice profile for a specific author, falling back to tenant default row only. */
+  /**
+   * Load voice JSON: Supabase uses global author resolution (newest `updated_at`), then
+   * tenant default; SQLite uses tenant + author only.
+   */
   getVoiceProfile(authorLogin: string | null): Promise<StoredVoiceProfile | null>;
 
-  /** Insert or update a voice profile row scoped to a specific author or tenant default. */
+  /** Insert or update a `voice_profiles` row for this `tenantId` (author or tenant default). */
   saveVoiceProfile(authorLogin: string | null, voice: VoiceProfile, expectedVersion?: number): Promise<boolean>;
 
   /** Update a post after Buffer publishes it (voice loop feedback). */
@@ -239,7 +246,7 @@ export interface IVoiceStorage {
    * Returns the top_module_id values for posts created in the last `days` days.
    * Used by the pipeline to apply the freshness multiplier to recently-fired modules.
    */
-  getRecentModuleIds(days: number): Promise<string[]>;
+  getRecentModuleIds(days: number, authorLogin?: string): Promise<string[]>;
 
   /** Get all posts with status='queued' for a given platform. */
   getQueuedPosts(platform: Platform): Promise<VoicePost[]>;

--- a/src/voice/supabase-storage.ts
+++ b/src/voice/supabase-storage.ts
@@ -405,15 +405,18 @@ export class SupabaseStorage implements IVoiceStorage {
     return [...authorSet];
   }
 
-  async getRecentModuleIds(days: number): Promise<string[]> {
+  async getRecentModuleIds(days: number, authorLogin?: string): Promise<string[]> {
     const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
-    const { data, error } = await this.db
+    let query = this.db
       .from('voice_posts')
       .select('top_module_id')
       .eq('tenant_id', this.tenantId)
       .gte('created_at', since)
       .not('top_module_id', 'is', null);
 
+    if (authorLogin) query = query.eq('author_login', authorLogin);
+
+    const { data, error } = await query;
     if (error) throw new Error(`getRecentModuleIds failed: ${error.message}`);
     return (data ?? []).map((r) => (r as { top_module_id: string }).top_module_id);
   }

--- a/src/voice/supabase-storage.ts
+++ b/src/voice/supabase-storage.ts
@@ -73,6 +73,7 @@ export class SupabaseStorage implements IVoiceStorage {
         match_connection: input.match_connection ?? null,
         generation_system: input.generation_system ?? null,
         opening_move: input.opening_move ?? null,
+        arc_type: input.arc_type ?? null,
         status: 'pending' satisfies PostStatus,
         tenant_id: this.tenantId,
       })
@@ -419,6 +420,22 @@ export class SupabaseStorage implements IVoiceStorage {
     const { data, error } = await query;
     if (error) throw new Error(`getRecentModuleIds failed: ${error.message}`);
     return (data ?? []).map((r) => (r as { top_module_id: string }).top_module_id);
+  }
+
+  async getRecentArcTypes(authorLogin: string | null, limit: number): Promise<string[]> {
+    let query = this.db
+      .from('voice_posts')
+      .select('arc_type')
+      .eq('tenant_id', this.tenantId)
+      .not('arc_type', 'is', null)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+
+    if (authorLogin) query = query.eq('author_login', authorLogin);
+
+    const { data, error } = await query;
+    if (error) throw new Error(`getRecentArcTypes failed: ${error.message}`);
+    return (data ?? []).map((r) => (r as { arc_type: string }).arc_type);
   }
 
   async hasDraft(commit_sha: string, platform: Platform): Promise<boolean> {

--- a/src/webhook/handlers/github-oauth.ts
+++ b/src/webhook/handlers/github-oauth.ts
@@ -65,7 +65,9 @@ export async function handleGitHubMemberCallback(
   clientSecret: string,
   webhookSecret: string,
 ): Promise<{ status: number; location: string }> {
-  const installationId = parseInt(state, 10);
+  const isPostsRedirect = state.startsWith('posts:');
+  const rawId = isPostsRedirect ? state.slice('posts:'.length) : state;
+  const installationId = parseInt(rawId, 10);
   if (!code || isNaN(installationId)) {
     logger.warn('github.member_callback.invalid_params', { state });
     return { status: 302, location: '/member/onboard?error=invalid_params' };
@@ -111,9 +113,10 @@ export async function handleGitHubMemberCallback(
 
   const memberToken = createMemberToken(installationId, user.login, webhookSecret);
 
-  logger.info('github.member_callback.success', { installationId, login: user.login });
+  const destination = isPostsRedirect ? 'posts' : 'member/onboard';
+  logger.info('github.member_callback.success', { installationId, login: user.login, destination });
   return {
     status: 302,
-    location: `/member/onboard?installation_id=${installationId}&member_token=${encodeURIComponent(memberToken)}`,
+    location: `/${destination}?installation_id=${installationId}&member_token=${encodeURIComponent(memberToken)}`,
   };
 }

--- a/src/webhook/handlers/member-onboard.ts
+++ b/src/webhook/handlers/member-onboard.ts
@@ -3,6 +3,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { sealTenantSecrets } from '../../security/tenant-secrets.js';
 import { BufferClient } from '../../buffer/client.js';
 import { logger } from '../../utils/logger.js';
+import type { BootstrapPost } from '../../config/schema.js';
 
 // ---------------------------------------------------------------------------
 // Member token — encodes installation_id + github_login, HMAC-signed.
@@ -420,6 +421,41 @@ export async function handleMemberOnboardPost(
   if (upsertError) {
     logger.error('member_onboard.save_failed', { login, error: upsertError.message });
     return { status: 302, location: `/member/onboard?installation_id=${installationId}&member_token=${encodeURIComponent(memberToken)}&error=save_failed` };
+  }
+
+  // Seed voice_profiles so the pipeline finds bootstrap posts for this author
+  if (voices.length > 0) {
+    const now = new Date().toISOString();
+    const bootstrapPosts: BootstrapPost[] = voices.map((text) => ({ text, pasted_at: now }));
+
+    const { data: tenantProfile } = await db
+      .from('voice_profiles')
+      .select('voice')
+      .eq('tenant_id', tenantId)
+      .is('github_author_login', null)
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const baseVoice = (tenantProfile?.voice ?? {}) as Record<string, unknown>;
+
+    const { error: profileError } = await db
+      .from('voice_profiles')
+      .upsert(
+        {
+          tenant_id: tenantId,
+          github_author_login: login,
+          voice: { ...baseVoice, bootstrap_posts: bootstrapPosts },
+          version: 1,
+        },
+        { onConflict: 'tenant_id,github_author_login' },
+      );
+
+    if (profileError) {
+      logger.error('member_onboard.voice_profile_seed_failed', { login, tenantId, error: profileError.message });
+    } else {
+      logger.info('member_onboard.voice_profile_seeded', { login, tenantId, bootstrapCount: voices.length });
+    }
   }
 
   logger.info('member_onboard.saved', { login, tenantId });

--- a/src/webhook/handlers/posts-feedback.ts
+++ b/src/webhook/handlers/posts-feedback.ts
@@ -1,0 +1,33 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { VALID_REJECTION_REASONS } from '../../review/notifier.js';
+import { parseMemberToken } from './member-onboard.js';
+
+export async function handlePostRejection(
+  postId: string,
+  memberToken: string,
+  reason: string,
+  installationId: number,
+  db: SupabaseClient,
+  webhookSecret: string,
+): Promise<{ status: number; location: string }> {
+  if (!VALID_REJECTION_REASONS.has(reason)) {
+    return { status: 302, location: `/posts?installation_id=${installationId}&error=invalid_reason` };
+  }
+
+  const parsed = parseMemberToken(memberToken, webhookSecret);
+  if (!parsed) {
+    return { status: 302, location: `/posts?installation_id=${installationId}&error=invalid_token` };
+  }
+
+  await db
+    .from('voice_posts')
+    .update({ rejection_reason: reason, status: 'expired' })
+    .eq('id', postId)
+    .eq('author_login', parsed.login)
+    .in('status', ['pending', 'scheduled', 'queued']);
+
+  return {
+    status: 302,
+    location: `/posts?installation_id=${installationId}&member_token=${encodeURIComponent(memberToken)}&saved=1`,
+  };
+}

--- a/src/webhook/handlers/posts-feedback.ts
+++ b/src/webhook/handlers/posts-feedback.ts
@@ -10,6 +10,7 @@ interface PostRow {
   platform: string;
   edit_ratio: number | null;
   voice_rating: number | null;
+  status: string;
 }
 
 function editRatioBadge(ratio: number | null): string {
@@ -26,23 +27,43 @@ function renderPostsHtml(
   memberToken: string,
 ): string {
   const rows = (posts ?? []).map((p) => {
-    const ratingHtml = p.voice_rating !== null
-      ? `<span style="font-size:1.25rem">${p.voice_rating === 2 ? '👍' : '👎'}</span>`
-      : `<form method="POST" action="/posts/${p.id}/feedback" style="display:inline-flex;gap:8px;align-items:center">
+    const isPending = ['pending', 'scheduled', 'queued'].includes(p.status);
+
+    const actionHtml = isPending
+      ? `<form method="POST" action="/posts/${p.id}/reject" style="display:inline-flex;gap:8px;align-items:center">
            <input type="hidden" name="member_token" value="${memberToken}">
            <input type="hidden" name="installation_id" value="${installationId}">
-           <button name="rating" value="2" style="background:none;border:1px solid #3f3f46;border-radius:6px;padding:4px 10px;cursor:pointer;color:#f4f4f5;font-size:0.875rem">👍 sonó como yo</button>
-           <button name="rating" value="1" style="background:none;border:1px solid #3f3f46;border-radius:6px;padding:4px 10px;cursor:pointer;color:#f4f4f5;font-size:0.875rem">👎 no sonó como yo</button>
-         </form>`;
+           <select name="reason" style="background:#27272a;border:1px solid #3f3f46;border-radius:6px;padding:4px 8px;color:#f4f4f5;font-size:0.875rem">
+             <option value="hook">hook fallido</option>
+             <option value="tone">tono</option>
+             <option value="too-technical">muy técnico</option>
+             <option value="too-long">muy largo</option>
+             <option value="off-topic">fuera de tema</option>
+             <option value="factual">dato incorrecto</option>
+           </select>
+           <button type="submit" style="background:none;border:1px solid #dc2626;border-radius:6px;padding:4px 10px;cursor:pointer;color:#fca5a5;font-size:0.875rem">Rechazar</button>
+         </form>`
+      : p.voice_rating !== null
+        ? `<span style="font-size:1.25rem">${p.voice_rating === 2 ? '👍' : '👎'}</span>`
+        : `<form method="POST" action="/posts/${p.id}/feedback" style="display:inline-flex;gap:8px;align-items:center">
+             <input type="hidden" name="member_token" value="${memberToken}">
+             <input type="hidden" name="installation_id" value="${installationId}">
+             <button name="rating" value="2" style="background:none;border:1px solid #3f3f46;border-radius:6px;padding:4px 10px;cursor:pointer;color:#f4f4f5;font-size:0.875rem">👍 sonó como yo</button>
+             <button name="rating" value="1" style="background:none;border:1px solid #3f3f46;border-radius:6px;padding:4px 10px;cursor:pointer;color:#f4f4f5;font-size:0.875rem">👎 no sonó como yo</button>
+           </form>`;
+
+    const statusBadge = isPending
+      ? `<span style="background:#854d0e;color:#fef08a;border-radius:4px;padding:1px 6px;font-size:0.75rem;margin-left:6px">${p.status}</span>`
+      : '';
 
     const date = p.published_at ? new Date(p.published_at).toLocaleDateString('es-CL') : '—';
-    const published = p.published ? escapeHtml(p.published.slice(0, 300)) : '(sin texto publicado)';
+    const text = p.published ? escapeHtml(p.published.slice(0, 300)) : escapeHtml(p.ai_draft.slice(0, 300));
     return `<div style="background:#18181b;border:1px solid #27272a;border-radius:10px;padding:16px;margin-bottom:12px">
       <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">
-        <span style="color:#a1a1aa;font-size:0.8rem">${date} · ${p.platform}${editRatioBadge(p.edit_ratio)}</span>
-        ${ratingHtml}
+        <span style="color:#a1a1aa;font-size:0.8rem">${date} · ${p.platform}${editRatioBadge(p.edit_ratio)}${statusBadge}</span>
+        ${actionHtml}
       </div>
-      <p style="white-space:pre-wrap;font-size:0.875rem;line-height:1.6;color:#f4f4f5">${published}</p>
+      <p style="white-space:pre-wrap;font-size:0.875rem;line-height:1.6;color:#f4f4f5">${text}</p>
     </div>`;
   }).join('');
 
@@ -75,11 +96,10 @@ export async function handlePostsGet(
 
   const { data } = await db
     .from('voice_posts')
-    .select('id, published, ai_draft, published_at, platform, edit_ratio, voice_rating')
+    .select('id, published, ai_draft, published_at, platform, edit_ratio, voice_rating, status')
     .eq('author_login', parsed.login)
-    .eq('status', 'published')
-    .not('published', 'is', null)
-    .order('published_at', { ascending: false })
+    .in('status', ['published', 'pending', 'scheduled', 'queued'])
+    .order('published_at', { ascending: false, nullsFirst: true })
     .limit(20);
 
   return {

--- a/src/webhook/handlers/posts-feedback.ts
+++ b/src/webhook/handlers/posts-feedback.ts
@@ -2,6 +2,124 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { VALID_REJECTION_REASONS } from '../../review/notifier.js';
 import { parseMemberToken } from './member-onboard.js';
 
+interface PostRow {
+  id: string;
+  published: string | null;
+  ai_draft: string;
+  published_at: string | null;
+  platform: string;
+  edit_ratio: number | null;
+  voice_rating: number | null;
+}
+
+function editRatioBadge(ratio: number | null): string {
+  if (ratio === null) return '';
+  const pct = Math.round(ratio * 100);
+  const color = ratio >= 0.85 ? '#22c55e' : ratio >= 0.65 ? '#f59e0b' : '#ef4444';
+  return `<span style="background:${color};color:#fff;border-radius:4px;padding:1px 6px;font-size:0.75rem;margin-left:6px">${pct}%</span>`;
+}
+
+function renderPostsHtml(
+  posts: PostRow[] | null,
+  login: string,
+  installationId: number,
+  memberToken: string,
+): string {
+  const rows = (posts ?? []).map((p) => {
+    const ratingHtml = p.voice_rating !== null
+      ? `<span style="font-size:1.25rem">${p.voice_rating === 2 ? '👍' : '👎'}</span>`
+      : `<form method="POST" action="/posts/${p.id}/feedback" style="display:inline-flex;gap:8px;align-items:center">
+           <input type="hidden" name="member_token" value="${memberToken}">
+           <input type="hidden" name="installation_id" value="${installationId}">
+           <button name="rating" value="2" style="background:none;border:1px solid #3f3f46;border-radius:6px;padding:4px 10px;cursor:pointer;color:#f4f4f5;font-size:0.875rem">👍 sonó como yo</button>
+           <button name="rating" value="1" style="background:none;border:1px solid #3f3f46;border-radius:6px;padding:4px 10px;cursor:pointer;color:#f4f4f5;font-size:0.875rem">👎 no sonó como yo</button>
+         </form>`;
+
+    const date = p.published_at ? new Date(p.published_at).toLocaleDateString('es-CL') : '—';
+    const published = p.published ? escapeHtml(p.published.slice(0, 300)) : '(sin texto publicado)';
+    return `<div style="background:#18181b;border:1px solid #27272a;border-radius:10px;padding:16px;margin-bottom:12px">
+      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">
+        <span style="color:#a1a1aa;font-size:0.8rem">${date} · ${p.platform}${editRatioBadge(p.edit_ratio)}</span>
+        ${ratingHtml}
+      </div>
+      <p style="white-space:pre-wrap;font-size:0.875rem;line-height:1.6;color:#f4f4f5">${published}</p>
+    </div>`;
+  }).join('');
+
+  const error = '';
+  return `<!DOCTYPE html><html lang="es"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>devcast — mis posts</title>
+<style>*{box-sizing:border-box;margin:0;padding:0}body{font-family:-apple-system,sans-serif;background:#09090b;color:#f4f4f5;min-height:100vh;padding:32px 16px}.container{max-width:680px;margin:0 auto}h1{font-size:1.25rem;font-weight:600;margin-bottom:4px}p.sub{color:#a1a1aa;font-size:0.875rem;margin-bottom:24px}</style>
+</head><body><div class="container">
+<h1>Mis posts</h1>
+<p class="sub">Sesión: ${escapeHtml(login)}</p>
+${error}
+${rows || '<p style="color:#71717a;text-align:center;padding:48px 0">Sin posts publicados aún.</p>'}
+</div></body></html>`;
+}
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+export async function handlePostsGet(
+  installationId: number,
+  memberToken: string,
+  db: SupabaseClient,
+  webhookSecret: string,
+): Promise<{ status: number; body?: string; location?: string; contentType?: string }> {
+  const parsed = parseMemberToken(memberToken, webhookSecret);
+  if (!parsed || parsed.installationId !== installationId) {
+    return { status: 302, location: `/posts?installation_id=${installationId}&error=invalid_token` };
+  }
+
+  const { data } = await db
+    .from('voice_posts')
+    .select('id, published, ai_draft, published_at, platform, edit_ratio, voice_rating')
+    .eq('author_login', parsed.login)
+    .eq('status', 'published')
+    .not('published', 'is', null)
+    .order('published_at', { ascending: false })
+    .limit(20);
+
+  return {
+    status: 200,
+    body: renderPostsHtml(data as PostRow[] | null, parsed.login, installationId, memberToken),
+    contentType: 'text/html',
+  };
+}
+
+export async function handlePostFeedback(
+  postId: string,
+  memberToken: string,
+  rating: number,
+  comment: string,
+  installationId: number,
+  db: SupabaseClient,
+  webhookSecret: string,
+): Promise<{ status: number; location: string }> {
+  const parsed = parseMemberToken(memberToken, webhookSecret);
+  if (!parsed) {
+    return { status: 302, location: `/posts?installation_id=${installationId}&error=invalid_token` };
+  }
+
+  const update: Record<string, unknown> = { voice_rating: rating };
+  if (rating === 1 && comment) {
+    update['rejection_reason'] = comment.slice(0, 500);
+  }
+
+  await db
+    .from('voice_posts')
+    .update(update)
+    .eq('id', postId)
+    .eq('author_login', parsed.login);
+
+  return {
+    status: 302,
+    location: `/posts?installation_id=${installationId}&member_token=${encodeURIComponent(memberToken)}&saved=1`,
+  };
+}
+
 export async function handlePostRejection(
   postId: string,
   memberToken: string,

--- a/src/webhook/server.ts
+++ b/src/webhook/server.ts
@@ -11,7 +11,7 @@ import { handleOnboardGet, handleOnboardPost } from './handlers/onboard.js';
 import { handleLinkedInRedirect, handleLinkedInCallback, handleLinkedInMemberRedirect, handleLinkedInMemberCallback } from './handlers/linkedin-oauth.js';
 import { handleGitHubCallback, handleGitHubMemberCallback } from './handlers/github-oauth.js';
 import { handleMemberOnboardGet, handleMemberOnboardPost } from './handlers/member-onboard.js';
-import { handlePostRejection } from './handlers/posts-feedback.js';
+import { handlePostRejection, handlePostsGet, handlePostFeedback } from './handlers/posts-feedback.js';
 import { VALID_REJECTION_REASONS } from '../review/notifier.js';
 import { logger } from '../utils/logger.js';
 
@@ -312,6 +312,69 @@ const server = createServer((req, res) => {
       logger.error('feedback.error', { error: String(err) });
       res.writeHead(500, { 'Content-Type': 'text/plain' });
       res.end('Internal error');
+    });
+    return;
+  }
+
+  // GET /posts — voice feedback page
+  if (req.method === 'GET' && path === '/posts') {
+    const installationId = parseInt(query.get('installation_id') ?? '', 10);
+    const memberToken = query.get('member_token') ?? '';
+
+    if (!memberToken) {
+      const callbackUrl = `${APP_BASE_URL}/auth/github/member-callback`;
+      const state = `posts:${installationId}`;
+      const githubUrl = `https://github.com/login/oauth/authorize?client_id=${GITHUB_APP_CLIENT_ID}&redirect_uri=${encodeURIComponent(callbackUrl)}&state=${encodeURIComponent(state)}&scope=read:user`;
+      res.writeHead(302, { 'Location': githubUrl });
+      res.end();
+      return;
+    }
+
+    (async () => {
+      const result = await handlePostsGet(installationId, memberToken, db, WEBHOOK_SECRET);
+      if (result.location) {
+        res.writeHead(result.status, { 'Location': result.location });
+        res.end();
+      } else {
+        res.writeHead(result.status, { 'Content-Type': result.contentType ?? 'text/html' });
+        res.end(result.body ?? '');
+      }
+    })().catch((err: unknown) => {
+      logger.error('posts.get.error', { error: String(err) });
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end('Internal error');
+    });
+    return;
+  }
+
+  // POST /posts/:id/feedback — save voice_rating for a published post
+  const feedbackMatch = path.match(/^\/posts\/([^/]+)\/feedback$/);
+  if (req.method === 'POST' && feedbackMatch) {
+    const postId = feedbackMatch[1]!;
+    let body = '';
+    req.on('data', (chunk: Buffer) => { body += chunk.toString(); });
+    req.on('end', () => {
+      const params = new URLSearchParams(body);
+      const rating = parseInt(params.get('rating') ?? '', 10);
+      const memberToken = params.get('member_token') ?? '';
+      const comment = params.get('comment') ?? '';
+      const installationId = parseInt(params.get('installation_id') ?? '0', 10);
+
+      if (rating !== 1 && rating !== 2) {
+        res.writeHead(400, { 'Content-Type': 'text/plain' });
+        res.end('Invalid rating');
+        return;
+      }
+
+      (async () => {
+        const result = await handlePostFeedback(postId, memberToken, rating, comment, installationId, db, WEBHOOK_SECRET);
+        res.writeHead(result.status, { 'Location': result.location });
+        res.end();
+      })().catch((err: unknown) => {
+        logger.error('posts.feedback.error', { error: String(err) });
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Internal error');
+      });
     });
     return;
   }

--- a/src/webhook/server.ts
+++ b/src/webhook/server.ts
@@ -11,6 +11,7 @@ import { handleOnboardGet, handleOnboardPost } from './handlers/onboard.js';
 import { handleLinkedInRedirect, handleLinkedInCallback, handleLinkedInMemberRedirect, handleLinkedInMemberCallback } from './handlers/linkedin-oauth.js';
 import { handleGitHubCallback, handleGitHubMemberCallback } from './handlers/github-oauth.js';
 import { handleMemberOnboardGet, handleMemberOnboardPost } from './handlers/member-onboard.js';
+import { handlePostRejection } from './handlers/posts-feedback.js';
 import { VALID_REJECTION_REASONS } from '../review/notifier.js';
 import { logger } from '../utils/logger.js';
 
@@ -311,6 +312,31 @@ const server = createServer((req, res) => {
       logger.error('feedback.error', { error: String(err) });
       res.writeHead(500, { 'Content-Type': 'text/plain' });
       res.end('Internal error');
+    });
+    return;
+  }
+
+  // POST /posts/:id/reject — expire a pending/scheduled post with a structured reason
+  const rejectMatch = path.match(/^\/posts\/([^/]+)\/reject$/);
+  if (req.method === 'POST' && rejectMatch) {
+    const postId = rejectMatch[1]!;
+    let body = '';
+    req.on('data', (chunk: Buffer) => { body += chunk.toString(); });
+    req.on('end', () => {
+      const params = new URLSearchParams(body);
+      const reason = params.get('reason') ?? '';
+      const memberToken = params.get('member_token') ?? '';
+      const installationId = parseInt(params.get('installation_id') ?? '0', 10);
+
+      (async () => {
+        const result = await handlePostRejection(postId, memberToken, reason, installationId, db, WEBHOOK_SECRET);
+        res.writeHead(result.status, { 'Location': result.location });
+        res.end();
+      })().catch((err: unknown) => {
+        logger.error('posts.reject.error', { error: String(err) });
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Internal error');
+      });
     });
     return;
   }

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -4,6 +4,7 @@ import { LinkedInClient, LinkedInAuthExpiredError } from '../linkedin/client.js'
 import { enrichCommit, type EnrichedCommit } from '../github/commit-enricher.js';
 import { isInteresting } from '../utils/commit-filter.js';
 import { detectCommitIntent, computeCollaborationWeight } from '../utils/commit-classifier.js';
+import { selectDevelopmentalAngle, buildAngleBlock, type ArcType } from '../ai/developmental-editor.js';
 import { runPipeline } from '../analysis/pipeline.js';
 import type { Finding } from '../analysis/types.js';
 import { MODULE_REGISTRY } from '../analysis/modules/index.js';
@@ -495,6 +496,12 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
     const authorState = authorStates.get(authorKey);
     if (!authorState) continue;
 
+    // Fetch arc history once per author (fail-open — anti-repetition disabled if query fails)
+    let recentArcTypes: ArcType[] = [];
+    try {
+      recentArcTypes = (await storage.getRecentArcTypes(authorState.authorLogin, 5)) as ArcType[];
+    } catch { /* fail-open */ }
+
     while (authorState.todayDrafts.length < dailyLimit && candidates.length > 0) {
       const [candidate] = selectTopDailyCandidates(candidates, authorState.todayDrafts, 1);
       if (!candidate) break;
@@ -621,6 +628,33 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
           logger.info('content.match.skipped', { sha: candidate.commit.sha, reason: 'no_embedder' });
         }
 
+        // R3: select narrative arc — fail-open if no evidence
+        const candidateCollabWeight = computeCollaborationWeight(candidate.commit.prContext);
+        const candidateIntent = detectCommitIntent({
+          message: candidate.commit.message,
+          branchRef: candidate.commit.branchRef,
+          prTitle: candidate.commit.prContext?.prTitle,
+          moduleIds: candidate.findings.map((f) => f.moduleId),
+        });
+        let developmentalAngle: string | undefined;
+        let selectedArcType: string | null = null;
+        try {
+          const angle = selectDevelopmentalAngle({
+            findings: candidate.findings,
+            commitIntent: candidateIntent,
+            closingIssues: candidate.commit.prContext?.closingIssues,
+            changesRequestedCount: candidate.commit.prContext?.changesRequestedCount ?? 0,
+            collaborationWeight: candidateCollabWeight,
+            recentArcTypes,
+          });
+          if (angle) {
+            developmentalAngle = buildAngleBlock(angle);
+            selectedArcType = angle.arcType;
+          }
+        } catch { /* fail-open */ }
+
+        draftMetadata = { ...draftMetadata, arc_type: selectedArcType };
+
         const {
           linkedinPost,
           bufferText,
@@ -642,6 +676,7 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
             recentModuleIds,
             chapterContext,
             industryContext,
+            developmentalAngle,
             draftMetadata,
             draftIndexToday,
             varietyConstraint,

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -777,6 +777,9 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
         github,
         deps.appBaseUrl,
         accumNowIso,
+        embedder ?? null,
+        matcherAi,
+        deps.db,
       );
     } catch (err) {
       logger.error('worker.accumulation.error', { authorLogin, repo: job.repo, error: String(err) });
@@ -932,6 +935,9 @@ async function runAccumulationCheck(
   github: import('../github/client.js').GitHubClient,
   appBaseUrl: string,
   nowIso: string,
+  embedder: import('../ai/types.js').IEmbedder | null,
+  matcherAi: import('../ai/types.js').IAIClient,
+  db: import('@supabase/supabase-js').SupabaseClient,
 ): Promise<void> {
   bestEffort('worker.accumulation.half_lives',
     storage.updateHalfLivesForAuthor(authorLogin, fullRepo),
@@ -1035,6 +1041,28 @@ async function runAccumulationCheck(
     if (angle) synthesisAngle = buildAngleBlock(angle, 0);
   } catch { /* fail-open — anti-repetition and arc disabled if query fails */ }
 
+  // Industry context — fail-open
+  let synthesisIndustryContext: string | undefined;
+  if (embedder) {
+    try {
+      const synFindingsForMatch: Finding[] = allSignals.map((s) => ({
+        moduleId: s.topic,
+        aspect: s.topic.replace(/_/g, ' '),
+        finding: s.specific_change,
+        technicalDetail: s.specific_change,
+        plainLanguage: s.specific_change,
+        interestScore: s.strength * 2,
+        contextHint: s.affected_files[0] ? `${s.affected_files[0]} in ${s.repo}` : undefined,
+      }));
+      const match = await matchFindingsToArticles(synFindingsForMatch, embedder, matcherAi, db);
+      if (match) {
+        synthesisIndustryContext = buildIndustryContextBlock({ connection: match.connection, articleUrl: match.articleUrl });
+      }
+    } catch (err) {
+      logger.warn('worker.accumulation.industry_context.skipped', { authorLogin, repo: fullRepo, error: String(err) });
+    }
+  }
+
   const synthesisInputs = topicsToGenerate.map((item, i) => ({
     authorLogin,
     repo: fullRepo,
@@ -1048,6 +1076,7 @@ async function runAccumulationCheck(
     bootstrapPosts,
     draftIndexToday: authorState.todayDrafts.length + i,
     developmentalAngle: synthesisAngle,
+    industryContext: synthesisIndustryContext,
   }));
 
   // Phase 1: generate all buffer texts in parallel — fail-fast, no DB writes.

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -1043,6 +1043,7 @@ async function runAccumulationCheck(
 
   // Industry context — fail-open
   let synthesisIndustryContext: string | undefined;
+  let synthesisFeaturedSignal: string | undefined;
   if (embedder) {
     try {
       const synFindingsForMatch: Finding[] = allSignals.map((s) => ({
@@ -1057,6 +1058,7 @@ async function runAccumulationCheck(
       const match = await matchFindingsToArticles(synFindingsForMatch, embedder, matcherAi, db);
       if (match) {
         synthesisIndustryContext = buildIndustryContextBlock({ connection: match.connection, articleUrl: match.articleUrl });
+        synthesisFeaturedSignal = match.matchedFinding;
       }
     } catch (err) {
       logger.warn('worker.accumulation.industry_context.skipped', { authorLogin, repo: fullRepo, error: String(err) });
@@ -1077,6 +1079,7 @@ async function runAccumulationCheck(
     draftIndexToday: authorState.todayDrafts.length + i,
     developmentalAngle: synthesisAngle,
     industryContext: synthesisIndustryContext,
+    featuredSignal: synthesisFeaturedSignal,
   }));
 
   // Phase 1: generate all buffer texts in parallel — fail-fast, no DB writes.

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -23,7 +23,7 @@ import { ConfigSchema } from '../config/schema.js';
 import type { BootstrapPost, Config, VoiceProfile } from '../config/schema.js';
 import type { IVoiceStorage, SaveDraftInput, VoicePost, VoiceStage } from '../voice/storage.js';
 import { resolveTenantSecrets } from '../security/tenant-secrets.js';
-import { filterFindingsByContentStrategy, matchesSkipPatterns, mergeVoiceProfile } from '../voice/profile-utils.js';
+import { applyPenalizedModules, filterFindingsByContentStrategy, matchesSkipPatterns, mergeVoiceProfile } from '../voice/profile-utils.js';
 import { computeVoiceStage } from '../voice/stage.js';
 import {
   buildModuleFireCounts,
@@ -431,15 +431,17 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
         continue;
       }
 
-      const findings = filterFindingsByContentStrategy(pipelineFindings, authorState.voiceProfile);
+      const strategyFindings = filterFindingsByContentStrategy(pipelineFindings, authorState.voiceProfile);
 
-      if (findings.length === 0) {
+      if (strategyFindings.length === 0) {
         logger.info('worker.commit.skip.no_findings_after_strategy', {
           sha: commit.sha,
           focus_modules: authorState.voiceProfile.content_strategy.focus_modules ?? [],
         });
         continue;
       }
+
+      const findings = applyPenalizedModules(strategyFindings, authorState.voiceProfile);
 
       const skipPattern = matchesSkipPatterns(commit, findings, authorState.voiceProfile);
       if (skipPattern) {

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -3,6 +3,7 @@ import { GitHubClient } from '../github/client.js';
 import { LinkedInClient, LinkedInAuthExpiredError } from '../linkedin/client.js';
 import { enrichCommit, type EnrichedCommit } from '../github/commit-enricher.js';
 import { isInteresting } from '../utils/commit-filter.js';
+import { detectCommitIntent, computeCollaborationWeight } from '../utils/commit-classifier.js';
 import { runPipeline } from '../analysis/pipeline.js';
 import type { Finding } from '../analysis/types.js';
 import { MODULE_REGISTRY } from '../analysis/modules/index.js';
@@ -358,6 +359,7 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
       }
 
       const commit = await enrichCommit(github, owner, repo, pushCommit.sha, tenant.github_username, job.ref ?? undefined);
+      const collaborationWeight = computeCollaborationWeight(commit.prContext);
 
       const filterResult = isInteresting(
         {
@@ -407,6 +409,13 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
         MODULE_REGISTRY,
         recentModuleIds,
       );
+
+      const commitIntent = detectCommitIntent({
+        message: commit.message,
+        branchRef: commit.branchRef,
+        prTitle: commit.prContext?.prTitle,
+        moduleIds: pipelineFindings.map((f) => f.moduleId),
+      });
 
       // Deposit weak signals (best-effort — never blocks post generation)
       const nowIso = new Date().toISOString();

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -640,6 +640,7 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
             changesRequestedCount: candidate.commit.prContext?.changesRequestedCount ?? 0,
             collaborationWeight: candidateCollabWeight,
             recentArcTypes,
+            discouragedArcTypes: (candidate.voiceProfile.content_preferences?.penalized_arc_types ?? []) as ArcType[],
           });
           if (angle) {
             developmentalAngle = buildAngleBlock(angle, candidateCollabWeight);

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -193,7 +193,7 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
     : null;
 
   const [owner, repo] = job.repo.split('/') as [string, string];
-  const recentModuleIds = await storage.getRecentModuleIds(30);
+  const recentModuleIds = await storage.getRecentModuleIds(30, tenant.github_username);
   const recentModuleFireCounts = buildModuleFireCounts(recentModuleIds);
   const dayStartIso = getStartOfDayIso(config.scheduling.timezone);
   const dailyLimit = config.posting.max_daily_posts_per_author;

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -360,7 +360,6 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
       }
 
       const commit = await enrichCommit(github, owner, repo, pushCommit.sha, tenant.github_username, job.ref ?? undefined);
-      const collaborationWeight = computeCollaborationWeight(commit.prContext);
 
       const filterResult = isInteresting(
         {
@@ -410,13 +409,6 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
         MODULE_REGISTRY,
         recentModuleIds,
       );
-
-      const commitIntent = detectCommitIntent({
-        message: commit.message,
-        branchRef: commit.branchRef,
-        prTitle: commit.prContext?.prTitle,
-        moduleIds: pipelineFindings.map((f) => f.moduleId),
-      });
 
       // Deposit weak signals (best-effort — never blocks post generation)
       const nowIso = new Date().toISOString();

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -648,7 +648,7 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
             recentArcTypes,
           });
           if (angle) {
-            developmentalAngle = buildAngleBlock(angle);
+            developmentalAngle = buildAngleBlock(angle, candidateCollabWeight);
             selectedArcType = angle.arcType;
           }
         } catch { /* fail-open */ }

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -1010,6 +1010,31 @@ async function runAccumulationCheck(
     repo: fullRepo,
   } as import('../github/commit-enricher.js').EnrichedCommit;
 
+  // R3: select narrative arc for synthesis — fail-open
+  let synthesisAngle: string | undefined;
+  try {
+    const synRecentArcs = (await storage.getRecentArcTypes(authorLogin, 5)) as ArcType[];
+    const synFindings: Finding[] = allSignals.map((s) => ({
+      moduleId: s.topic,
+      aspect: s.topic.replace(/_/g, ' '),
+      finding: s.specific_change,
+      technicalDetail: s.specific_change,
+      plainLanguage: s.specific_change,
+      interestScore: s.strength * 2,
+      contextHint: s.affected_files[0] ? `${s.affected_files[0]} in ${s.repo}` : undefined,
+    }));
+    const angle = selectDevelopmentalAngle({
+      findings: synFindings,
+      commitIntent: 'planned_feature',
+      closingIssues: [],
+      changesRequestedCount: 0,
+      collaborationWeight: 0,
+      recentArcTypes: synRecentArcs,
+      discouragedArcTypes: (authorState.voiceProfile.content_preferences?.penalized_arc_types ?? []) as ArcType[],
+    });
+    if (angle) synthesisAngle = buildAngleBlock(angle, 0);
+  } catch { /* fail-open — anti-repetition and arc disabled if query fails */ }
+
   const synthesisInputs = topicsToGenerate.map((item, i) => ({
     authorLogin,
     repo: fullRepo,
@@ -1022,6 +1047,7 @@ async function runAccumulationCheck(
     exposurePool,
     bootstrapPosts,
     draftIndexToday: authorState.todayDrafts.length + i,
+    developmentalAngle: synthesisAngle,
   }));
 
   // Phase 1: generate all buffer texts in parallel — fail-fast, no DB writes.


### PR DESCRIPTION
## Summary

- Wire R3 (narrative arc), R4 (no-quantification), R6 (Instagram variant), and industry context into Camino 2 (`runAccumulationCheck`) — previously only Camino 1 passed through the editorial pipeline
- Industry context match pins the dominant narrative: the signal that triggered the article match is passed as `featuredSignal` so Claude writes exclusively about that decision
- Reframe industry context as editorial tension frame (not validation footnote) in Camino 1 prompt
- Fix synthesis tag parsing: accept `<linkedin_draft>` with fallback to `<buffer_text>`
- Add output format instructions to `buildSynthesisUserPrompt` (was missing, Claude had no scaffold)
- Update `replay-synthesis.ts` and `replay-commit.ts` to exercise the full editorial pipeline in dry-run mode

## Key decisions

- `featuredSignal` flows: `matcher.ts` → `runAccumulationCheck` → `SynthesisGeneratorInput` → `buildSynthesisUserPrompt`. When no industry context match, Claude falls back to its own narrative judgment.
- R3 in synthesis uses `commitIntent: 'planned_feature'` (signals have no individual commit message to detect intent from).
- All editorial steps are fail-open — a failed R3/industry context call never blocks post generation.
- Synthesis prompt: "Write the post exclusively about that one decision. Do not reference other signals, other work, or the time span."

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `replay-synthesis.ts korutx microboxlabs/ecm-coordinator` generates a post focused on a single decision with no unrelated signal mentions
- [ ] `replay-commit.ts` shows R3 arc stage before prompt build
- [ ] Instagram draft saved when `platforms.instagram.enabled = true`