### PR TITLE
feat(camino1): wire featuredFinding pin into buildUserPrompt

### DIFF
--- a/src/ai/post-generator.ts
+++ b/src/ai/post-generator.ts
@@ -24,6 +24,7 @@ export interface GeneratePostsOptions {
   recentModuleIds?: string[];
   chapterContext?: string;
   industryContext?: string;
+  featuredFinding?: string;
   developmentalAngle?: string;
   draftMetadata?: Partial<SaveDraftInput>;
   draftIndexToday?: number;
@@ -68,6 +69,7 @@ export async function generatePosts(
     options.industryContext,
     options.developmentalAngle,
     instagramEnabled,
+    options.featuredFinding,
   );
 
   logger.info('ai.generate.start', {

--- a/src/ai/prompt-builder.ts
+++ b/src/ai/prompt-builder.ts
@@ -166,6 +166,7 @@ export function buildUserPrompt(
   industryContext?: string,
   developmentalAngle?: string,
   instagramEnabled = false,
+  featuredFinding?: string,
 ): string {
   const parts: string[] = [];
 
@@ -265,7 +266,11 @@ export function buildUserPrompt(
     parts.push('');
   }
   parts.push('Write one main post and one short variant.');
-  parts.push('Feature the highest-value finding and only keep secondary findings when they sharpen the same story.');
+  if (featuredFinding) {
+    parts.push(`Write the post about this specific finding: "${featuredFinding}". It connects to the industry context above. Do not reference other findings, other work, or unrelated context.`);
+  } else {
+    parts.push('Write the post exclusively about the highest-value finding. Do not reference other findings unless they are a direct consequence of the same decision.');
+  }
   parts.push('Lead with the engineering decision or consequence, not the tool used to get there.');
   parts.push('Describe what changed in the system behavior, control surface, reliability, cost, or operational flexibility.');
   if (commit.isPrivateRepo) {

--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -556,6 +556,7 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
         // Content matching — inject industry context when a strong match is found.
         // Graceful degradation: any failure skips context, post generated normally.
         let industryContext: string | undefined;
+        let featuredFinding: string | undefined;
         let draftMetadata: Partial<SaveDraftInput> = {
           author_login: candidate.authorLogin,
           generation_system: authorState.voiceStage === 'cold' ? 'v1' : 'v2_progressive',
@@ -590,6 +591,7 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
                   connection: match.connection,
                   articleUrl: match.articleUrl,
                 });
+                featuredFinding = match.matchedFinding;
                 draftMetadata = {
                   ...draftMetadata,
                   context_status: 'matched',
@@ -671,6 +673,7 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
             recentModuleIds,
             chapterContext,
             industryContext,
+            featuredFinding,
             developmentalAngle,
             draftMetadata,
             draftIndexToday,


### PR DESCRIPTION
When industry context matches a finding, pass matchedFinding as featuredFinding through GeneratePostsOptions -> buildUserPrompt. With a pin: Claude writes exclusively about that finding. Without a pin: stronger constraint replaces the old 'secondary findings' instruction.

Aligns Camino 1 one-story discipline with Camino 2.