### PR TITLE
fix(camino1): wire featuredFinding pin + fix excludePattern test

### DIFF
--- a/src/__tests__/commit-filter.test.ts
+++ b/src/__tests__/commit-filter.test.ts
@@ -92,7 +92,7 @@ describe('isInteresting', () => {
 
   it('rejects a commit matching an excludePattern', () => {
     const result = isInteresting(
-      { ...REAL_COMMIT, message: 'chore: bump version to 1.2.3' },
+      { ...REAL_COMMIT, message: 'chore: update ci config' },
       { ...BASE_CONFIG, excludePatterns: ['^chore:'] },
     );
     expect(result.interesting).toBe(false);


### PR DESCRIPTION
## Summary
- Wire `featuredFinding` from `matchedFinding` through `GeneratePostsOptions` → `buildUserPrompt` (Camino 1 one-story discipline, mirrors Camino 2)
- Replace weak "secondary findings" instruction with a hard pin when industry context matches, and a stronger generic constraint when it doesn't
- Fix pre-existing test bug: `'chore: bump version to 1.2.3'` was caught by `RELEASE_PATTERNS` before reaching the `excludePatterns` check, causing CI failure on trunk after PR #116 merge

## Test plan
- [ ] `npx vitest run src/__tests__/commit-filter.test.ts` — 12/12 pass
- [ ] `npx tsc --noEmit` — clean