### PR TITLE
feat(pat-poller): per-user GitHub PAT event poller

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,3 +84,13 @@ jobs:
             --update-env-vars "SUPABASE_URL=$SUPABASE_URL,GCP_KMS_KEY_NAME=$GCP_KMS_KEY_NAME" \
             --update-secrets "SUPABASE_SERVICE_ROLE_KEY=supabase-service-role-key:latest,OPENAI_API_KEY=OPENAI_API_KEY:latest" \
             --quiet
+
+      - name: Deploy PAT poller job
+        run: |
+          gcloud run jobs update devcast-pat-poller \
+            --image "$IMAGE" \
+            --region "$REGION" \
+            --project "$PROJECT_ID" \
+            --update-env-vars "SUPABASE_URL=$SUPABASE_URL,GCP_KMS_KEY_NAME=$GCP_KMS_KEY_NAME" \
+            --update-secrets "SUPABASE_SERVICE_ROLE_KEY=supabase-service-role-key:latest" \
+            --quiet

--- a/database/migrations/2026-05-25-developer-profile-pat-poller-state.sql
+++ b/database/migrations/2026-05-25-developer-profile-pat-poller-state.sql
@@ -1,0 +1,6 @@
+-- Poller state for PAT-based event polling (per developer).
+-- Tracks last seen event and ETag so each run is incremental.
+
+ALTER TABLE developer_profiles
+  ADD COLUMN IF NOT EXISTS pat_last_event_id TEXT DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS pat_last_etag     TEXT DEFAULT NULL;

--- a/src/worker/main-pat-poller.ts
+++ b/src/worker/main-pat-poller.ts
@@ -1,0 +1,23 @@
+import { createClient } from '@supabase/supabase-js';
+import { logger } from '../utils/logger.js';
+import { runPatPoller } from './pat-poller.js';
+
+const SUPABASE_URL = process.env['SUPABASE_URL'] ?? '';
+const SUPABASE_SERVICE_ROLE_KEY = process.env['SUPABASE_SERVICE_ROLE_KEY'] ?? '';
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  logger.error('pat-poller.missing_env', { vars: 'SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY' });
+  process.exit(1);
+}
+
+const db = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+async function main(): Promise<void> {
+  logger.info('pat-poller.main.start');
+  await runPatPoller(db);
+}
+
+main().catch((err) => {
+  logger.error('pat-poller.fatal', { error: String(err) });
+  process.exit(1);
+});

--- a/src/worker/pat-poller.ts
+++ b/src/worker/pat-poller.ts
@@ -1,0 +1,151 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { GitHubClient } from '../github/client.js';
+import { resolveTenantSecrets } from '../security/tenant-secrets.js';
+import { logger } from '../utils/logger.js';
+
+interface DevProfileRow {
+  readonly github_login: string;
+  readonly tenant_id: string;
+  readonly encrypted_dek: string | null;
+  readonly github_pat: string | null;
+  readonly pat_last_event_id: string | null;
+  readonly pat_last_etag: string | null;
+}
+
+interface RawPushEvent {
+  id: string;
+  type: string;
+  repo: { name: string };
+  payload: {
+    before?: string;
+    head?: string;
+    ref?: string;
+  };
+}
+
+/**
+ * Polls GitHub Events API for all tenants that have a github_pat configured.
+ * For each new push event found, inserts a job into job_queue.
+ * Idempotency key prevents duplicates with App webhook-sourced jobs.
+ */
+export async function runPatPoller(db: SupabaseClient): Promise<void> {
+  // Join developer_profiles with tenants to get tenant_id per github_login.
+  const { data, error } = await db
+    .from('developer_profiles')
+    .select('github_login, encrypted_dek, github_pat, pat_last_event_id, pat_last_etag, tenants!inner(id)')
+    .not('github_pat', 'is', null);
+
+  if (error) {
+    throw new Error(`pat-poller: failed to fetch developer profiles: ${error.message}`);
+  }
+
+  const rows = (data ?? []) as unknown as Array<Omit<DevProfileRow, 'tenant_id'> & { tenants: { id: string } }>;
+
+  logger.info('pat-poller.start', { tenantCount: rows.length });
+
+  for (const row of rows) {
+    const tenantId = row.tenants.id;
+    try {
+      await pollTenant(db, {
+        github_login: row.github_login,
+        tenant_id: tenantId,
+        encrypted_dek: row.encrypted_dek,
+        github_pat: row.github_pat,
+        pat_last_event_id: row.pat_last_event_id,
+        pat_last_etag: row.pat_last_etag,
+      });
+    } catch (err) {
+      logger.warn('pat-poller.tenant_failed', {
+        login: row.github_login,
+        error: String(err),
+      });
+    }
+  }
+
+  logger.info('pat-poller.done', { tenantCount: rows.length });
+}
+
+async function pollTenant(db: SupabaseClient, row: DevProfileRow): Promise<void> {
+  const resolved = await resolveTenantSecrets({
+    encrypted_dek: row.encrypted_dek,
+    buffer_access_token: null,
+    github_pat: row.github_pat,
+  });
+
+  if (!resolved.githubPat) return;
+
+  const client = new GitHubClient(resolved.githubPat);
+
+  const { events, newEtag, notModified } = await client.listUserEvents(
+    row.github_login,
+    row.pat_last_etag ?? undefined,
+  );
+
+  if (notModified) {
+    logger.info('pat-poller.not_modified', { login: row.github_login });
+    return;
+  }
+
+  const pushEvents = (events as RawPushEvent[]).filter((e) => e.type === 'PushEvent');
+
+  const lastSeenIdx = row.pat_last_event_id
+    ? pushEvents.findIndex((e) => e.id === row.pat_last_event_id)
+    : -1;
+
+  const newEvents = lastSeenIdx === -1
+    ? pushEvents
+    : pushEvents.slice(0, lastSeenIdx);
+
+  logger.info('pat-poller.events', {
+    login: row.github_login,
+    total: pushEvents.length,
+    new: newEvents.length,
+  });
+
+  let enqueued = 0;
+  for (const event of newEvents) {
+    const { before, head, ref } = event.payload;
+    if (!before || !head) continue;
+
+    const idempotencyKey = `${row.tenant_id}:${head}`;
+
+    const { error: insertError } = await db.from('job_queue').insert({
+      tenant_id: row.tenant_id,
+      repo: event.repo.name,
+      before_sha: before,
+      after_sha: head,
+      ref: ref ?? null,
+      idempotency_key: idempotencyKey,
+    });
+
+    if (insertError) {
+      if (insertError.message.includes('duplicate') || insertError.message.includes('unique')) {
+        // Already queued by the App webhook or a previous run — skip silently.
+        continue;
+      }
+      logger.warn('pat-poller.enqueue_failed', {
+        login: row.github_login,
+        repo: event.repo.name,
+        error: insertError.message,
+      });
+      continue;
+    }
+
+    enqueued++;
+  }
+
+  // Persist new poller state regardless of whether we enqueued anything.
+  const newLastEventId = (events as RawPushEvent[])[0]?.id ?? row.pat_last_event_id;
+  await db
+    .from('developer_profiles')
+    .update({
+      pat_last_event_id: newLastEventId,
+      pat_last_etag: newEtag ?? row.pat_last_etag,
+    })
+    .eq('github_login', row.github_login);
+
+  logger.info('pat-poller.tenant_done', {
+    login: row.github_login,
+    enqueued,
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `pat-poller.ts`: polls `GET /users/{login}/events` for every `developer_profiles` row that has a `github_pat`, inserts new PushEvents into `job_queue` with idempotency key `{tenant_id}:{after_sha}`
- Adds `main-pat-poller.ts`: Cloud Run Job entry point (validates env vars, creates Supabase client, calls `runPatPoller`)
- Migration adds `pat_last_event_id` and `pat_last_etag` to `developer_profiles` for incremental polling with ETag caching
- Deploy workflow gets a `devcast-pat-poller` job update step

**Why**: When a user pushes to a repo in an org where the GitHub App is not installed, the webhook never fires. The PAT poller closes that gap per-user — no commits are missed.

## Before deploying

The Cloud Run Job must be created once in GCP (the deploy step uses `update`, not `create`):

```bash
gcloud run jobs create devcast-pat-poller \
  --image "gcr.io/lilicurl/devcast:<sha>" \
  --region us-central1 \
  --project lilicurl \
  --command "npx,tsx,src/worker/main-pat-poller.ts" \
  --set-env-vars "SUPABASE_URL=https://wxejktojaeqrieczzcnk.supabase.co,GCP_KMS_KEY_NAME=projects/lilicurl/locations/global/keyRings/devcast/cryptoKeys/tenant-secrets" \
  --set-secrets "SUPABASE_SERVICE_ROLE_KEY=supabase-service-role-key:latest"
```

Run the migration in Supabase SQL Editor (`database/migrations/2026-05-25-developer-profile-pat-poller-state.sql`).

## Test plan

- [ ] Run migration in Supabase SQL Editor
- [ ] Create Cloud Run Job in GCP with command override
- [ ] Register a PAT via onboarding form (`/onboard`)
- [ ] Merge the PR and let CI deploy
- [ ] Trigger job manually in GCP Console and check Cloud Logging for `pat-poller.events`
- [ ] Push to a repo in the org — verify a job appears in `job_queue`