### PR TITLE
fix(worker): use PAT as primary GitHub client when App installation is missing

### DIFF
--- a/src/worker/process-job.ts
+++ b/src/worker/process-job.ts
@@ -176,17 +176,7 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
     ref: job.ref,
   });
 
-  // Installation token is valid for 1 hour — enough for one job
-  const installationToken = await getInstallationToken(
-    deps.appId,
-    deps.privateKey,
-    tenant.github_installation_id,
-  );
-
-  const github = new GitHubClient(installationToken);
-
-  // PAT fallback: resolve from the tenant's developer_profile.
-  // Used when the App installation token gets 403 (repo org without App installed).
+  // Resolve PAT first — needed as primary client if App isn't installed on this tenant.
   let patClient: GitHubClient | undefined;
   try {
     const { data: tenantDevProfile } = await deps.db
@@ -205,6 +195,22 @@ export async function processJob(jobId: string, deps: ProcessJobDeps): Promise<v
     }
   } catch (err) {
     logger.warn('worker.pat_fallback.load_failed', { tenant: tenant.github_username, error: String(err) });
+  }
+
+  // Installation token is valid for 1 hour — enough for one job.
+  // Falls back to PAT when the App isn't installed on this tenant's org.
+  let github: GitHubClient;
+  try {
+    const installationToken = await getInstallationToken(
+      deps.appId,
+      deps.privateKey,
+      tenant.github_installation_id,
+    );
+    github = new GitHubClient(installationToken);
+  } catch (err) {
+    if (!patClient) throw err;
+    logger.info('worker.app_auth_failed.pat_primary', { tenant: tenant.github_username, error: String(err) });
+    github = patClient;
   }
 
   const generationAi = createAIClient('anthropic', deps.anthropicApiKey, config.ai.model, config.ai.max_tokens);


### PR DESCRIPTION
## Summary

When `getInstallationToken` fails with 404 (GitHub App not installed on the tenant's org), the job fails immediately before reaching any PAT fallback logic.

Fix: resolve the PAT **before** attempting App auth. If App auth fails and a PAT is available, use the PAT as the primary `github` client for the whole job instead of throwing.

If App auth fails and there's no PAT, the original error is rethrown.

## Before / After

**Before:** `GitHub App auth failed (404)` → job marked failed (3 attempts, permanent)  
**After:** `worker.app_auth_failed.pat_primary` logged → job continues with PAT client

## Test plan

- [ ] Merge and let CI deploy
- [ ] Reset failed jobs: `UPDATE job_queue SET status='pending', attempts=0, error=NULL WHERE tenant_id='307fe010-23dc-4e39-9276-cacf2f8a40f9' AND status='failed'`
- [ ] Execute `devcast-worker` and verify `worker.app_auth_failed.pat_primary` in logs
- [ ] Verify jobs complete (or hit isInteresting filter) instead of failing